### PR TITLE
addon: EditorPlugin status dock with live editor state (closes #2)

### DIFF
--- a/godot/addons/godot_mcp/godot_mcp.gd
+++ b/godot/addons/godot_mcp/godot_mcp.gd
@@ -2,29 +2,78 @@
 extends EditorPlugin
 ## godot-mcp EditorPlugin entry point.
 ##
-## This is the ONLY layer that touches the Godot Editor API. It will run a
-## TCPServer + WebSocketPeer, route incoming JSON command envelopes through a
-## single command router to cmd_<verb>_<noun> handlers, and show a read-only
-## status dock.
+## This is the ONLY layer that touches the Godot Editor API. It currently
+## establishes live editor presence: a read-only status dock that reflects
+## connection state, project path, active scene, selected node, and a recent
+## command log (issue #2). The WebSocket bridge and cmd_* command router land in
+## issue #3 — that introduces TCPServer/WebSocketPeer (verify against the Godot
+## 4.4 docs before use, per .claude/rules/addon.md).
 ##
-## Scaffold stub (issue #1): only the plugin lifecycle is wired so the plugin
-## enables/disables cleanly. The status dock lands in issue #2 and the
-## WebSocket bridge in issue #3 — those introduce the volatile editor APIs
-## (TCPServer, WebSocketPeer, EditorInterface) that MUST be verified against the
-## Godot 4.4 docs before use (see .claude/rules/addon.md).
+## API note: add_control_to_dock()/remove_control_from_docks() are deprecated as
+## of Godot 4.6 in favour of EditorDock/add_dock(), but EditorDock does not exist
+## in 4.4/4.5 and this project targets 4.4+, so the broadly-compatible API is the
+## correct choice here.
 
 const PLUGIN_NAME := "godot_mcp"
+const MCPDockScript := preload("res://addons/godot_mcp/mcp_dock.gd")
+
+var _dock: VBoxContainer
+var _selection: EditorSelection
 
 
 func _enter_tree() -> void:
-	# Initialization of the plugin goes here (dock + bridge added in #2/#3).
-	pass
+	_dock = MCPDockScript.new()
+	add_control_to_dock(DOCK_SLOT_LEFT_UR, _dock)
+
+	# No bridge yet (issue #3); presence is "disconnected" for now.
+	_dock.set_connection_status(MCPDockScript.ConnectionStatus.DISCONNECTED)
+
+	# Live editor state: refresh on selection and scene changes.
+	_selection = EditorInterface.get_selection()
+	_selection.selection_changed.connect(_on_selection_changed)
+	scene_changed.connect(_on_scene_changed)
+
+	_refresh_all()
 
 
 func _exit_tree() -> void:
-	# Clean-up of the plugin goes here; must leave the editor leak-free.
-	pass
+	if _selection != null and _selection.selection_changed.is_connected(_on_selection_changed):
+		_selection.selection_changed.disconnect(_on_selection_changed)
+	if scene_changed.is_connected(_on_scene_changed):
+		scene_changed.disconnect(_on_scene_changed)
+	_selection = null
+
+	if _dock != null:
+		remove_control_from_docks(_dock)
+		_dock.queue_free()
+		_dock = null
 
 
 func _get_plugin_name() -> String:
 	return PLUGIN_NAME
+
+
+## Push the full current editor state into the dock (used on enable).
+func _refresh_all() -> void:
+	_dock.set_project_path(ProjectSettings.globalize_path("res://"))
+	_on_scene_changed(EditorInterface.get_edited_scene_root())
+	_on_selection_changed()
+
+
+func _on_scene_changed(scene_root: Node) -> void:
+	_dock.set_active_scene(_scene_label(scene_root))
+
+
+func _on_selection_changed() -> void:
+	var nodes := _selection.get_selected_nodes()
+	_dock.set_selected_node(nodes[0].name if not nodes.is_empty() else "")
+
+
+## Human-readable name for the active scene: its file name, else the root node
+## name, else empty (the dock renders empty as a placeholder).
+func _scene_label(scene_root: Node) -> String:
+	if scene_root == null:
+		return ""
+	if not scene_root.scene_file_path.is_empty():
+		return scene_root.scene_file_path.get_file()
+	return scene_root.name

--- a/godot/addons/godot_mcp/godot_mcp.gd
+++ b/godot/addons/godot_mcp/godot_mcp.gd
@@ -15,18 +15,17 @@ extends EditorPlugin
 ## correct choice here.
 
 const PLUGIN_NAME := "godot_mcp"
-const MCPDockScript := preload("res://addons/godot_mcp/mcp_dock.gd")
 
-var _dock: VBoxContainer
+var _dock: MCPStatusDock
 var _selection: EditorSelection
 
 
 func _enter_tree() -> void:
-	_dock = MCPDockScript.new()
+	_dock = MCPStatusDock.new()
 	add_control_to_dock(DOCK_SLOT_LEFT_UR, _dock)
 
 	# No bridge yet (issue #3); presence is "disconnected" for now.
-	_dock.set_connection_status(MCPDockScript.ConnectionStatus.DISCONNECTED)
+	_dock.set_connection_status(MCPStatusDock.ConnectionStatus.DISCONNECTED)
 
 	# Live editor state: refresh on selection and scene changes.
 	_selection = EditorInterface.get_selection()

--- a/godot/addons/godot_mcp/godot_mcp.gd.uid
+++ b/godot/addons/godot_mcp/godot_mcp.gd.uid
@@ -1,0 +1,1 @@
+uid://bdcr3htc87mjj

--- a/godot/addons/godot_mcp/mcp_dock.gd
+++ b/godot/addons/godot_mcp/mcp_dock.gd
@@ -1,4 +1,5 @@
 @tool
+class_name MCPStatusDock
 extends VBoxContainer
 ## godot-mcp status dock — read-only editor presence (issue #2).
 ##
@@ -93,7 +94,8 @@ func log_command(entry: String) -> void:
 
 
 func get_recent_commands() -> PackedStringArray:
-	return _recent
+	# Return a copy so callers cannot mutate the dock's state behind its back.
+	return _recent.duplicate()
 
 
 # --- Accessors used by the headless dock test to assert the labels updated. ---

--- a/godot/addons/godot_mcp/mcp_dock.gd
+++ b/godot/addons/godot_mcp/mcp_dock.gd
@@ -1,0 +1,118 @@
+@tool
+extends VBoxContainer
+## godot-mcp status dock — read-only editor presence (issue #2).
+##
+## A dumb, editor-independent Control: it holds no Godot Editor API knowledge and
+## never mutates the project. The EditorPlugin (godot_mcp.gd) feeds it live state
+## through the public setters below. Keeping it editor-free makes it verifiable
+## headlessly (see godot/tests/dock_smoke.gd).
+##
+## The bridge/MCP integration (issues #3+) only ever calls set_connection_status()
+## and log_command(); this phase has no networking.
+
+enum ConnectionStatus { DISCONNECTED, CONNECTING, CONNECTED }
+
+const MAX_LOG_ENTRIES := 10
+const PLACEHOLDER := "(none)"
+const _UNKNOWN := "(unknown)"
+
+const _CONNECTION_TEXT := {
+	ConnectionStatus.DISCONNECTED: "Disconnected",
+	ConnectionStatus.CONNECTING: "Connecting…",
+	ConnectionStatus.CONNECTED: "Connected",
+}
+
+var _connection_value: Label
+var _project_value: Label
+var _scene_value: Label
+var _selected_value: Label
+var _log_value: Label
+var _recent: PackedStringArray = PackedStringArray()
+
+
+func _init() -> void:
+	# Build the UI eagerly so the dock is usable whether or not it is in the tree
+	# (the headless test exercises it detached from any scene tree).
+	name = "MCP"
+	add_theme_constant_override("separation", 6)
+
+	_connection_value = _add_field("Status:")
+	_project_value = _add_field("Project:")
+	_scene_value = _add_field("Scene:")
+	_selected_value = _add_field("Selected:")
+
+	var log_title := Label.new()
+	log_title.text = "Recent commands"
+	add_child(log_title)
+	_log_value = Label.new()
+	_log_value.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	add_child(_log_value)
+
+	# Sensible defaults before the plugin pushes real state.
+	set_connection_status(ConnectionStatus.DISCONNECTED)
+	set_project_path("")
+	set_active_scene("")
+	set_selected_node("")
+
+
+## Add a "label: value" row and return the value Label for later updates.
+func _add_field(caption: String) -> Label:
+	var row := HBoxContainer.new()
+	var caption_label := Label.new()
+	caption_label.text = caption
+	var value_label := Label.new()
+	value_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(caption_label)
+	row.add_child(value_label)
+	add_child(row)
+	return value_label
+
+
+func set_connection_status(status: ConnectionStatus) -> void:
+	_connection_value.text = _CONNECTION_TEXT.get(status, _UNKNOWN)
+
+
+func set_project_path(path: String) -> void:
+	_project_value.text = path if not path.is_empty() else _UNKNOWN
+
+
+func set_active_scene(scene_name: String) -> void:
+	_scene_value.text = scene_name if not scene_name.is_empty() else PLACEHOLDER
+
+
+func set_selected_node(node_name: String) -> void:
+	_selected_value.text = node_name if not node_name.is_empty() else PLACEHOLDER
+
+
+## Append a command to the recent log, keeping only the last MAX_LOG_ENTRIES.
+func log_command(entry: String) -> void:
+	_recent.append(entry)
+	while _recent.size() > MAX_LOG_ENTRIES:
+		_recent.remove_at(0)
+	_log_value.text = "\n".join(_recent)
+
+
+func get_recent_commands() -> PackedStringArray:
+	return _recent
+
+
+# --- Accessors used by the headless dock test to assert the labels updated. ---
+
+func displayed_connection() -> String:
+	return _connection_value.text
+
+
+func displayed_project() -> String:
+	return _project_value.text
+
+
+func displayed_scene() -> String:
+	return _scene_value.text
+
+
+func displayed_selected() -> String:
+	return _selected_value.text
+
+
+func displayed_log() -> String:
+	return _log_value.text

--- a/godot/addons/godot_mcp/mcp_dock.gd.uid
+++ b/godot/addons/godot_mcp/mcp_dock.gd.uid
@@ -1,0 +1,1 @@
+uid://bpaqkailndyb7

--- a/godot/tests/dock_smoke.gd
+++ b/godot/tests/dock_smoke.gd
@@ -1,0 +1,71 @@
+@tool
+extends SceneTree
+## Headless behavior test for the MCP status dock (issue #2).
+##
+## Run via: godot --headless --path godot/ --script res://tests/dock_smoke.gd
+## Exercises mcp_dock.gd's public state API WITHOUT the editor — the dock is a
+## dumb, editor-independent Control fed by the plugin, so it can be verified with
+## no EditorInterface present. Prints DOCK_TEST_OK and quits 0 on success;
+## prints each failure and DOCK_TEST_FAIL, quits 1 otherwise.
+##
+## The pytest wrapper tests/integration/test_addon_dock.py runs this and asserts
+## on its exit code + output.
+
+const MCPDockScript := preload("res://addons/godot_mcp/mcp_dock.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+	var dock := MCPDockScript.new()
+
+	# Connection status reflects in the label.
+	dock.set_connection_status(MCPDockScript.ConnectionStatus.CONNECTED)
+	_expect(failures, "connection", dock.displayed_connection(), "Connected")
+	dock.set_connection_status(MCPDockScript.ConnectionStatus.CONNECTING)
+	_expect(failures, "connecting", dock.displayed_connection(), "Connecting…")
+	dock.set_connection_status(MCPDockScript.ConnectionStatus.DISCONNECTED)
+	_expect(failures, "disconnected", dock.displayed_connection(), "Disconnected")
+
+	# Project / scene / selected node reflect live values.
+	dock.set_project_path("res://demo")
+	_expect(failures, "project", dock.displayed_project(), "res://demo")
+	dock.set_active_scene("Main")
+	_expect(failures, "scene", dock.displayed_scene(), "Main")
+	dock.set_selected_node("Player")
+	_expect(failures, "selected", dock.displayed_selected(), "Player")
+
+	# Empty values fall back to a readable placeholder.
+	dock.set_active_scene("")
+	_expect(failures, "scene_placeholder", dock.displayed_scene(), "(none)")
+	dock.set_selected_node("")
+	_expect(failures, "selected_placeholder", dock.displayed_selected(), "(none)")
+
+	# Recent-command log keeps only the last 10 entries.
+	for i in range(15):
+		dock.log_command("cmd_%d" % i)
+	var recent := dock.get_recent_commands()
+	if recent.size() != 10:
+		failures.append("log size: expected 10, got %d" % recent.size())
+	else:
+		_expect(failures, "log_first", recent[0], "cmd_5")
+		_expect(failures, "log_last", recent[9], "cmd_14")
+	if not dock.displayed_log().contains("cmd_14"):
+		failures.append("log label missing newest entry 'cmd_14'")
+	if dock.displayed_log().contains("cmd_4"):
+		failures.append("log label still shows evicted entry 'cmd_4'")
+
+	dock.free()
+
+	if failures.is_empty():
+		print("DOCK_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("DOCK_TEST_FAIL")
+		quit(1)
+
+
+func _expect(failures: Array[String], label: String, got: String, want: String) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, want, got])

--- a/godot/tests/dock_smoke.gd.uid
+++ b/godot/tests/dock_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://yqffx5fmphlw

--- a/tests/integration/_godot.py
+++ b/tests/integration/_godot.py
@@ -1,0 +1,52 @@
+"""Helpers for driving the Godot editor headlessly from integration tests.
+
+The addon is GDScript that only runs inside Godot, so these tests shell out to
+the Godot binary. They are gated with ``@pytest.mark.skipif`` on the binary being
+absent — a genuine environmental precondition, the one conditional skip the
+testing rules permit (CI has no editor; a dev machine with Godot 4.4+ does).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GODOT_PROJECT = REPO_ROOT / "godot"
+
+# Common macOS install location; extend as needed for other platforms.
+_MAC_APP = Path("/Applications/Godot.app/Contents/MacOS/Godot")
+
+
+def find_godot() -> str | None:
+    """Locate a Godot binary: ``$GODOT_BIN`` → ``PATH`` → known app bundle."""
+    env_bin = os.environ.get("GODOT_BIN")
+    if env_bin and Path(env_bin).is_file():
+        return env_bin
+    on_path = shutil.which("godot") or shutil.which("Godot")
+    if on_path:
+        return on_path
+    if _MAC_APP.is_file():
+        return str(_MAC_APP)
+    return None
+
+
+GODOT_BIN = find_godot()
+
+
+def run_godot(args: list[str], timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    """Run the Godot binary against the addon project and capture output.
+
+    ``args`` are appended after ``--headless --path <godot project>``.
+    """
+    assert GODOT_BIN is not None, "run_godot called without a Godot binary"
+    cmd = [GODOT_BIN, "--headless", "--path", str(GODOT_PROJECT), *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )

--- a/tests/integration/test_addon_dock.py
+++ b/tests/integration/test_addon_dock.py
@@ -1,0 +1,24 @@
+"""Integration test: the MCP status dock behaves correctly (issue #2).
+
+Runs the headless GDScript exerciser ``godot/tests/dock_smoke.gd`` and asserts it
+reports success. This pins the dock's state API — connection status, project /
+scene / selected-node display, and the 10-entry recent-command log — against the
+real Godot runtime, not a Python mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._godot import GODOT_BIN, run_godot
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+
+def test_dock_state_and_command_log() -> None:
+    result = run_godot(["--script", "res://tests/dock_smoke.gd"])
+    output = result.stdout + result.stderr
+    assert "DOCK_TEST_OK" in output, (
+        f"dock smoke test did not pass (exit {result.returncode}):\n{output}"
+    )
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}:\n{output}"

--- a/tests/integration/test_addon_editor_load.py
+++ b/tests/integration/test_addon_editor_load.py
@@ -1,0 +1,29 @@
+"""Integration test: the addon enables in the editor without errors (issue #2).
+
+Loads the project in the headless Godot *editor*, which enables the plugin listed
+in ``project.godot`` — running ``godot_mcp.gd``'s ``_enter_tree``, adding the dock,
+and querying ``EditorInterface``. A parse error, a bad API call, or a failed dock
+add would surface as ``SCRIPT ERROR`` and/or a non-zero exit. This is the
+automated form of the "enables/disables cleanly without crashing the editor"
+acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._godot import GODOT_BIN, run_godot
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+
+def test_editor_loads_addon_without_errors() -> None:
+    # --editor --quit imports the project, enables plugins, then exits.
+    result = run_godot(["--editor", "--quit"])
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0, f"editor exited {result.returncode}:\n{output}"
+    assert "SCRIPT ERROR" not in output, f"GDScript error during editor load:\n{output}"
+    # Catch a plugin that fails to instantiate/enable even if exit code is lenient.
+    for marker in ("Unable to load addon script", "Failed to instantiate an autoload"):
+        assert marker not in output, f"addon failed to enable ({marker!r}):\n{output}"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -70,12 +70,13 @@ def test_dock_script_exists_and_is_tool() -> None:
     assert dock.is_file(), "status dock script mcp_dock.gd must exist"
     source = dock.read_text()
     assert "@tool" in source, "dock script must carry @tool"
+    assert "class_name MCPStatusDock" in source, "dock must expose a class_name for typed use"
     # The dock is read-only this phase: no editor mutation API leaks into it.
     assert "EditorInterface" not in source, "dock must stay editor-independent (plugin feeds it)"
 
 
 def test_plugin_wires_the_dock() -> None:
     source = (ADDON_DIR / "godot_mcp.gd").read_text()
-    assert "mcp_dock.gd" in source, "plugin must instantiate the dock script"
+    assert "MCPStatusDock" in source, "plugin must instantiate the typed dock"
     assert "add_control_to_dock" in source, "plugin must add the dock to an editor dock slot"
     assert "remove_control_from_docks" in source, "plugin must remove the dock on _exit_tree"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -63,3 +63,19 @@ def test_project_godot_enables_plugin() -> None:
     assert PROJECT_GODOT.is_file(), "godot/project.godot must exist so the addon is loadable"
     text = PROJECT_GODOT.read_text()
     assert "res://addons/godot_mcp/plugin.cfg" in text, "project must enable the godot_mcp plugin"
+
+
+def test_dock_script_exists_and_is_tool() -> None:
+    dock = ADDON_DIR / "mcp_dock.gd"
+    assert dock.is_file(), "status dock script mcp_dock.gd must exist"
+    source = dock.read_text()
+    assert "@tool" in source, "dock script must carry @tool"
+    # The dock is read-only this phase: no editor mutation API leaks into it.
+    assert "EditorInterface" not in source, "dock must stay editor-independent (plugin feeds it)"
+
+
+def test_plugin_wires_the_dock() -> None:
+    source = (ADDON_DIR / "godot_mcp.gd").read_text()
+    assert "mcp_dock.gd" in source, "plugin must instantiate the dock script"
+    assert "add_control_to_dock" in source, "plugin must add the dock to an editor dock slot"
+    assert "remove_control_from_docks" in source, "plugin must remove the dock on _exit_tree"


### PR DESCRIPTION
## Summary

Builds the initial Godot addon presence: a read-only status dock fed by the `EditorPlugin`. No MCP/networking yet — that lands in #3. Closes #2.

## Tasks / Acceptance criteria (issue #2)

- [x] `plugin.cfg` with name, description, version (from #1; carried forward)
- [x] `godot_mcp.gd` extends `EditorPlugin` with `@tool`; `_enter_tree`/`_exit_tree` lifecycle
- [x] Custom dock showing connection status, project path, active scene, selected node, recent command log (last 10)
- [x] Dock updates dynamically (selection_changed + scene_changed signals)
- [x] Addon enables in Project Settings → Plugins; dock appears without errors
- [x] Shows live project/scene/node info; no MCP integration
- [x] Enables/disables cleanly without crashing the editor

## Design notes

- **Dock is editor-independent.** `mcp_dock.gd` is a dumb `Control` with public setters; it holds zero Editor API knowledge, so it's unit-testable headlessly and the plugin is the only thing that touches `EditorInterface` (per `architecture.md`/`addon.md`).
- **Dock built in code, not a `.tscn`.** More testable and self-contained; still a Control "scene" in the dock slot. Minor deviation from the issue's parenthetical, stated here.
- **API choice:** `add_control_to_dock()`/`remove_control_from_docks()` are doc-deprecated as of 4.6 in favor of `EditorDock`/`add_dock()`, but `EditorDock` doesn't exist in 4.4/4.5 and the project targets **4.4+**, so the compatible API is correct. No runtime deprecation warning observed on 4.6.3.

## Test plan

- `uv run pytest -q` → **22 passed** (18 from #1 + 4 new). Dock test verified red-first (parse error: dock missing) → green.
- New integration tests run real Godot headless (skipif-gated on the binary — the one environmental skip the rules permit):
  - `test_addon_dock.py` drives `godot/tests/dock_smoke.gd` to pin the dock state API + 10-entry log cap.
  - `test_addon_editor_load.py` loads the headless editor and asserts the plugin enables with no `SCRIPT ERROR` — automates #1's previously-manual preflight.
- Manual: headless editor load on **Godot 4.6.3** → exit 0, no errors or deprecation warnings.
- `ruff` / `mypy` / zero-skip scan all clean.

> Note: CI (ubuntu, no Godot) skips the two integration tests via `skipif`; they run on a dev machine with Godot 4.4+. The static unit checks cover the addon wiring in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)