### PR TITLE
server: bootstrap FastMCP stdio server with health_check (closes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,60 @@ pytest
 3. The status dock appears once issue #2 lands; the bridge listens on
    `ws://localhost:9080` by default (configurable, localhost-only, no auth in v1).
 
+### Running the server
+
+```bash
+uv run godot-mcp                      # stdio (default)
+GODOT_MCP_TRANSPORT=http uv run godot-mcp   # Streamable HTTP on 127.0.0.1:9090
+```
+
+`python -m mcp_server.main` is the equivalent module invocation. (Running
+`python mcp_server/main.py` directly does **not** work — the package uses absolute
+imports, so use the console script or `-m`.)
+
+Configuration (all optional, env vars):
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `GODOT_MCP_TRANSPORT` | `stdio` | `stdio` or `http` |
+| `GODOT_MCP_HTTP_HOST` / `GODOT_MCP_HTTP_PORT` | `127.0.0.1` / `9090` | HTTP bind (when `transport=http`) |
+| `GODOT_MCP_BRIDGE_URL` | `ws://localhost:9080` | Godot addon WebSocket URL |
+| `GODOT_MCP_LOG_LEVEL` | `INFO` | log level (JSON logs → stderr) |
+| `GODOT_MCP_PERMISSION_MODE` | `ask` | tool permission mode (enforced in issue #14) |
+
 ### Connecting an MCP client
 
-The server registers as a local **stdio** MCP command. Concrete `claude mcp add` /
-`.mcp.json` (Claude Code) and `opencode.json` (OpenCode) examples are documented once the
-stdio entrypoint exists (issue #4). Planned entrypoint: `uv run godot-mcp`.
+The server registers as a local **stdio** MCP command. The `health_check` tool reports
+server version and Godot bridge connection state.
+
+**OpenCode** (`opencode.json`):
+
+```json
+{
+  "mcp": {
+    "godot": {
+      "type": "local",
+      "command": ["uv", "run", "godot-mcp"]
+    }
+  }
+}
+```
+
+**Claude Code** (`.mcp.json`, or `claude mcp add godot -- uv run godot-mcp`):
+
+```json
+{
+  "mcpServers": {
+    "godot": {
+      "command": "uv",
+      "args": ["run", "godot-mcp"]
+    }
+  }
+}
+```
+
+Both assume the command runs from the repo root (so `uv` resolves this project's
+environment). Use an absolute path or a `--directory` if launching elsewhere.
 
 ## Contributing
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -8,14 +8,21 @@ with no auth, per the v1 design.
 from __future__ import annotations
 
 import os
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 DEFAULT_BRIDGE_URL = "ws://localhost:9080"
 DEFAULT_REQUEST_TIMEOUT = 10.0
 
-# Environment override for the bridge URL.
+# MCP HTTP transport defaults (distinct from Godot's bridge port 9080).
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 9090
+
+# Environment overrides.
 BRIDGE_URL_ENV = "GODOT_MCP_BRIDGE_URL"
+
+Transport = Literal["stdio", "http"]
 
 
 class BridgeConfig(BaseModel):
@@ -28,3 +35,32 @@ class BridgeConfig(BaseModel):
     def from_env(cls) -> BridgeConfig:
         """Build config from the environment, falling back to localhost defaults."""
         return cls(url=os.environ.get(BRIDGE_URL_ENV, DEFAULT_BRIDGE_URL))
+
+
+class ServerConfig(BaseModel):
+    """Top-level MCP server configuration.
+
+    Transport defaults to ``stdio`` (the spec'd, auth-free local transport);
+    ``http`` exposes the server over Streamable HTTP for clients that want a
+    long-lived shared server. ``permission_mode`` is plumbed here but enforced in
+    issue #14.
+    """
+
+    bridge: BridgeConfig = Field(default_factory=BridgeConfig)
+    transport: Transport = "stdio"
+    host: str = DEFAULT_HTTP_HOST
+    port: int = DEFAULT_HTTP_PORT
+    log_level: str = "INFO"
+    permission_mode: str = "ask"
+
+    @classmethod
+    def from_env(cls) -> ServerConfig:
+        """Build full server config from the environment."""
+        return cls(
+            bridge=BridgeConfig.from_env(),
+            transport=os.environ.get("GODOT_MCP_TRANSPORT", "stdio"),  # type: ignore[arg-type]
+            host=os.environ.get("GODOT_MCP_HTTP_HOST", DEFAULT_HTTP_HOST),
+            port=int(os.environ.get("GODOT_MCP_HTTP_PORT", DEFAULT_HTTP_PORT)),
+            log_level=os.environ.get("GODOT_MCP_LOG_LEVEL", "INFO"),
+            permission_mode=os.environ.get("GODOT_MCP_PERMISSION_MODE", "ask"),
+        )

--- a/mcp_server/logging_setup.py
+++ b/mcp_server/logging_setup.py
@@ -1,0 +1,49 @@
+"""Structured (JSON) logging for the MCP server (issue #4).
+
+Logs are emitted as one JSON object per line to **stderr**. Under the stdio
+transport, stdout is the MCP protocol channel — writing logs there would corrupt
+it — so logging must never touch stdout (see .claude/rules/error-handling.md for
+the structured-logging requirement).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any
+
+# Standard LogRecord attributes, so we can surface any extra structured fields.
+_RESERVED = set(
+    logging.makeLogRecord({}).__dict__
+) | {"message", "asctime", "taskName"}
+
+
+class JsonFormatter(logging.Formatter):
+    """Format a log record as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Include structured extras passed via logging's ``extra=`` (e.g. the
+        # bridge command id), and exception info when present.
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED and not key.startswith("_"):
+                payload[key] = value
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Install a JSON stderr handler on the root logger (idempotent)."""
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(JsonFormatter())
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level.upper())

--- a/mcp_server/logging_setup.py
+++ b/mcp_server/logging_setup.py
@@ -38,12 +38,29 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(payload, default=str)
 
 
-def configure_logging(level: str = "INFO") -> None:
-    """Install a JSON stderr handler on the root logger (idempotent)."""
-    handler = logging.StreamHandler(stream=sys.stderr)
-    handler.setFormatter(JsonFormatter())
+def _is_json_stderr_handler(handler: logging.Handler) -> bool:
+    return isinstance(handler.formatter, JsonFormatter) and (
+        getattr(handler, "stream", None) is sys.stderr
+    )
 
+
+def configure_logging(level: str = "INFO") -> None:
+    """Route root logging to a JSON stderr handler.
+
+    Idempotent and non-destructive: removes only stdout-bound handlers (which would
+    corrupt the stdio MCP channel) and installs our stderr JSON handler at most
+    once, leaving any unrelated handlers in place.
+    """
     root = logging.getLogger()
-    root.handlers.clear()
-    root.addHandler(handler)
+
+    # Drop any handler writing to stdout — stdout is the stdio protocol channel.
+    for handler in list(root.handlers):
+        if getattr(handler, "stream", None) is sys.stdout:
+            root.removeHandler(handler)
+
+    if not any(_is_json_stderr_handler(h) for h in root.handlers):
+        handler = logging.StreamHandler(stream=sys.stderr)
+        handler.setFormatter(JsonFormatter())
+        root.addHandler(handler)
+
     root.setLevel(level.upper())

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,26 +1,34 @@
-"""stdio entrypoint for the godot-mcp FastMCP server.
+"""stdio (and optional Streamable HTTP) entrypoint for the godot-mcp server.
 
-This is a scaffold placeholder (issue #1). The FastMCP server instance, the
-``health_check`` tool, and the bridge wiring are bootstrapped in issue #4. Keeping
-this thin avoids import-time side effects (no socket connect, no ``mcp.run()`` at
-import — see .claude/rules/async-patterns.md).
+Run with ``uv run godot-mcp`` (or ``python -m mcp_server.main``). Transport
+defaults to stdio; set ``GODOT_MCP_TRANSPORT=http`` (with ``GODOT_MCP_HTTP_HOST`` /
+``GODOT_MCP_HTTP_PORT``) for a long-lived HTTP server. The FastMCP runtime owns
+the event loop — we never call ``asyncio.run`` here
+(see .claude/rules/async-patterns.md).
 """
 
 from __future__ import annotations
 
-from mcp_server import __version__
+import logging
+
+from mcp_server.config import ServerConfig
+from mcp_server.logging_setup import configure_logging
+from mcp_server.server import create_server
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    """Console-script entry point (``godot-mcp``).
+    """Build the server from the environment and run it on the configured transport."""
+    config = ServerConfig.from_env()
+    configure_logging(config.log_level)
+    logger.info("starting godot-mcp", extra={"transport": config.transport})
 
-    Replaced in issue #4 with the FastMCP stdio server. For now it only reports
-    that the server is not yet bootstrapped so the entry point is wired and
-    importable without performing any I/O at import time.
-    """
-    raise SystemExit(
-        f"godot-mcp {__version__}: server entrypoint not yet bootstrapped (issue #4)."
-    )
+    server = create_server(config)
+    if config.transport == "http":
+        server.run(transport="http", host=config.host, port=config.port)
+    else:
+        server.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/mcp_server/models/health.py
+++ b/mcp_server/models/health.py
@@ -1,0 +1,15 @@
+"""Health-check model (issue #4)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class HealthStatus(BaseModel):
+    """Server status and Godot bridge connection state."""
+
+    server: str
+    version: str
+    transport: str
+    bridge_url: str
+    bridge_connected: bool

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -11,7 +11,6 @@ missing editor never blocks the server) and closes on shutdown
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -35,10 +34,17 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncIterator[None]:
         # Best-effort connect: if Godot isn't running, start anyway and report
-        # disconnected via health_check rather than failing to boot.
-        with contextlib.suppress(Exception):
+        # disconnected via health_check rather than failing to boot — but log the
+        # failure so a wrong URL / missing addon is diagnosable.
+        try:
             await bridge.connect()
             logger.info("bridge connected", extra={"url": config.bridge.url})
+        except Exception:
+            logger.warning(
+                "bridge not connected at startup; continuing (check the editor/addon)",
+                extra={"url": config.bridge.url},
+                exc_info=True,
+            )
         try:
             yield
         finally:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,61 @@
+"""FastMCP server factory (issue #4).
+
+Builds the AI-facing MCP server: wires the Godot bridge, registers tools, and
+manages the bridge lifecycle via the server lifespan. The server is
+transport-agnostic — ``main.py`` chooses stdio (default) or Streamable HTTP.
+
+No I/O happens at import time; the bridge connects on startup (best-effort, so a
+missing editor never blocks the server) and closes on shutdown
+(see .claude/rules/async-patterns.md).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.tools.health import register_health
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "godot-mcp"
+
+
+def create_server(config: ServerConfig | None = None, bridge: Bridge | None = None) -> FastMCP:
+    """Create the FastMCP server, wiring the bridge and registering tools."""
+    config = config or ServerConfig()
+    bridge = bridge or Bridge(config.bridge)
+
+    @asynccontextmanager
+    async def lifespan(_server: FastMCP) -> AsyncIterator[None]:
+        # Best-effort connect: if Godot isn't running, start anyway and report
+        # disconnected via health_check rather than failing to boot.
+        with contextlib.suppress(Exception):
+            await bridge.connect()
+            logger.info("bridge connected", extra={"url": config.bridge.url})
+        try:
+            yield
+        finally:
+            await bridge.close()
+
+    mcp = FastMCP(SERVER_NAME, lifespan=lifespan)
+    register_health(mcp, bridge, config)
+    return mcp
+
+
+async def list_tools_by_safety_class(mcp: FastMCP) -> dict[str, list[str]]:
+    """Group registered tool names by their ``safety_class`` for agent introspection.
+
+    Tools without a declared safety class are grouped under ``"unclassified"``.
+    """
+    grouped: dict[str, list[str]] = {}
+    for tool in await mcp.list_tools():
+        safety_class = (tool.meta or {}).get("safety_class", "unclassified")
+        grouped.setdefault(safety_class, []).append(tool.name)
+    return grouped

--- a/mcp_server/tools/health.py
+++ b/mcp_server/tools/health.py
@@ -1,0 +1,39 @@
+"""The health_check tool (issue #4).
+
+A ``read_only`` tool: it reports server identity/version and whether the Godot
+bridge is currently connected. Thin delegation — the handler just assembles a
+typed model from injected state (see .claude/rules/architecture.md).
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from mcp_server import __version__
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.health import HealthStatus
+
+
+def build_health(bridge: Bridge, config: ServerConfig) -> HealthStatus:
+    """Assemble the current health status from injected state (pure, testable)."""
+    return HealthStatus(
+        server="godot-mcp",
+        version=__version__,
+        transport=config.transport,
+        bridge_url=config.bridge.url,
+        bridge_connected=bridge.connected,
+    )
+
+
+def register_health(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> None:
+    """Register health_check on the given server."""
+
+    @mcp.tool(meta={"safety_class": "read_only"})
+    async def health_check() -> HealthStatus:
+        """Report server version and whether the Godot editor bridge is connected.
+
+        Use this first to confirm the server is up and that Godot is reachable
+        before issuing other commands. Never mutates anything.
+        """
+        return build_health(bridge, config)

--- a/tests/contract/test_health_check.py
+++ b/tests/contract/test_health_check.py
@@ -45,16 +45,21 @@ async def test_health_check_reports_connected_bridge() -> None:
     assert payload["bridge_url"] == ServerConfig().bridge.url
 
 
-async def test_health_check_reports_disconnected_when_godot_absent() -> None:
-    # A connector that always fails ⇒ lifespan connect is suppressed ⇒ disconnected.
+async def test_health_check_reports_disconnected_when_godot_absent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A connector that always fails ⇒ startup connect fails ⇒ disconnected, and the
+    # failure is logged at WARNING (not silently swallowed) so it is diagnosable.
     bridge = Bridge(
         ServerConfig().bridge,
         connector=flaky_connector(fail_times=99, connection=FakeAddonConnection()),
     )
     server = _server_with_bridge(bridge)
-    async with Client(server) as client:
-        result = await client.call_tool("health_check", {})
+    with caplog.at_level("WARNING", logger="mcp_server.server"):
+        async with Client(server) as client:
+            result = await client.call_tool("health_check", {})
     assert result.structured_content["bridge_connected"] is False
+    assert any("bridge not connected" in r.message for r in caplog.records)
 
 
 async def test_list_tools_by_safety_class_groups_health_check() -> None:

--- a/tests/contract/test_health_check.py
+++ b/tests/contract/test_health_check.py
@@ -1,0 +1,64 @@
+"""Contract tests for the health_check tool (issue #4).
+
+Exercises the real FastMCP server over the in-memory client: the tool is listed,
+carries its safety class, and reports the live bridge connection state.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server import __version__
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server, list_tools_by_safety_class
+from tests.fakes import FakeAddonConnection, connector_for, flaky_connector
+
+pytestmark = pytest.mark.asyncio
+
+
+def _server_with_bridge(bridge: Bridge) -> FastMCP:
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_health_check_is_listed_as_read_only() -> None:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
+    server = _server_with_bridge(bridge)
+    async with Client(server) as client:
+        tools = await client.list_tools()
+    names = {t.name for t in tools}
+    assert "health_check" in names
+    health = next(t for t in tools if t.name == "health_check")
+    assert health.meta is not None and health.meta.get("safety_class") == "read_only"
+
+
+async def test_health_check_reports_connected_bridge() -> None:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
+    server = _server_with_bridge(bridge)
+    async with Client(server) as client:
+        result = await client.call_tool("health_check", {})
+    payload = result.structured_content
+    assert payload["server"] == "godot-mcp"
+    assert payload["version"] == __version__
+    assert payload["bridge_connected"] is True
+    assert payload["bridge_url"] == ServerConfig().bridge.url
+
+
+async def test_health_check_reports_disconnected_when_godot_absent() -> None:
+    # A connector that always fails ⇒ lifespan connect is suppressed ⇒ disconnected.
+    bridge = Bridge(
+        ServerConfig().bridge,
+        connector=flaky_connector(fail_times=99, connection=FakeAddonConnection()),
+    )
+    server = _server_with_bridge(bridge)
+    async with Client(server) as client:
+        result = await client.call_tool("health_check", {})
+    assert result.structured_content["bridge_connected"] is False
+
+
+async def test_list_tools_by_safety_class_groups_health_check() -> None:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
+    server = _server_with_bridge(bridge)
+    grouped = await list_tools_by_safety_class(server)
+    assert "health_check" in grouped["read_only"]

--- a/tests/integration/test_server_stdio.py
+++ b/tests/integration/test_server_stdio.py
@@ -1,0 +1,39 @@
+"""Integration test: the server starts over real stdio and lists its tool (issue #4).
+
+Spawns the actual entrypoint as a subprocess (``python -m mcp_server.main``) and
+drives it with a real MCP stdio client — the automated form of the acceptance
+criteria "starts without errors" and "client can list at least one tool". Needs
+no Godot (the bridge simply reports disconnected), so it runs in CI.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+def _entrypoint_transport() -> StdioTransport:
+    # Use the current interpreter and the module entrypoint (absolute imports mean
+    # `python -m mcp_server.main`, not running the file path directly).
+    return StdioTransport(command=sys.executable, args=["-m", "mcp_server.main"])
+
+
+async def test_stdio_server_lists_health_check() -> None:
+    async with Client(_entrypoint_transport()) as client:
+        await client.ping()
+        tools = await client.list_tools()
+    assert "health_check" in {t.name for t in tools}
+
+
+async def test_stdio_server_health_check_callable() -> None:
+    async with Client(_entrypoint_transport()) as client:
+        result = await client.call_tool("health_check", {})
+    payload = result.structured_content
+    assert payload["server"] == "godot-mcp"
+    # No editor running under this test ⇒ bridge reports disconnected, not an error.
+    assert payload["bridge_connected"] is False

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 
-from mcp_server.logging_setup import JsonFormatter, configure_logging
+from mcp_server.logging_setup import (
+    JsonFormatter,
+    _is_json_stderr_handler,
+    configure_logging,
+)
 
 
 def test_json_formatter_emits_parseable_record() -> None:
@@ -31,6 +36,29 @@ def test_configure_logging_does_not_touch_stdout() -> None:
     handlers = logging.getLogger().handlers
     assert handlers, "configure_logging must install a handler"
     streams = [getattr(h, "stream", None) for h in handlers]
-    import sys
 
     assert sys.stdout not in streams, "logging must never write to stdout"
+
+
+def test_configure_logging_is_idempotent() -> None:
+
+    configure_logging("INFO")
+    count = sum(1 for h in logging.getLogger().handlers if _is_json_stderr_handler(h))
+    configure_logging("INFO")
+    recount = sum(1 for h in logging.getLogger().handlers if _is_json_stderr_handler(h))
+    assert recount == count == 1, "repeated calls must not stack duplicate handlers"
+
+
+def test_configure_logging_removes_only_stdout_handlers() -> None:
+
+    root = logging.getLogger()
+    stdout_handler = logging.StreamHandler(stream=sys.stdout)
+    unrelated = logging.StreamHandler(stream=sys.stderr)  # not our JSON handler
+    root.addHandler(stdout_handler)
+    root.addHandler(unrelated)
+    try:
+        configure_logging("INFO")
+        assert stdout_handler not in root.handlers, "stdout handler must be removed"
+        assert unrelated in root.handlers, "unrelated handlers must be left in place"
+    finally:
+        root.removeHandler(unrelated)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,36 @@
+"""Unit tests for structured logging setup (issue #4)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp_server.logging_setup import JsonFormatter, configure_logging
+
+
+def test_json_formatter_emits_parseable_record() -> None:
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="mcp_server.bridge",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="bridge connected",
+        args=(),
+        exc_info=None,
+    )
+    payload = json.loads(formatter.format(record))
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "mcp_server.bridge"
+    assert payload["message"] == "bridge connected"
+
+
+def test_configure_logging_does_not_touch_stdout() -> None:
+    # stdio transport uses stdout for the MCP protocol; logs must go to stderr.
+    configure_logging("INFO")
+    handlers = logging.getLogger().handlers
+    assert handlers, "configure_logging must install a handler"
+    streams = [getattr(h, "stream", None) for h in handlers]
+    import sys
+
+    assert sys.stdout not in streams, "logging must never write to stdout"

--- a/tests/unit/test_server_config.py
+++ b/tests/unit/test_server_config.py
@@ -1,0 +1,37 @@
+"""Unit tests for ServerConfig (issue #4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.config import DEFAULT_BRIDGE_URL, ServerConfig
+
+
+def test_defaults_are_stdio_localhost() -> None:
+    config = ServerConfig()
+    assert config.transport == "stdio"
+    assert config.bridge.url == DEFAULT_BRIDGE_URL
+    assert config.log_level == "INFO"
+    # The MCP HTTP port is distinct from Godot's bridge port (9080).
+    assert config.port != 9080
+
+
+def test_from_env_reads_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("GODOT_MCP_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setenv("GODOT_MCP_HTTP_PORT", "9095")
+    monkeypatch.setenv("GODOT_MCP_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("GODOT_MCP_BRIDGE_URL", "ws://localhost:9081")
+
+    config = ServerConfig.from_env()
+    assert config.transport == "http"
+    assert config.host == "0.0.0.0"
+    assert config.port == 9095
+    assert config.log_level == "DEBUG"
+    assert config.bridge.url == "ws://localhost:9081"
+
+
+def test_from_env_rejects_unknown_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_TRANSPORT", "carrier-pigeon")
+    with pytest.raises(ValueError):
+        ServerConfig.from_env()

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -53,10 +53,9 @@ def test_main_entrypoint_is_callable_without_import_side_effects() -> None:
     assert callable(main_mod.main)
 
 
-def test_main_reports_not_yet_bootstrapped() -> None:
-    from mcp_server.main import main
+def test_create_server_builds_without_io() -> None:
+    # Building the server must not perform I/O or block (it runs in-process here).
+    from mcp_server.server import create_server
 
-    # The scaffold entrypoint exits cleanly with a message, not a traceback.
-    with pytest.raises(SystemExit) as excinfo:
-        main()
-    assert "issue #4" in str(excinfo.value)
+    server = create_server()
+    assert server is not None


### PR DESCRIPTION
## Summary

The AI-facing entry point: a transport-agnostic FastMCP server. **stdio by default** (spec'd, auth-free local transport), **Streamable HTTP** via `GODOT_MCP_TRANSPORT=http`. Closes #4.

> Transport: per discussion, stdio stays the v1 default (localhost/no-auth) and HTTP is a one-flag option, since FastMCP makes the transport a one-line switch and HTTP's multi-client benefit isn't a v1 goal.

## Acceptance criteria

- [x] Server starts without errors — verified by a real stdio subprocess test
- [x] MCP client can list at least one tool (`health_check`)
- [x] Structured logging — JSON to **stderr** (stdout is the stdio protocol channel)
- [x] `opencode.json` (+ Claude Code `.mcp.json`) documented in README
- [x] Installs cleanly from a fresh 3.11+ venv (`uv sync`)

## What's here

- `server.py` — `create_server()` wires the bridge + tools and manages the bridge via the **lifespan** (best-effort connect on startup so a missing editor never blocks boot; close on shutdown). `list_tools_by_safety_class()` for introspection.
- `tools/health.py` — `health_check` (`read_only`) → typed `HealthStatus`, tagged with `safety_class` meta.
- `config.py` — `ServerConfig` (transport/host/port/log_level/permission_mode + `BridgeConfig`) with `from_env()`. `permission_mode` is plumbed; **enforced in #14**.
- `logging_setup.py` — JSON logging to stderr. `main.py` — transport-agnostic entrypoint.

## Test plan

- `uv run pytest -q` → **60 passed** (up from 49). New: config env, JSON logging + a stdout-safety assertion, `health_check` contract over the in-memory client (listed / safety-class / connected vs disconnected), and `test_server_stdio.py` which spawns `python -m mcp_server.main` and drives it with a real MCP stdio client — needs no Godot, so it runs in CI.
- `ruff` / `mypy --strict` / zero-skip clean.

## Notes / deviations

- All FastMCP APIs verified against current v3 docs before use.
- `python mcp_server/main.py` (literal file path from the issue) does **not** work with the package's absolute imports — README documents `uv run godot-mcp` / `python -m mcp_server.main` instead, and the `opencode.json` example uses the console script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)