### PR TITLE
tools: core read-only inspection tools, both sides (closes #5)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,11 +117,25 @@ contract tests) before adding a new code.
 
 ## Type coercion
 
-Godot types (`Vector2/3`, `Color`, `Rect2`, `NodePath`) cross the bridge as JSON-safe
-forms and are coerced on the addon side in a dedicated `type_coerce.gd` helper (issue #6),
-never inline. Scene trees serialize to `{ name, type, script, children }` and honor a
-`max_depth` parameter. The exact JSON shape for each type is fixed alongside the mutation
-tools in issue #6 and documented in [`tool-contracts.md`](tool-contracts.md).
+Godot types cross the bridge as JSON-safe forms, coerced on the addon side in the
+dedicated `type_coerce.gd` helper (`MCPTypeCoerce`), never inline. The read direction
+(Godot → JSON) landed in issue #5; the write direction (`from_json`, using each property's
+declared type to reconstruct the Godot value) lands with the mutation tools in issue #6.
+
+| Godot type | JSON shape |
+|------------|------------|
+| `Vector2` / `Vector2i` | `{ "x": float, "y": float }` |
+| `Vector3` / `Vector3i` | `{ "x": float, "y": float, "z": float }` |
+| `Color` | `{ "r": float, "g": float, "b": float, "a": float }` |
+| `Rect2` / `Rect2i` | `{ "position": {x,y}, "size": {x,y} }` |
+| `NodePath` / `StringName` | string |
+| `Resource` | its `resource_path` (else the class name) |
+| `Array` / packed arrays / `Dictionary` | coerced element-wise |
+| `null`, `bool`, `int`, `float`, `String` | passed through unchanged |
+
+Scene trees serialize to `{ name, type, script, children }` and honor a `max_depth`
+parameter (`-1` = unlimited, `0` = the node with no children). Node detail serializes to
+`{ node_path, type, script, properties, children }` (see [`tool-contracts.md`](tool-contracts.md)).
 
 ## Health check
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -67,6 +67,25 @@ Document each tool here as it lands, using this shape:
 > **Returns:** `CreateNodeResult { node_path: str, created: bool }`.
 > **Bridge command:** `cmd_create_node`.
 
+### Implemented tools
+
+#### Inspection (issue #5) — all `read_only`
+
+Every tool routes to the matching `cmd_*` addon handler and returns a typed model.
+Failures surface as a `ToolError` carrying `"<ERROR_CODE>: <hint>"`. No-scene / no-selection
+states return an empty model (`is_open=False` / `tree=None` / `selected=None`), not an error.
+
+| Tool | Params | Returns | Bridge command |
+|------|--------|---------|----------------|
+| `get_project_info` | — | `ProjectInfo { name, godot_version, main_scene?, autoloads, input_actions }` | `cmd_get_project_info` |
+| `get_active_scene` | — | `ActiveScene { is_open, path?, name? }` | `cmd_get_active_scene` |
+| `get_scene_tree` | `max_depth: int = -1` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
+| `get_selected_node` | — | `SelectedNode { selected: NodeInfo? }` | `cmd_get_selected_node` |
+| `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
+
+`SceneNode = { name, type, script?, children: [SceneNode] }`. `get_node_properties` errors
+with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
+
 ## Resources
 
 - `@mcp.resource("godot://…")` handlers are **read-only** and return JSON strings; no side

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -1,57 +1,141 @@
 @tool
 class_name MCPCommandRouter
 extends RefCounted
-## Routes incoming command envelopes to cmd_* handlers (issue #3).
+## Routes incoming command envelopes to cmd_* handlers (issues #3, #5).
 ##
-## Pure dispatch with no networking, so it is verifiable headlessly
-## (see godot/tests/bridge_smoke.gd). Every outcome is a JSON-safe response
-## envelope — { id, ok, result } on success, { id, ok:false, error, hint } on
-## failure — never a raw error or a crash (see .claude/rules/error-handling.md).
+## Pure dispatch + structured errors; every outcome is a JSON-safe response
+## envelope — { id, ok, result } or { id, ok:false, error, hint[, required] } —
+## never a raw error or crash (see .claude/rules/error-handling.md).
 ##
-## Handlers are named cmd_<verb>_<noun>; the matching MCP tool drops the cmd_
-## prefix. Mutation handlers (issue #6) register UndoRedo; only ping exists now.
+## Handlers receive the params dict and return a response *body* (without id) via
+## the _ok / _fail builders; handle() stamps the id. Read-only inspection
+## handlers (#5) read editor state through EditorInterface; safety/preconditions
+## are owned by the MCP server, except the local guards needed to return a
+## structured error instead of crashing.
+
+const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
 
 var _handlers: Dictionary = {}
 
 
 func _init() -> void:
 	_handlers["ping"] = _cmd_ping
+	_handlers["get_project_info"] = _cmd_get_project_info
+	_handlers["get_active_scene"] = _cmd_get_active_scene
+	_handlers["get_scene_tree"] = _cmd_get_scene_tree
+	_handlers["get_selected_node"] = _cmd_get_selected_node
+	_handlers["get_node_properties"] = _cmd_get_node_properties
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
 func handle(envelope: Dictionary) -> Dictionary:
-	var id := str(envelope.get("id", ""))
-	if not envelope.has("command"):
-		return _error(id, "VALIDATION_ERROR", "Envelope is missing 'command'.")
-
-	var command := str(envelope["command"])
-	if not _handlers.has(command):
-		return _error(id, "VALIDATION_ERROR", "Unknown command '%s'." % command)
-
-	# params is untrusted JSON: reject anything that is not an object.
-	var raw_params: Variant = envelope.get("params", {})
-	if typeof(raw_params) != TYPE_DICTIONARY:
-		return _error(id, "VALIDATION_ERROR", "'params' must be an object.")
-
-	var handler: Callable = _handlers[command]
-	return _ok(id, handler.call(raw_params as Dictionary))
+	var body := _route(envelope)
+	body["id"] = str(envelope.get("id", ""))
+	return body
 
 
 func has_command(command: String) -> bool:
 	return _handlers.has(command)
 
 
+func _route(envelope: Dictionary) -> Dictionary:
+	if not envelope.has("command"):
+		return _fail("VALIDATION_ERROR", "Envelope is missing 'command'.")
+	var command := str(envelope["command"])
+	if not _handlers.has(command):
+		return _fail("VALIDATION_ERROR", "Unknown command '%s'." % command)
+	var raw_params: Variant = envelope.get("params", {})
+	if typeof(raw_params) != TYPE_DICTIONARY:
+		return _fail("VALIDATION_ERROR", "'params' must be an object.")
+	var handler: Callable = _handlers[command]
+	return handler.call(raw_params as Dictionary)
+
+
 # --- handlers --------------------------------------------------------------
 
 func _cmd_ping(_params: Dictionary) -> Dictionary:
-	return {"pong": true}
+	return _ok({"pong": true})
 
 
-# --- envelope builders -----------------------------------------------------
+func _cmd_get_project_info(_params: Dictionary) -> Dictionary:
+	return _ok({
+		"name": ProjectSettings.get_setting("application/config/name", ""),
+		"godot_version": Engine.get_version_info().get("string", ""),
+		"main_scene": ProjectSettings.get_setting("application/run/main_scene", ""),
+		"autoloads": _autoloads(),
+		"input_actions": _input_actions(),
+	})
 
-func _ok(id: String, result: Dictionary) -> Dictionary:
-	return {"id": id, "ok": true, "result": result}
+
+func _cmd_get_active_scene(_params: Dictionary) -> Dictionary:
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _ok({"is_open": false, "path": null, "name": null})
+	return _ok({"is_open": true, "path": root.scene_file_path, "name": _scene_name(root)})
 
 
-func _error(id: String, code: String, hint: String) -> Dictionary:
-	return {"id": id, "ok": false, "error": code, "hint": hint}
+func _cmd_get_scene_tree(params: Dictionary) -> Dictionary:
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _ok({"tree": null})
+	var max_depth := int(params.get("max_depth", -1))
+	return _ok({"tree": Inspect.serialize_tree(root, max_depth)})
+
+
+func _cmd_get_selected_node(_params: Dictionary) -> Dictionary:
+	var selected: Array[Node] = EditorInterface.get_selection().get_selected_nodes()
+	if selected.is_empty():
+		return _ok({"selected": null})
+	var root: Node = EditorInterface.get_edited_scene_root()
+	return _ok({"selected": Inspect.node_info(selected[0], root if root != null else selected[0])})
+
+
+func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
+	if not params.has("node_path"):
+		return _fail("VALIDATION_ERROR", "'node_path' is required.")
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node: Node = root.get_node_or_null(NodePath(str(params["node_path"])))
+	if node == null:
+		return _fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
+	return _ok(Inspect.node_info(node, root))
+
+
+# --- editor-state helpers --------------------------------------------------
+
+func _scene_name(root: Node) -> String:
+	if not root.scene_file_path.is_empty():
+		return root.scene_file_path.get_file()
+	return String(root.name)
+
+
+func _autoloads() -> Dictionary:
+	var autoloads: Dictionary = {}
+	for entry in ProjectSettings.get_property_list():
+		var key: String = entry["name"]
+		if key.begins_with("autoload/"):
+			autoloads[key.trim_prefix("autoload/")] = str(ProjectSettings.get_setting(key, ""))
+	return autoloads
+
+
+func _input_actions() -> Array:
+	var actions: Array = []
+	for entry in ProjectSettings.get_property_list():
+		var key: String = entry["name"]
+		if key.begins_with("input/"):
+			actions.append(key.trim_prefix("input/"))
+	return actions
+
+
+# --- response builders -----------------------------------------------------
+
+func _ok(result: Dictionary) -> Dictionary:
+	return {"ok": true, "result": result}
+
+
+func _fail(code: String, hint: String, required: String = "") -> Dictionary:
+	var body: Dictionary = {"ok": false, "error": code, "hint": hint}
+	if not required.is_empty():
+		body["required"] = required
+	return body

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -19,12 +19,14 @@ var _handlers: Dictionary = {}
 
 
 func _init() -> void:
-	_handlers["ping"] = _cmd_ping
-	_handlers["get_project_info"] = _cmd_get_project_info
-	_handlers["get_active_scene"] = _cmd_get_active_scene
-	_handlers["get_scene_tree"] = _cmd_get_scene_tree
-	_handlers["get_selected_node"] = _cmd_get_selected_node
-	_handlers["get_node_properties"] = _cmd_get_node_properties
+	# Wire command strings are the cmd_<verb>_<noun> handler names (the matching MCP
+	# tool drops the cmd_ prefix); see docs/architecture.md.
+	_handlers["cmd_ping"] = _cmd_ping
+	_handlers["cmd_get_project_info"] = _cmd_get_project_info
+	_handlers["cmd_get_active_scene"] = _cmd_get_active_scene
+	_handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
+	_handlers["cmd_get_selected_node"] = _cmd_get_selected_node
+	_handlers["cmd_get_node_properties"] = _cmd_get_node_properties
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -1,0 +1,66 @@
+@tool
+class_name MCPSceneInspect
+extends RefCounted
+## Pure, read-only serialization of scene/node state (issue #5).
+##
+## These helpers take Nodes (never EditorInterface), so they are verifiable
+## headlessly (see godot/tests/inspect_smoke.gd). All output is JSON-safe via
+## MCPTypeCoerce. The cmd_* handlers supply the editor-provided nodes.
+
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+
+
+## Recursive { name, type, script, children } for a subtree.
+## max_depth < 0 is unlimited; max_depth == 0 returns the node with no children.
+static func serialize_tree(node: Node, max_depth: int = -1) -> Dictionary:
+	var data: Dictionary = {
+		"name": String(node.name),
+		"type": node.get_class(),
+		"script": script_path(node),
+	}
+	var children: Array = []
+	if max_depth != 0:
+		var child_depth: int = (max_depth - 1) if max_depth > 0 else -1
+		for child in node.get_children():
+			children.append(serialize_tree(child, child_depth))
+	data["children"] = children
+	return data
+
+
+## { node_path, type, script, properties, children:[names] } for one node,
+## with node_path relative to scene_root ("." for the root itself).
+static func node_info(node: Node, scene_root: Node) -> Dictionary:
+	var child_names: Array = []
+	for child in node.get_children():
+		child_names.append(String(child.name))
+	return {
+		"node_path": relative_path(node, scene_root),
+		"type": node.get_class(),
+		"script": script_path(node),
+		"properties": node_properties(node),
+		"children": child_names,
+	}
+
+
+## Exported / script-declared properties, JSON-coerced.
+static func node_properties(node: Node) -> Dictionary:
+	var props: Dictionary = {}
+	for entry in node.get_property_list():
+		if (entry.get("usage", 0) & PROPERTY_USAGE_SCRIPT_VARIABLE) != 0:
+			var name: String = entry["name"]
+			props[name] = Coerce.to_json(node.get(name))
+	return props
+
+
+## The attached script's resource path, or null when there is none.
+static func script_path(node: Node) -> Variant:
+	var script: Variant = node.get_script()
+	if script is Script and not script.resource_path.is_empty():
+		return script.resource_path
+	return null
+
+
+static func relative_path(node: Node, scene_root: Node) -> String:
+	if node == scene_root:
+		return "."
+	return String(scene_root.get_path_to(node))

--- a/godot/addons/godot_mcp/scene_inspect.gd.uid
+++ b/godot/addons/godot_mcp/scene_inspect.gd.uid
@@ -1,0 +1,1 @@
+uid://bteapendds7y0

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -1,0 +1,49 @@
+@tool
+class_name MCPTypeCoerce
+extends RefCounted
+## JSON-safe coercion of Godot types (issue #5; extended for write/roundtrip in #6).
+##
+## Everything crossing the bridge must be JSON-safe — no Godot objects
+## (see .claude/rules/addon.md). This is the single place that knows how Godot
+## types map to JSON; never coerce inline. Read direction (Godot → JSON) only for
+## now; from_json() lands with the mutation tools (#6).
+##
+## Shapes (documented in docs/architecture.md):
+##   Vector2 → {x, y}      Vector3 → {x, y, z}
+##   Color   → {r, g, b, a}  Rect2  → {position:{x,y}, size:{x,y}}
+##   NodePath → string       Resource → its resource_path (or class name)
+##   Arrays/Dictionaries are coerced element-wise; primitives pass through.
+
+
+static func to_json(value: Variant) -> Variant:
+	match typeof(value):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_COLOR:
+			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+		TYPE_RECT2, TYPE_RECT2I:
+			return {"position": to_json(value.position), "size": to_json(value.size)}
+		TYPE_NODE_PATH, TYPE_STRING_NAME:
+			return str(value)
+		TYPE_ARRAY, TYPE_PACKED_STRING_ARRAY, TYPE_PACKED_INT32_ARRAY, \
+		TYPE_PACKED_INT64_ARRAY, TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY:
+			var out: Array = []
+			for item in value:
+				out.append(to_json(item))
+			return out
+		TYPE_DICTIONARY:
+			var out: Dictionary = {}
+			for key in value:
+				out[str(key)] = to_json(value[key])
+			return out
+		TYPE_OBJECT:
+			if value == null:
+				return null
+			if value is Resource and not value.resource_path.is_empty():
+				return value.resource_path
+			return str(value)
+		_:
+			# Primitives (null, bool, int, float, String) are already JSON-safe.
+			return value

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -43,7 +43,8 @@ static func to_json(value: Variant) -> Variant:
 				return null
 			if value is Resource and not value.resource_path.is_empty():
 				return value.resource_path
-			return str(value)
+			# Stable fallback: the class name, never str() (which leaks instance ids).
+			return value.get_class()
 		_:
 			# Primitives (null, bool, int, float, String) are already JSON-safe.
 			return value

--- a/godot/addons/godot_mcp/type_coerce.gd.uid
+++ b/godot/addons/godot_mcp/type_coerce.gd.uid
@@ -1,0 +1,1 @@
+uid://c7fpmj2rxtqrm

--- a/godot/tests/bridge_smoke.gd
+++ b/godot/tests/bridge_smoke.gd
@@ -16,7 +16,7 @@ func _initialize() -> void:
 	var router := Router.new()
 
 	# ping → ok with {pong: true}, echoing the request id.
-	var pong: Dictionary = router.handle({"id": "1", "command": "ping", "params": {}})
+	var pong: Dictionary = router.handle({"id": "1", "command": "cmd_ping", "params": {}})
 	if pong.get("id") != "1":
 		failures.append("ping id not echoed: %s" % str(pong.get("id")))
 	if pong.get("ok") != true:
@@ -42,7 +42,7 @@ func _initialize() -> void:
 		failures.append("malformed error code: %s" % str(malformed.get("error")))
 
 	# Non-object params (untrusted JSON) → structured error, never a runtime crash.
-	var bad_params: Dictionary = router.handle({"id": "4", "command": "ping", "params": "oops"})
+	var bad_params: Dictionary = router.handle({"id": "4", "command": "cmd_ping", "params": "oops"})
 	if bad_params.get("ok") != false:
 		failures.append("non-object params should fail")
 	if bad_params.get("error") != "VALIDATION_ERROR":

--- a/godot/tests/fixtures/probe.gd
+++ b/godot/tests/fixtures/probe.gd
@@ -1,0 +1,7 @@
+@tool
+extends Node2D
+## Test fixture: a node with exported script variables, used to verify
+## MCPSceneInspect.node_properties() picks up exported/script properties.
+
+@export var speed: float = 200.0
+@export var health: int = 100

--- a/godot/tests/fixtures/probe.gd.uid
+++ b/godot/tests/fixtures/probe.gd.uid
@@ -1,0 +1,1 @@
+uid://cqlhc2hi57ogm

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -1,0 +1,110 @@
+@tool
+extends SceneTree
+## Headless behavior test for the read-only inspection serializers (issue #5).
+##
+## Run via: godot --headless --path godot/ --script res://tests/inspect_smoke.gd
+## Exercises the pure, editor-independent helpers MCPTypeCoerce and
+## MCPSceneInspect — JSON-safe type coercion, recursive scene serialization, and
+## max_depth — without EditorInterface. The editor glue in the cmd_* handlers is
+## covered by the cross-process e2e test (test_inspection_e2e.py).
+
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+const Probe := preload("res://tests/fixtures/probe.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+	_test_type_coerce(failures)
+	_test_serialize_tree(failures)
+	_test_node_properties(failures)
+	_test_node_info(failures)
+
+	if failures.is_empty():
+		print("INSPECT_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("INSPECT_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])
+
+
+func _test_type_coerce(failures: Array[String]) -> void:
+	_eq(failures, "vector2", Coerce.to_json(Vector2(1, 2)), {"x": 1.0, "y": 2.0})
+	_eq(failures, "vector3", Coerce.to_json(Vector3(1, 2, 3)), {"x": 1.0, "y": 2.0, "z": 3.0})
+	_eq(failures, "color", Coerce.to_json(Color(1, 0, 0, 1)), {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0})
+	_eq(failures, "nodepath", Coerce.to_json(NodePath("a/b")), "a/b")
+	_eq(failures, "array", Coerce.to_json([Vector2(0, 0), 5]), [{"x": 0.0, "y": 0.0}, 5])
+	_eq(failures, "dict", Coerce.to_json({"v": Vector2(1, 1)}), {"v": {"x": 1.0, "y": 1.0}})
+	# Primitives pass through unchanged.
+	_eq(failures, "int", Coerce.to_json(42), 42)
+	_eq(failures, "string", Coerce.to_json("hi"), "hi")
+	_eq(failures, "bool", Coerce.to_json(true), true)
+	_eq(failures, "null", Coerce.to_json(null), null)
+
+
+func _test_serialize_tree(failures: Array[String]) -> void:
+	var world := Node2D.new()
+	world.name = "World"
+	var sprite := Sprite2D.new()
+	sprite.name = "Sprite"
+	var deep := Node.new()
+	deep.name = "Deep"
+	world.add_child(sprite)
+	sprite.add_child(deep)
+
+	var full: Dictionary = Inspect.serialize_tree(world)
+	_eq(failures, "tree.name", full.get("name"), "World")
+	_eq(failures, "tree.type", full.get("type"), "Node2D")
+	_eq(failures, "tree.script", full.get("script"), null)
+	var children: Array = full.get("children")
+	if children.size() != 1 or children[0].get("name") != "Sprite":
+		failures.append("tree children wrong: %s" % str(children))
+	elif children[0].get("children")[0].get("name") != "Deep":
+		failures.append("tree grandchild wrong")
+
+	# max_depth=1 ⇒ root + immediate children, but their children truncated.
+	var shallow: Dictionary = Inspect.serialize_tree(world, 1)
+	var shallow_children: Array = shallow.get("children")
+	_eq(failures, "depth1.child", shallow_children[0].get("name"), "Sprite")
+	_eq(failures, "depth1.truncated", shallow_children[0].get("children"), [])
+
+	# Output must be JSON-safe (stringify must not error).
+	if JSON.stringify(full) == "":
+		failures.append("serialized tree is not JSON-safe")
+
+	world.free()
+
+
+func _test_node_properties(failures: Array[String]) -> void:
+	var node := Node2D.new()
+	node.set_script(Probe)
+	var props: Dictionary = Inspect.node_properties(node)
+	_eq(failures, "props.speed", props.get("speed"), 200.0)
+	_eq(failures, "props.health", props.get("health"), 100)
+	node.free()
+
+
+func _test_node_info(failures: Array[String]) -> void:
+	var root := Node2D.new()
+	root.name = "Root"
+	var player := CharacterBody2D.new()
+	player.name = "Player"
+	var sprite := Sprite2D.new()
+	sprite.name = "Sprite2D"
+	root.add_child(player)
+	player.add_child(sprite)
+
+	var info: Dictionary = Inspect.node_info(player, root)
+	_eq(failures, "info.node_path", info.get("node_path"), "Player")
+	_eq(failures, "info.type", info.get("type"), "CharacterBody2D")
+	_eq(failures, "info.children", info.get("children"), ["Sprite2D"])
+	# Root resolves to "." relative to itself.
+	_eq(failures, "info.root_path", Inspect.node_info(root, root).get("node_path"), ".")
+	root.free()

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -47,6 +47,8 @@ func _test_type_coerce(failures: Array[String]) -> void:
 	_eq(failures, "string", Coerce.to_json("hi"), "hi")
 	_eq(failures, "bool", Coerce.to_json(true), true)
 	_eq(failures, "null", Coerce.to_json(null), null)
+	# A path-less Resource coerces to its class name, never str() instance details.
+	_eq(failures, "resource_classname", Coerce.to_json(Resource.new()), "Resource")
 
 
 func _test_serialize_tree(failures: Array[String]) -> void:

--- a/godot/tests/inspect_smoke.gd.uid
+++ b/godot/tests/inspect_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://18h0v01bsgty

--- a/mcp_server/bridge.py
+++ b/mcp_server/bridge.py
@@ -139,8 +139,8 @@ class Bridge:
         return await self._await_response(msg_id, future, timeout)
 
     async def ping(self) -> bool:
-        """Liveness probe: a ``ping`` command should answer ``{pong: true}``."""
-        response = await self.send("ping")
+        """Liveness probe: ``cmd_ping`` should answer ``{pong: true}``."""
+        response = await self.send("cmd_ping")
         return response.ok and bool(response.result and response.result.get("pong"))
 
     # --- internals -------------------------------------------------------

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -1,0 +1,59 @@
+"""Typed models for read-only inspection tools (issue #5).
+
+Mirror the JSON-safe shapes the addon returns. ``snake_case`` throughout.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ProjectInfo(BaseModel):
+    """Project-level context."""
+
+    name: str
+    godot_version: str
+    main_scene: str | None = None
+    autoloads: dict[str, str] = Field(default_factory=dict)
+    input_actions: list[str] = Field(default_factory=list)
+
+
+class ActiveScene(BaseModel):
+    """The currently open scene, or ``is_open=False`` when none is open."""
+
+    is_open: bool
+    path: str | None = None
+    name: str | None = None
+
+
+class SceneNode(BaseModel):
+    """A node in the recursive scene-tree serialization."""
+
+    name: str
+    type: str
+    script: str | None = None
+    children: list[SceneNode] = Field(default_factory=list)
+
+
+class SceneTree(BaseModel):
+    """The active scene tree, or ``tree=None`` when no scene is open."""
+
+    tree: SceneNode | None = None
+
+
+class NodeInfo(BaseModel):
+    """Full detail for a single node (path, type, script, properties, children)."""
+
+    node_path: str
+    type: str
+    script: str | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+    children: list[str] = Field(default_factory=list)
+
+
+class SelectedNode(BaseModel):
+    """The selected node, or ``selected=None`` when nothing is selected."""
+
+    selected: NodeInfo | None = None

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -20,6 +20,7 @@ from fastmcp import FastMCP
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
 from mcp_server.tools.health import register_health
+from mcp_server.tools.inspection import register_inspection
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
 
     mcp = FastMCP(SERVER_NAME, lifespan=lifespan)
     register_health(mcp, bridge, config)
+    register_inspection(mcp, bridge)
     return mcp
 
 

--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -1,0 +1,26 @@
+"""Bridge → tool routing helper (issue #5).
+
+Keeps tool handlers thin (delegation only, per .claude/rules/architecture.md): send
+a command, return the result dict on success, or raise a ``ToolError`` carrying the
+structured ``error: hint`` on failure so the agent gets an actionable message
+instead of a stack trace.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+
+from mcp_server.bridge import Bridge
+
+
+async def route(
+    bridge: Bridge, command: str, params: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Send a command over the bridge; return its result or raise a structured error."""
+    response = await bridge.send(command, params or {})
+    if not response.ok:
+        detail = f"{response.error}: {response.hint}" if response.hint else str(response.error)
+        raise ToolError(detail)
+    return response.result or {}

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -30,14 +30,14 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         """Get project-level context: name, Godot version, main scene, autoloads,
         and project-defined input actions. Call this to orient before editing.
         """
-        return ProjectInfo(**await route(bridge, "get_project_info"))
+        return ProjectInfo(**await route(bridge, "cmd_get_project_info"))
 
     @mcp.tool(meta=READ_ONLY)
     async def get_active_scene() -> ActiveScene:
         """Get the currently open scene's path and name. Returns ``is_open=False``
         when no scene is open (not an error).
         """
-        return ActiveScene(**await route(bridge, "get_active_scene"))
+        return ActiveScene(**await route(bridge, "cmd_get_active_scene"))
 
     @mcp.tool(meta=READ_ONLY)
     async def get_scene_tree(max_depth: int = -1) -> SceneTree:
@@ -47,7 +47,7 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         0 = root only); use it to avoid huge payloads on deep scenes. ``tree`` is
         null when no scene is open.
         """
-        return SceneTree(**await route(bridge, "get_scene_tree", {"max_depth": max_depth}))
+        return SceneTree(**await route(bridge, "cmd_get_scene_tree", {"max_depth": max_depth}))
 
     @mcp.tool(meta=READ_ONLY)
     async def get_selected_node() -> SelectedNode:
@@ -55,7 +55,7 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         properties, and child names. Returns ``selected=None`` when nothing is
         selected.
         """
-        return SelectedNode(**await route(bridge, "get_selected_node"))
+        return SelectedNode(**await route(bridge, "cmd_get_selected_node"))
 
     @mcp.tool(meta=READ_ONLY)
     async def get_node_properties(node_path: str) -> NodeInfo:
@@ -64,4 +64,4 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         with RESOURCE_NOT_FOUND if the path doesn't resolve, or PRECONDITION_FAILED
         if no scene is open.
         """
-        return NodeInfo(**await route(bridge, "get_node_properties", {"node_path": node_path}))
+        return NodeInfo(**await route(bridge, "cmd_get_node_properties", {"node_path": node_path}))

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -1,0 +1,67 @@
+"""Read-only inspection tools (issue #5).
+
+The most frequently called tools: they let an agent understand the project and
+scene before making changes. All ``read_only`` — they never mutate anything.
+Each is a thin wrapper that routes to the addon and returns a typed model.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.models.inspection import (
+    ActiveScene,
+    NodeInfo,
+    ProjectInfo,
+    SceneTree,
+    SelectedNode,
+)
+from mcp_server.tools._route import route
+
+READ_ONLY = {"safety_class": "read_only"}
+
+
+def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register all five inspection tools on the server."""
+
+    @mcp.tool(meta=READ_ONLY)
+    async def get_project_info() -> ProjectInfo:
+        """Get project-level context: name, Godot version, main scene, autoloads,
+        and project-defined input actions. Call this to orient before editing.
+        """
+        return ProjectInfo(**await route(bridge, "get_project_info"))
+
+    @mcp.tool(meta=READ_ONLY)
+    async def get_active_scene() -> ActiveScene:
+        """Get the currently open scene's path and name. Returns ``is_open=False``
+        when no scene is open (not an error).
+        """
+        return ActiveScene(**await route(bridge, "get_active_scene"))
+
+    @mcp.tool(meta=READ_ONLY)
+    async def get_scene_tree(max_depth: int = -1) -> SceneTree:
+        """Get the open scene as a recursive tree of {name, type, script, children}.
+
+        ``max_depth`` limits how many child levels are returned (-1 = unlimited,
+        0 = root only); use it to avoid huge payloads on deep scenes. ``tree`` is
+        null when no scene is open.
+        """
+        return SceneTree(**await route(bridge, "get_scene_tree", {"max_depth": max_depth}))
+
+    @mcp.tool(meta=READ_ONLY)
+    async def get_selected_node() -> SelectedNode:
+        """Get the node currently selected in the editor — its path, type, script,
+        properties, and child names. Returns ``selected=None`` when nothing is
+        selected.
+        """
+        return SelectedNode(**await route(bridge, "get_selected_node"))
+
+    @mcp.tool(meta=READ_ONLY)
+    async def get_node_properties(node_path: str) -> NodeInfo:
+        """Get a node's detail by scene-relative path (e.g. "Player/Sprite2D"):
+        type, attached script, exported/set properties, and child names. Errors
+        with RESOURCE_NOT_FOUND if the path doesn't resolve, or PRECONDITION_FAILED
+        if no scene is open.
+        """
+        return NodeInfo(**await route(bridge, "get_node_properties", {"node_path": node_path}))

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.asyncio
 
 def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
-        case "get_project_info":
+        case "cmd_get_project_info":
             return ResponseEnvelope.success(
                 cmd.id,
                 {
@@ -33,16 +33,16 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "input_actions": ["jump"],
                 },
             )
-        case "get_active_scene":
+        case "cmd_get_active_scene":
             return ResponseEnvelope.success(
                 cmd.id, {"is_open": True, "path": "res://main.tscn", "name": "main.tscn"}
             )
-        case "get_scene_tree":
+        case "cmd_get_scene_tree":
             return ResponseEnvelope.success(
                 cmd.id,
                 {"tree": {"name": "Main", "type": "Node2D", "script": None, "children": []}},
             )
-        case "get_selected_node":
+        case "cmd_get_selected_node":
             return ResponseEnvelope.success(
                 cmd.id,
                 {
@@ -55,7 +55,7 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     }
                 },
             )
-        case "get_node_properties":
+        case "cmd_get_node_properties":
             if cmd.params.get("node_path") == "Missing":
                 return ResponseEnvelope.failure(
                     cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Missing'."
@@ -75,11 +75,11 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
 
 def _empty(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
-        case "get_active_scene":
+        case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": False, "path": None, "name": None})
-        case "get_scene_tree":
+        case "cmd_get_scene_tree":
             return ResponseEnvelope.success(cmd.id, {"tree": None})
-        case "get_selected_node":
+        case "cmd_get_selected_node":
             return ResponseEnvelope.success(cmd.id, {"selected": None})
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -1,0 +1,163 @@
+"""Contract tests for the read-only inspection tools (issue #5).
+
+Drive the real FastMCP server over the in-memory client, backed by a fake addon
+peer with canned responses: verify each tool routes to the right command, maps
+the JSON-safe response to its typed model, handles empty/no-scene state, and
+surfaces structured errors.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    match cmd.command:
+        case "get_project_info":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "name": "demo",
+                    "godot_version": "4.6.3",
+                    "main_scene": "res://main.tscn",
+                    "autoloads": {"Game": "res://game.gd"},
+                    "input_actions": ["jump"],
+                },
+            )
+        case "get_active_scene":
+            return ResponseEnvelope.success(
+                cmd.id, {"is_open": True, "path": "res://main.tscn", "name": "main.tscn"}
+            )
+        case "get_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"tree": {"name": "Main", "type": "Node2D", "script": None, "children": []}},
+            )
+        case "get_selected_node":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "selected": {
+                        "node_path": "Player",
+                        "type": "CharacterBody2D",
+                        "script": "res://player.gd",
+                        "properties": {"speed": 200.0},
+                        "children": ["Sprite2D"],
+                    }
+                },
+            )
+        case "get_node_properties":
+            if cmd.params.get("node_path") == "Missing":
+                return ResponseEnvelope.failure(
+                    cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Missing'."
+                )
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "type": "Sprite2D",
+                    "script": None,
+                    "properties": {},
+                    "children": [],
+                },
+            )
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
+
+
+def _empty(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    match cmd.command:
+        case "get_active_scene":
+            return ResponseEnvelope.success(cmd.id, {"is_open": False, "path": None, "name": None})
+        case "get_scene_tree":
+            return ResponseEnvelope.success(cmd.id, {"tree": None})
+        case "get_selected_node":
+            return ResponseEnvelope.success(cmd.id, {"selected": None})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
+
+
+def _build(conn: FakeAddonConnection) -> FastMCP:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_get_project_info() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool("get_project_info", {})
+    info = result.structured_content
+    assert info["name"] == "demo"
+    assert info["godot_version"] == "4.6.3"
+    assert info["autoloads"] == {"Game": "res://game.gd"}
+    assert info["input_actions"] == ["jump"]
+
+
+async def test_get_active_scene() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool("get_active_scene", {})
+    assert result.structured_content["is_open"] is True
+    assert result.structured_content["name"] == "main.tscn"
+
+
+async def test_get_scene_tree_passes_max_depth() -> None:
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("get_scene_tree", {"max_depth": 2})
+    assert result.structured_content["tree"]["name"] == "Main"
+    assert conn.last_command().params["max_depth"] == 2
+
+
+async def test_get_selected_node() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool("get_selected_node", {})
+    selected = result.structured_content["selected"]
+    assert selected["node_path"] == "Player"
+    assert selected["properties"]["speed"] == 200.0
+
+
+async def test_get_node_properties_success() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool("get_node_properties", {"node_path": "Player/Sprite2D"})
+    assert result.structured_content["node_path"] == "Player/Sprite2D"
+    assert result.structured_content["type"] == "Sprite2D"
+
+
+async def test_get_node_properties_missing_is_structured_error() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool(
+            "get_node_properties", {"node_path": "Missing"}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "RESOURCE_NOT_FOUND" in str(result.content)
+
+
+async def test_inspection_tools_are_read_only() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        tools = await client.list_tools()
+    by_name = {t.name: t for t in tools}
+    for name in (
+        "get_project_info",
+        "get_active_scene",
+        "get_scene_tree",
+        "get_selected_node",
+        "get_node_properties",
+    ):
+        assert by_name[name].meta is not None
+        assert by_name[name].meta.get("safety_class") == "read_only"
+
+
+async def test_inspection_handles_no_open_scene() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_empty))) as client:
+        scene = await client.call_tool("get_active_scene", {})
+        tree = await client.call_tool("get_scene_tree", {})
+        selected = await client.call_tool("get_selected_node", {})
+    assert scene.structured_content["is_open"] is False
+    assert tree.structured_content["tree"] is None
+    assert selected.structured_content["selected"] is None

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -20,8 +20,8 @@ Responder = Callable[[CommandEnvelope], ResponseEnvelope | None]
 
 
 def ping_responder(command: CommandEnvelope) -> ResponseEnvelope | None:
-    """Default addon behaviour: answer ``ping`` with ``{pong: true}``."""
-    if command.command == "ping":
+    """Default addon behaviour: answer ``cmd_ping`` with ``{pong: true}``."""
+    if command.command == "cmd_ping":
         return ResponseEnvelope.success(command.id, {"pong": True})
     return ResponseEnvelope.failure(
         command.id, "VALIDATION_ERROR", f"Unknown command '{command.command}'."

--- a/tests/integration/test_addon_inspect.py
+++ b/tests/integration/test_addon_inspect.py
@@ -1,0 +1,24 @@
+"""Integration test: the inspection serializers behave correctly (issue #5).
+
+Runs the headless GDScript exerciser ``godot/tests/inspect_smoke.gd`` and asserts
+it reports success — pinning JSON-safe type coercion, recursive scene
+serialization, ``max_depth``, and node-property/info extraction against the real
+Godot runtime, with no editor required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._godot import GODOT_BIN, run_godot
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+
+def test_inspection_serializers() -> None:
+    result = run_godot(["--script", "res://tests/inspect_smoke.gd"])
+    output = result.stdout + result.stderr
+    assert "INSPECT_TEST_OK" in output, (
+        f"inspection smoke test did not pass (exit {result.returncode}):\n{output}"
+    )
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}:\n{output}"

--- a/tests/integration/test_inspection_e2e.py
+++ b/tests/integration/test_inspection_e2e.py
@@ -1,0 +1,73 @@
+"""End-to-end inspection test: live Python bridge ↔ live Godot editor (issue #5).
+
+Boots the headless editor and exercises the cmd_* inspection handlers against the
+real EditorInterface. The project has no scene open, so this also verifies the
+graceful empty-state behaviour (acceptance: "works even when no scene is open").
+Skipped when no Godot binary is present.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://localhost:9080"
+
+
+async def _run_checks() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    for _ in range(60):
+        try:
+            await bridge.connect()
+            break
+        except Exception:
+            await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("could not connect to the addon bridge")
+
+    try:
+        info = await bridge.send("get_project_info")
+        assert info.ok and info.result is not None, info
+        assert info.result["name"] == "godot-mcp"  # from godot/project.godot
+        assert info.result["godot_version"].startswith("4.")
+
+        scene = await bridge.send("get_active_scene")
+        assert scene.ok and scene.result is not None
+        assert scene.result["is_open"] is False
+
+        tree = await bridge.send("get_scene_tree")
+        assert tree.ok and tree.result is not None
+        assert tree.result["tree"] is None
+
+        # No scene open ⇒ get_node_properties fails with a structured precondition.
+        props = await bridge.send("get_node_properties", {"node_path": "Anything"})
+        assert props.ok is False
+        assert props.error == "PRECONDITION_FAILED"
+        assert props.required == "active_scene"
+    finally:
+        await bridge.close()
+
+
+def test_live_editor_inspection() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        asyncio.run(_run_checks())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()

--- a/tests/integration/test_inspection_e2e.py
+++ b/tests/integration/test_inspection_e2e.py
@@ -34,21 +34,21 @@ async def _run_checks() -> None:
         raise AssertionError("could not connect to the addon bridge")
 
     try:
-        info = await bridge.send("get_project_info")
+        info = await bridge.send("cmd_get_project_info")
         assert info.ok and info.result is not None, info
         assert info.result["name"] == "godot-mcp"  # from godot/project.godot
         assert info.result["godot_version"].startswith("4.")
 
-        scene = await bridge.send("get_active_scene")
+        scene = await bridge.send("cmd_get_active_scene")
         assert scene.ok and scene.result is not None
         assert scene.result["is_open"] is False
 
-        tree = await bridge.send("get_scene_tree")
+        tree = await bridge.send("cmd_get_scene_tree")
         assert tree.ok and tree.result is not None
         assert tree.result["tree"] is None
 
         # No scene open ⇒ get_node_properties fails with a structured precondition.
-        props = await bridge.send("get_node_properties", {"node_path": "Anything"})
+        props = await bridge.send("cmd_get_node_properties", {"node_path": "Anything"})
         assert props.ok is False
         assert props.error == "PRECONDITION_FAILED"
         assert props.required == "active_scene"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -116,11 +116,12 @@ def test_inspection_helpers_exist() -> None:
 
 def test_router_registers_inspection_commands() -> None:
     source = (ADDON_DIR / "command_router.gd").read_text()
+    # Wire commands are cmd_-prefixed (the handler name); see docs/architecture.md.
     for command in (
-        "get_project_info",
-        "get_active_scene",
-        "get_scene_tree",
-        "get_selected_node",
-        "get_node_properties",
+        "cmd_get_project_info",
+        "cmd_get_active_scene",
+        "cmd_get_scene_tree",
+        "cmd_get_selected_node",
+        "cmd_get_node_properties",
     ):
         assert f'"{command}"' in source, f"router must register {command}"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -105,3 +105,22 @@ def test_plugin_wires_the_bridge() -> None:
     source = (ADDON_DIR / "godot_mcp.gd").read_text()
     assert "MCPBridge" in source, "plugin must start the bridge"
     assert "_bridge.stop()" in source, "plugin must stop the bridge on _exit_tree"
+
+
+def test_inspection_helpers_exist() -> None:
+    coerce = ADDON_DIR / "type_coerce.gd"
+    inspect = ADDON_DIR / "scene_inspect.gd"
+    assert coerce.is_file() and "class_name MCPTypeCoerce" in coerce.read_text()
+    assert inspect.is_file() and "class_name MCPSceneInspect" in inspect.read_text()
+
+
+def test_router_registers_inspection_commands() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    for command in (
+        "get_project_info",
+        "get_active_scene",
+        "get_scene_tree",
+        "get_selected_node",
+        "get_node_properties",
+    ):
+        assert f'"{command}"' in source, f"router must register {command}"


### PR DESCRIPTION
## Summary

Five `read_only` inspection tools — the most frequently called in any workflow — so an agent can reason about the project/scene before editing. Both sides. Closes #5.

## Acceptance criteria

- [x] All 5 tools return correct editor context (verified by real-editor e2e + contract tests)
- [x] Scene tree is JSON-safe (no Godot objects) — `MCPTypeCoerce` + headless serializer test
- [x] Errors return structured JSON with `error`/`hint` (`RESOURCE_NOT_FOUND`, `PRECONDITION_FAILED`)
- [x] Works when no scene is open — returns empty models (`is_open=False`/`tree=None`/`selected=None`), not errors
- [x] Tool descriptions are clear for agent use (agent-facing docstrings)

## Design

- **Pure serializers, editor-independent.** `type_coerce.gd` + `scene_inspect.gd` take Nodes, not `EditorInterface`, so coercion / `max_depth` / property extraction are unit-tested headlessly. The thin `EditorInterface` glue in the `cmd_*` handlers is covered by a real-editor e2e.
- **Router refactor.** `handle()` now stamps the `id` onto a handler-produced response *body*, so handlers can return structured failures (e.g. node-not-found), not just successes. Existing ping/error contract preserved.
- **Tool layer stays thin** — `tools/_route.py` sends to the bridge and raises `ToolError("<CODE>: <hint>")` on failure; tools just map the result dict to a typed model.

## Test plan

- `uv run pytest -q` → **74 passed** (up from 62). New:
  - `inspect_smoke.gd` (headless) — type coercion shapes, `max_depth` truncation, exported-property extraction, scene-relative paths.
  - `test_inspection.py` (contract, in-memory client + fake peer) — routing, typed mapping, `max_depth` passthrough, no-scene empty state, structured error, `read_only` meta on all 5.
  - `test_inspection_e2e.py` — boots the real headless editor, asserts `get_project_info`, no-scene `get_active_scene`/`get_scene_tree`, and `PRECONDITION_FAILED` from `get_node_properties`.
- `ruff` / `mypy --strict` / zero-skip clean. All Godot APIs verified against current docs.

## Notes

- `get_project_info` returns a curated set (name, version, main_scene, autoloads, input_actions) rather than dumping all project settings — bounded and agent-friendly. Documented in `tool-contracts.md`.
- `safety_class: read_only` is set on every tool via `meta`; full enforcement + `list_tools_by_safety_class` polish is issue #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)