### PR TITLE
safety: tool safety classes, preconditions, dry-run/confirm framework (closes #14)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -44,16 +44,42 @@ Every tool is tagged with exactly one:
 
 - `dry_run=True` returns what *would* happen and performs nothing.
 - All safety logic lives in `mcp_server/safety.py` — **never** in the addon (issue #14).
-- `list_tools_by_safety_class()` exposes the tagging for agent introspection.
+- Tag tools with the `READ_ONLY` / `MUTATING` / `DESTRUCTIVE` / `RUNTIME` meta constants
+  from `safety.py`, e.g. `@mcp.tool(meta=MUTATING)`.
+- `list_tools_by_safety_class()` is a `read_only` tool returning `{ class: [tool names] }`
+  for agent introspection.
+
+#### `dry_run` / `confirm` convention (issue #14)
+
+- `mutating` and `destructive` tools take `dry_run: bool = False`. With `dry_run=True`, the
+  tool runs its preconditions and returns its typed result describing what *would* happen
+  (e.g. a `created=False` / `dry_run=True` flag), **sending no mutation** over the bridge.
+- `destructive` tools additionally take `confirm: bool = False` and call
+  `require_confirmation(confirm, action)` — without `confirm=True` they fail with a
+  `PRECONDITION_FAILED` (`required="confirm"`), never deleting anything.
 
 ### Preconditions
 
-Checked before any mutation; a failure returns a structured `PRECONDITION_FAILED`
-envelope (see [`architecture.md`](architecture.md)), never a Python exception:
+Checked before any side effect. Each is a function in `safety.py` that raises a typed
+`PreconditionError`; the `enforce_preconditions` decorator converts it to a `ToolError`
+carrying `"<ERROR_CODE>: <hint> [required=<field>]"` — a structured, actionable message,
+never a Python traceback. The structured precondition shape (matching the bridge envelope):
 
-- `require_bridge_connected` — the Godot addon is reachable.
-- `require_active_scene` — a scene is open in the editor.
-- `require_node_exists(path)` — the target node path resolves.
+```json
+{
+  "ok": false,
+  "error": "PRECONDITION_FAILED",
+  "hint": "No scene is currently open. Open a scene before creating nodes.",
+  "required": "active_scene"
+}
+```
+
+- `require_bridge_connected(bridge)` — Godot reachable (else `BRIDGE_DISCONNECTED`,
+  `required="bridge_connected"`).
+- `require_active_scene(bridge)` — a scene is open (`required="active_scene"`).
+- `require_node_exists(bridge, path)` — the target node path resolves (else
+  `RESOURCE_NOT_FOUND`, `required="node_exists"`).
+- `require_confirmation(confirm, action)` — destructive guard (`required="confirm"`).
 
 ### Per-tool contract template
 
@@ -85,6 +111,12 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 
 `SceneNode = { name, type, script?, children: [SceneNode] }`. `get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
+
+#### Safety introspection (issue #14) — `read_only`
+
+| Tool | Params | Returns |
+|------|--------|---------|
+| `list_tools_by_safety_class` | — | `{ "read_only": [...], "mutating": [...], ... }` |
 
 ## Resources
 

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -1,0 +1,163 @@
+"""Tool safety: classes, preconditions, confirmation, and dry-run (issue #14).
+
+All safety/permission logic lives here, never in the addon
+(see .claude/rules/mcp-tools.md). Tools are tagged with a ``safety_class`` via the
+``READ_ONLY`` / ``MUTATING`` / ``DESTRUCTIVE`` / ``RUNTIME`` meta constants.
+
+Preconditions raise a typed :class:`PreconditionError`; the
+:func:`enforce_preconditions` decorator (applied by mutating/destructive tools in
+issue #6) converts it to a ``ToolError`` so the agent gets a structured,
+actionable message instead of a stack trace.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from enum import StrEnum
+from functools import wraps
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from mcp_server.bridge import Bridge
+from mcp_server.models.envelope import ErrorCode, ResponseEnvelope
+
+
+class SafetyClass(StrEnum):
+    """How risky a tool is. Drives the extra requirements below."""
+
+    READ_ONLY = "read_only"  # never mutates
+    MUTATING = "mutating"  # reversible editor change (UndoRedo); takes dry_run
+    DESTRUCTIVE = "destructive"  # may be irreversible; takes dry_run + confirm
+    RUNTIME = "runtime"  # controls game execution
+
+
+def _meta(safety_class: SafetyClass) -> dict[str, str]:
+    return {"safety_class": safety_class.value}
+
+
+# Meta constants to tag tools with, e.g. ``@mcp.tool(meta=READ_ONLY)``.
+READ_ONLY = _meta(SafetyClass.READ_ONLY)
+MUTATING = _meta(SafetyClass.MUTATING)
+DESTRUCTIVE = _meta(SafetyClass.DESTRUCTIVE)
+RUNTIME = _meta(SafetyClass.RUNTIME)
+
+
+class PreconditionError(Exception):
+    """A precondition for a tool was not met. Carries the structured fields the
+    agent needs to recover (see the precondition envelope in docs/architecture.md).
+    """
+
+    def __init__(
+        self,
+        hint: str,
+        required: str,
+        error: ErrorCode | str = ErrorCode.PRECONDITION_FAILED,
+    ) -> None:
+        self.error = str(error)
+        self.hint = hint
+        self.required = required
+        super().__init__(f"{self.error}: {hint}")
+
+    def as_tool_error(self) -> ToolError:
+        return ToolError(f"{self.error}: {self.hint} [required={self.required}]")
+
+
+# --- preconditions ---------------------------------------------------------
+
+
+def require_bridge_connected(bridge: Bridge) -> None:
+    """Fail fast if the Godot editor bridge is not connected."""
+    if not bridge.connected:
+        raise PreconditionError(
+            "Godot is not connected. Open the editor with the godot_mcp addon enabled.",
+            required="bridge_connected",
+            error=ErrorCode.BRIDGE_DISCONNECTED,
+        )
+
+
+async def require_active_scene(bridge: Bridge) -> None:
+    """Fail fast if no scene is open in the editor."""
+    require_bridge_connected(bridge)
+    response = await bridge.send("cmd_get_active_scene")
+    _raise_if_failed(response)
+    if not (response.result or {}).get("is_open"):
+        raise PreconditionError(
+            "No scene is currently open. Open a scene before this action.",
+            required="active_scene",
+        )
+
+
+async def require_node_exists(bridge: Bridge, node_path: str) -> None:
+    """Fail fast if ``node_path`` does not resolve in the active scene."""
+    require_bridge_connected(bridge)
+    response = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
+    if not response.ok:
+        raise PreconditionError(
+            response.hint or f"No node at '{node_path}'.",
+            required=response.required or "node_exists",
+            error=response.error or ErrorCode.RESOURCE_NOT_FOUND,
+        )
+
+
+def require_confirmation(confirm: bool, action: str) -> None:
+    """Block a destructive action unless ``confirm=True`` was passed."""
+    if not confirm:
+        raise PreconditionError(
+            f"'{action}' is destructive and may be irreversible. Pass confirm=true to proceed.",
+            required="confirm",
+        )
+
+
+def _raise_if_failed(response: ResponseEnvelope) -> None:
+    if not response.ok:
+        raise PreconditionError(
+            response.hint or "A precondition check failed.",
+            required=response.required or "unknown",
+            error=response.error or ErrorCode.INTERNAL_ERROR,
+        )
+
+
+# --- enforcement decorator -------------------------------------------------
+
+ToolFn = Callable[..., Awaitable[Any]]
+
+
+def enforce_preconditions(fn: ToolFn) -> ToolFn:
+    """Convert any :class:`PreconditionError` raised by a tool into a structured
+    ``ToolError``. Applied to mutating/destructive tools (issue #6).
+    """
+
+    @wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await fn(*args, **kwargs)
+        except PreconditionError as exc:
+            raise exc.as_tool_error() from exc
+
+    return wrapper
+
+
+# --- introspection ---------------------------------------------------------
+
+
+async def grouped_by_safety_class(mcp: FastMCP) -> dict[str, list[str]]:
+    """Group registered tool names by ``safety_class`` (``"unclassified"`` if unset)."""
+    grouped: dict[str, list[str]] = {}
+    for tool in await mcp.list_tools():
+        safety_class = (tool.meta or {}).get("safety_class", "unclassified")
+        grouped.setdefault(safety_class, []).append(tool.name)
+    return grouped
+
+
+def register_safety_tools(mcp: FastMCP) -> None:
+    """Register the agent-facing safety introspection tool."""
+
+    @mcp.tool(meta=READ_ONLY)
+    async def list_tools_by_safety_class() -> dict[str, list[str]]:
+        """List every available tool grouped by its safety class
+        (read_only / mutating / destructive / runtime). Call this to learn which
+        tools are safe to call freely and which need ``dry_run``/``confirm``.
+        """
+        return await grouped_by_safety_class(mcp)

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -93,12 +93,17 @@ async def require_node_exists(bridge: Bridge, node_path: str) -> None:
     """Fail fast if ``node_path`` does not resolve in the active scene."""
     require_bridge_connected(bridge)
     response = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
-    if not response.ok:
+    if response.ok:
+        return
+    # Only a genuine not-found means "fix the path"; other failures (TIMEOUT,
+    # BRIDGE_DISCONNECTED, no scene, …) propagate with their own error/required.
+    if response.error == ErrorCode.RESOURCE_NOT_FOUND:
         raise PreconditionError(
             response.hint or f"No node at '{node_path}'.",
-            required=response.required or "node_exists",
-            error=response.error or ErrorCode.RESOURCE_NOT_FOUND,
+            required="node_exists",
+            error=ErrorCode.RESOURCE_NOT_FOUND,
         )
+    _raise_if_failed(response)
 
 
 def require_confirmation(confirm: bool, action: str) -> None:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -19,6 +19,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
+from mcp_server.safety import register_safety_tools
 from mcp_server.tools.health import register_health
 from mcp_server.tools.inspection import register_inspection
 
@@ -54,16 +55,5 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
     mcp = FastMCP(SERVER_NAME, lifespan=lifespan)
     register_health(mcp, bridge, config)
     register_inspection(mcp, bridge)
+    register_safety_tools(mcp)
     return mcp
-
-
-async def list_tools_by_safety_class(mcp: FastMCP) -> dict[str, list[str]]:
-    """Group registered tool names by their ``safety_class`` for agent introspection.
-
-    Tools without a declared safety class are grouped under ``"unclassified"``.
-    """
-    grouped: dict[str, list[str]] = {}
-    for tool in await mcp.list_tools():
-        safety_class = (tool.meta or {}).get("safety_class", "unclassified")
-        grouped.setdefault(safety_class, []).append(tool.name)
-    return grouped

--- a/mcp_server/tools/health.py
+++ b/mcp_server/tools/health.py
@@ -13,6 +13,7 @@ from mcp_server import __version__
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
 from mcp_server.models.health import HealthStatus
+from mcp_server.safety import READ_ONLY
 
 
 def build_health(bridge: Bridge, config: ServerConfig) -> HealthStatus:
@@ -29,7 +30,7 @@ def build_health(bridge: Bridge, config: ServerConfig) -> HealthStatus:
 def register_health(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> None:
     """Register health_check on the given server."""
 
-    @mcp.tool(meta={"safety_class": "read_only"})
+    @mcp.tool(meta=READ_ONLY)
     async def health_check() -> HealthStatus:
         """Report server version and whether the Godot editor bridge is connected.
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -17,9 +17,8 @@ from mcp_server.models.inspection import (
     SceneTree,
     SelectedNode,
 )
+from mcp_server.safety import READ_ONLY
 from mcp_server.tools._route import route
-
-READ_ONLY = {"safety_class": "read_only"}
 
 
 def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:

--- a/tests/contract/test_health_check.py
+++ b/tests/contract/test_health_check.py
@@ -12,7 +12,8 @@ from fastmcp import Client, FastMCP
 from mcp_server import __version__
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
-from mcp_server.server import create_server, list_tools_by_safety_class
+from mcp_server.safety import grouped_by_safety_class
+from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for, flaky_connector
 
 pytestmark = pytest.mark.asyncio
@@ -65,5 +66,5 @@ async def test_health_check_reports_disconnected_when_godot_absent(
 async def test_list_tools_by_safety_class_groups_health_check() -> None:
     bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
     server = _server_with_bridge(bridge)
-    grouped = await list_tools_by_safety_class(server)
+    grouped = await grouped_by_safety_class(server)
     assert "health_check" in grouped["read_only"]

--- a/tests/contract/test_safety_tool.py
+++ b/tests/contract/test_safety_tool.py
@@ -1,0 +1,48 @@
+"""Contract test for the list_tools_by_safety_class introspection tool (issue #14)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _server() -> FastMCP:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_list_tools_by_safety_class_tool() -> None:
+    async with Client(_server()) as client:
+        result = await client.call_tool("list_tools_by_safety_class", {})
+    grouped = result.structured_content
+
+    # Every tool to date is read_only — including the introspection tool itself.
+    read_only = set(grouped["read_only"])
+    expected = {
+        "health_check",
+        "get_project_info",
+        "get_active_scene",
+        "get_scene_tree",
+        "get_selected_node",
+        "get_node_properties",
+        "list_tools_by_safety_class",
+    }
+    assert expected <= read_only
+    # Nothing should be unclassified — every tool carries a safety class.
+    assert "unclassified" not in grouped
+
+
+async def test_every_tool_has_a_safety_class() -> None:
+    async with Client(_server()) as client:
+        tools = await client.list_tools()
+    for tool in tools:
+        assert tool.meta is not None and tool.meta.get("safety_class"), (
+            f"tool {tool.name} is missing a safety_class"
+        )

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -1,0 +1,118 @@
+"""Unit tests for the safety framework (issue #14)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.safety import (
+    DESTRUCTIVE,
+    MUTATING,
+    READ_ONLY,
+    RUNTIME,
+    PreconditionError,
+    SafetyClass,
+    enforce_preconditions,
+    require_active_scene,
+    require_bridge_connected,
+    require_confirmation,
+    require_node_exists,
+)
+from tests.fakes import FakeAddonConnection, connector_for
+
+# asyncio_mode=auto handles the async tests; no module-wide mark (it would warn on
+# the synchronous tests below).
+
+
+def test_safety_meta_constants() -> None:
+    assert READ_ONLY == {"safety_class": "read_only"}
+    assert MUTATING == {"safety_class": "mutating"}
+    assert DESTRUCTIVE == {"safety_class": "destructive"}
+    assert RUNTIME == {"safety_class": "runtime"}
+    assert SafetyClass.DESTRUCTIVE.value == "destructive"
+
+
+async def _connected(responder: object) -> Bridge:
+    conn = FakeAddonConnection(responder=responder)  # type: ignore[arg-type]
+    bridge = Bridge(BridgeConfig(), connector=connector_for(conn))
+    await bridge.connect()
+    return bridge
+
+
+def test_require_bridge_connected_when_disconnected() -> None:
+    bridge = Bridge(BridgeConfig())  # never connected
+    with pytest.raises(PreconditionError) as exc:
+        require_bridge_connected(bridge)
+    assert exc.value.error == "BRIDGE_DISCONNECTED"
+    assert exc.value.required == "bridge_connected"
+
+
+async def test_require_active_scene_passes_when_open() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"is_open": True})
+
+    bridge = await _connected(responder)
+    await require_active_scene(bridge)  # must not raise
+    await bridge.close()
+
+
+async def test_require_active_scene_fails_when_closed() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"is_open": False})
+
+    bridge = await _connected(responder)
+    with pytest.raises(PreconditionError) as exc:
+        await require_active_scene(bridge)
+    assert exc.value.required == "active_scene"
+    assert exc.value.error == "PRECONDITION_FAILED"
+    await bridge.close()
+
+
+async def test_require_node_exists_propagates_not_found() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'X'.")
+
+    bridge = await _connected(responder)
+    with pytest.raises(PreconditionError) as exc:
+        await require_node_exists(bridge, "X")
+    assert exc.value.error == "RESOURCE_NOT_FOUND"
+    await bridge.close()
+
+
+async def test_require_node_exists_passes_when_present() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"node_path": "Player", "type": "Node2D"})
+
+    bridge = await _connected(responder)
+    await require_node_exists(bridge, "Player")  # must not raise
+    await bridge.close()
+
+
+def test_require_confirmation() -> None:
+    require_confirmation(True, "delete_node")  # must not raise
+    with pytest.raises(PreconditionError) as exc:
+        require_confirmation(False, "delete_node")
+    assert exc.value.required == "confirm"
+
+
+async def test_enforce_preconditions_converts_to_tool_error() -> None:
+    @enforce_preconditions
+    async def boom() -> None:
+        raise PreconditionError("Open a scene first.", required="active_scene")
+
+    with pytest.raises(ToolError) as exc:
+        await boom()
+    message = str(exc.value)
+    assert "PRECONDITION_FAILED" in message
+    assert "active_scene" in message
+
+
+async def test_enforce_preconditions_passes_through_success() -> None:
+    @enforce_preconditions
+    async def ok() -> str:
+        return "done"
+
+    assert await ok() == "done"

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -21,7 +21,7 @@ from mcp_server.safety import (
     require_confirmation,
     require_node_exists,
 )
-from tests.fakes import FakeAddonConnection, connector_for
+from tests.fakes import FakeAddonConnection, Responder, connector_for
 
 # asyncio_mode=auto handles the async tests; no module-wide mark (it would warn on
 # the synchronous tests below).
@@ -35,8 +35,8 @@ def test_safety_meta_constants() -> None:
     assert SafetyClass.DESTRUCTIVE.value == "destructive"
 
 
-async def _connected(responder: object) -> Bridge:
-    conn = FakeAddonConnection(responder=responder)  # type: ignore[arg-type]
+async def _connected(responder: Responder) -> Bridge:
+    conn = FakeAddonConnection(responder=responder)
     bridge = Bridge(BridgeConfig(), connector=connector_for(conn))
     await bridge.connect()
     return bridge
@@ -88,6 +88,19 @@ async def test_require_node_exists_passes_when_present() -> None:
 
     bridge = await _connected(responder)
     await require_node_exists(bridge, "Player")  # must not raise
+    await bridge.close()
+
+
+async def test_require_node_exists_does_not_mislabel_other_failures() -> None:
+    # A TIMEOUT must not be reported as a "node_exists" problem.
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.failure(cmd.id, "TIMEOUT", "No response from Godot.")
+
+    bridge = await _connected(responder)
+    with pytest.raises(PreconditionError) as exc:
+        await require_node_exists(bridge, "Player")
+    assert exc.value.error == "TIMEOUT"
+    assert exc.value.required != "node_exists"
     await bridge.close()
 
 


### PR DESCRIPTION
## Summary

A pure MCP-layer safety framework that protects the project from unintended/destructive agent actions — the foundation #6's mutation tools build on. Closes #14.

> There are no mutating/destructive tools yet (they arrive in #6), so this issue **delivers and tests the framework**: the precondition machinery, the `confirm` guard, the `dry_run` convention, the safety-class tagging, and the introspection tool. #6 attaches `dry_run`/`confirm` to its actual tools.

## Acceptance criteria

- [x] Every tool has a documented safety class — `meta` constants + a test asserting *no* tool is unclassified
- [x] `mutating` tools support `dry_run=True` — convention + `require_confirmation`; applied in #6 (no mutating tools yet)
- [x] `destructive` tools require `confirm=True` — `require_confirmation(confirm, action)`
- [x] Precondition failures return structured JSON, not exceptions — `PreconditionError` → `ToolError`
- [x] `list_tools_by_safety_class()` returns accurate categorization — now a real `read_only` tool

## What's here (`mcp_server/safety.py`)

- **`SafetyClass`** enum + `READ_ONLY`/`MUTATING`/`DESTRUCTIVE`/`RUNTIME` meta constants (health + inspection tools now import these instead of inline dicts).
- **Preconditions**: `require_bridge_connected`, `require_active_scene`, `require_node_exists(path)`, `require_confirmation(confirm, action)` — each raises a typed `PreconditionError {error, hint, required}`.
- **`enforce_preconditions`** decorator → converts `PreconditionError` to a structured `ToolError` (`"<CODE>: <hint> [required=<field>]"`).
- **`list_tools_by_safety_class`** introspection tool.

## Test plan

- `uv run pytest -q` → **85 passed** (up from 74). New: `test_safety.py` (every precondition with the fake bridge — connected/not, scene open/closed, node present/missing; confirm guard; decorator conversion), `test_safety_tool.py` (introspection tool + every tool carries a safety class).
- `ruff` / `mypy --strict` / zero-skip clean. No addon work (per the issue — all safety logic is MCP-side).

## Docs

`tool-contracts.md` gains the structured precondition envelope, the `dry_run`/`confirm` convention, and the introspection tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)