### PR TITLE
tools: safe scene mutation tools, both sides (closes #6)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -112,6 +112,29 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 `SceneNode = { name, type, script?, children: [SceneNode] }`. `get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
 
+#### Mutation (issue #6) — `mutating` (except `delete_node`)
+
+All take `dry_run: bool = False` (preview, sends no change). Each routes to a
+UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
+
+| Tool | Params | Returns | Class |
+|------|--------|---------|-------|
+| `create_node` | `parent_path, node_type, node_name` | `CreateNodeResult { node_path, created }` | `mutating` |
+| `rename_node` | `node_path, new_name` | `RenameNodeResult { node_path, old_name?, new_name, renamed }` | `mutating` |
+| `set_node_property` | `node_path, property, value` | `SetPropertyResult { node_path, property, value, set }` | `mutating` |
+| `delete_node` | `node_path, confirm=False` | `DeleteNodeResult { node_path, deleted }` | **`destructive`** |
+| `attach_script` | `node_path, script_path` | `AttachScriptResult { node_path, script_path, attached }` | `mutating` |
+| `connect_signal` | `source_path, signal_name, target_path, method_name` | `ConnectSignalResult { …, connected }` | `mutating` |
+| `save_scene` | — | `SaveSceneResult { path?, saved }` | `mutating` |
+| `create_scene` | `root_type, scene_path` | `CreateSceneResult { scene_path, root_type, created }` | `mutating` |
+
+- `set_node_property` coerces JSON to the property's declared Godot type via
+  `type_coerce.from_json` (Vector2/3 & Color as `{…}` objects or arrays, NodePath as string).
+- `delete_node` (destructive) requires `confirm=True` to delete; `dry_run=True` previews
+  without confirming. The addon also honors the `confirm` flag defensively.
+- `create_scene` writes a new `.tscn`/`.scn` and opens it; it is a file creation, not a
+  UndoRedo-tracked tree edit.
+
 #### Safety introspection (issue #14) — `read_only`
 
 | Tool | Params | Returns |

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -196,10 +196,12 @@ func _cmd_delete_node(params: Dictionary) -> Dictionary:
 		return _fail("PRECONDITION_FAILED", "Deleting a node requires confirm=true.", "confirm")
 
 	var parent := node.get_parent()
+	var index := node.get_index()  # restore at the same sibling position on undo
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Delete %s" % node.name)
 	ur.add_do_method(parent, "remove_child", node)
 	ur.add_undo_method(parent, "add_child", node)
+	ur.add_undo_method(parent, "move_child", node, index)
 	ur.add_undo_method(node, "set_owner", root)
 	ur.add_undo_reference(node)
 	ur.commit_action()

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -14,6 +14,7 @@ extends RefCounted
 ## structured error instead of crashing.
 
 const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
 
 var _handlers: Dictionary = {}
 
@@ -27,6 +28,15 @@ func _init() -> void:
 	_handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
 	_handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	_handlers["cmd_get_node_properties"] = _cmd_get_node_properties
+	# Mutations (issue #6) — all UndoRedo-wrapped via EditorUndoRedoManager.
+	_handlers["cmd_create_node"] = _cmd_create_node
+	_handlers["cmd_rename_node"] = _cmd_rename_node
+	_handlers["cmd_set_node_property"] = _cmd_set_node_property
+	_handlers["cmd_delete_node"] = _cmd_delete_node
+	_handlers["cmd_attach_script"] = _cmd_attach_script
+	_handlers["cmd_connect_signal"] = _cmd_connect_signal
+	_handlers["cmd_save_scene"] = _cmd_save_scene
+	_handlers["cmd_create_scene"] = _cmd_create_scene
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
@@ -104,7 +114,208 @@ func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
 	return _ok(Inspect.node_info(node, root))
 
 
+# --- mutation handlers (issue #6) ------------------------------------------
+
+func _cmd_create_node(params: Dictionary) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node_type := str(params.get("node_type", ""))
+	if not ClassDB.class_exists(node_type) or not ClassDB.can_instantiate(node_type):
+		return _fail("VALIDATION_ERROR", "Unknown or non-instantiable node type '%s'." % node_type)
+	var parent: Node = root.get_node_or_null(NodePath(str(params.get("parent_path", "."))))
+	if parent == null:
+		return _fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params.get("parent_path")))
+
+	var node: Node = ClassDB.instantiate(node_type)
+	node.name = str(params.get("name", node_type))
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Create %s" % node.name)
+	ur.add_do_method(parent, "add_child", node)
+	ur.add_do_method(node, "set_owner", root)
+	ur.add_do_reference(node)
+	ur.add_undo_method(parent, "remove_child", node)
+	ur.commit_action()
+	return _ok({"node_path": Inspect.relative_path(node, root), "created": true})
+
+
+func _cmd_rename_node(params: Dictionary) -> Dictionary:
+	var found := _resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var old_name := String(node.name)
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Rename %s" % old_name)
+	ur.add_do_property(node, "name", str(params.get("new_name", old_name)))
+	ur.add_undo_property(node, "name", old_name)
+	ur.commit_action()
+	return _ok({
+		"node_path": Inspect.relative_path(node, EditorInterface.get_edited_scene_root()),
+		"old_name": old_name,
+		"new_name": String(node.name),
+		"renamed": true,
+	})
+
+
+func _cmd_set_node_property(params: Dictionary) -> Dictionary:
+	var found := _resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var property := str(params.get("property", ""))
+	var prop_type := _property_type(node, property)
+	if prop_type == -1:
+		return _fail("VALIDATION_ERROR", "Node has no property '%s'." % property)
+
+	var old_value: Variant = node.get(property)
+	var new_value: Variant = Coerce.from_json(params.get("value"), prop_type)
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Set %s.%s" % [String(node.name), property])
+	ur.add_do_property(node, property, new_value)
+	ur.add_undo_property(node, property, old_value)
+	ur.commit_action()
+	return _ok({
+		"node_path": str(params.get("node_path")),
+		"property": property,
+		"value": Coerce.to_json(node.get(property)),
+		"set": true,
+	})
+
+
+func _cmd_delete_node(params: Dictionary) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	var found := _resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	if node == root:
+		return _fail("VALIDATION_ERROR", "Cannot delete the scene root.")
+	# Server enforces the safety class; the addon honors the confirm flag too.
+	if not bool(params.get("confirm", false)):
+		return _fail("PRECONDITION_FAILED", "Deleting a node requires confirm=true.", "confirm")
+
+	var parent := node.get_parent()
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Delete %s" % node.name)
+	ur.add_do_method(parent, "remove_child", node)
+	ur.add_undo_method(parent, "add_child", node)
+	ur.add_undo_method(node, "set_owner", root)
+	ur.add_undo_reference(node)
+	ur.commit_action()
+	return _ok({"node_path": str(params.get("node_path")), "deleted": true})
+
+
+func _cmd_attach_script(params: Dictionary) -> Dictionary:
+	var found := _resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var script_path := str(params.get("script_path", ""))
+	if not ResourceLoader.exists(script_path):
+		return _fail("RESOURCE_NOT_FOUND", "No script at '%s'. Create it first." % script_path)
+	var script: Variant = load(script_path)
+	if not (script is Script):
+		return _fail("VALIDATION_ERROR", "'%s' is not a script resource." % script_path)
+
+	var old_script: Variant = node.get_script()
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Attach script to %s" % node.name)
+	ur.add_do_method(node, "set_script", script)
+	ur.add_undo_method(node, "set_script", old_script)
+	ur.commit_action()
+	return _ok({"node_path": str(params.get("node_path")), "script_path": script_path, "attached": true})
+
+
+func _cmd_connect_signal(params: Dictionary) -> Dictionary:
+	var source_found := _resolve(params.get("source_path", ""))
+	if not source_found["ok"]:
+		return source_found
+	var target_found := _resolve(params.get("target_path", ""))
+	if not target_found["ok"]:
+		return target_found
+	var source: Node = source_found["node"]
+	var target: Node = target_found["node"]
+	var signal_name := str(params.get("signal_name", ""))
+	var method_name := str(params.get("method_name", ""))
+	if not source.has_signal(signal_name):
+		return _fail("VALIDATION_ERROR", "Source has no signal '%s'." % signal_name)
+	if not target.has_method(method_name):
+		return _fail("VALIDATION_ERROR", "Target has no method '%s'." % method_name)
+	var callable := Callable(target, method_name)
+	if source.is_connected(signal_name, callable):
+		return _fail("VALIDATION_ERROR", "Signal '%s' is already connected to that method." % signal_name)
+
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Connect %s" % signal_name)
+	# CONNECT_PERSIST so the connection is saved into the scene file.
+	ur.add_do_method(source, "connect", signal_name, callable, Object.CONNECT_PERSIST)
+	ur.add_undo_method(source, "disconnect", signal_name, callable)
+	ur.commit_action()
+	return _ok({
+		"source_path": str(params.get("source_path")),
+		"signal_name": signal_name,
+		"target_path": str(params.get("target_path")),
+		"method_name": method_name,
+		"connected": true,
+	})
+
+
+func _cmd_save_scene(_params: Dictionary) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	if root.scene_file_path.is_empty():
+		return _fail("PRECONDITION_FAILED", "Scene has no path yet; create it with a path first.", "scene_path")
+	var err := EditorInterface.save_scene()
+	if err != OK:
+		return _fail("INTERNAL_ERROR", "Failed to save scene (error %d)." % err)
+	return _ok({"path": root.scene_file_path, "saved": true})
+
+
+func _cmd_create_scene(params: Dictionary) -> Dictionary:
+	var root_type := str(params.get("root_type", ""))
+	var scene_path := str(params.get("scene_path", ""))
+	if not ClassDB.class_exists(root_type) or not ClassDB.can_instantiate(root_type):
+		return _fail("VALIDATION_ERROR", "Unknown or non-instantiable root type '%s'." % root_type)
+	if not scene_path.ends_with(".tscn") and not scene_path.ends_with(".scn"):
+		return _fail("VALIDATION_ERROR", "scene_path must end with .tscn or .scn.")
+
+	var root: Node = ClassDB.instantiate(root_type)
+	root.name = scene_path.get_file().get_basename()
+	var packed := PackedScene.new()
+	var pack_err := packed.pack(root)
+	root.free()
+	if pack_err != OK:
+		return _fail("INTERNAL_ERROR", "Failed to pack scene (error %d)." % pack_err)
+	var save_err := ResourceSaver.save(packed, scene_path)
+	if save_err != OK:
+		return _fail("INTERNAL_ERROR", "Failed to save scene to '%s' (error %d)." % [scene_path, save_err])
+	# Creating a file isn't an UndoRedo-tracked tree edit; open it for editing.
+	EditorInterface.open_scene_from_path(scene_path)
+	return _ok({"scene_path": scene_path, "root_type": root_type, "created": true})
+
+
 # --- editor-state helpers --------------------------------------------------
+
+## Resolve a node by scene-relative path, returning {ok, node} or an error body.
+func _resolve(raw_path: Variant) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node: Node = root.get_node_or_null(NodePath(str(raw_path)))
+	if node == null:
+		return _fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(raw_path))
+	return {"ok": true, "node": node}
+
+
+## The Variant.Type of a node property, or -1 if the node has no such property.
+func _property_type(node: Node, property: String) -> int:
+	for entry in node.get_property_list():
+		if entry["name"] == property:
+			return int(entry["type"])
+	return -1
+
 
 func _scene_name(root: Node) -> String:
 	if not root.scene_file_path.is_empty():

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -48,3 +48,56 @@ static func to_json(value: Variant) -> Variant:
 		_:
 			# Primitives (null, bool, int, float, String) are already JSON-safe.
 			return value
+
+
+## JSON → Godot value of the given Variant.Type (issue #6, write direction).
+## Vectors/Color accept either the dict form to_json emits ({x, y}) or an array
+## ([x, y]); NodePath/StringName from string; primitives coerced to the type.
+static func from_json(value: Variant, type: int) -> Variant:
+	match type:
+		TYPE_VECTOR2:
+			return Vector2(_component(value, "x", 0), _component(value, "y", 1))
+		TYPE_VECTOR2I:
+			return Vector2i(_component(value, "x", 0), _component(value, "y", 1))
+		TYPE_VECTOR3:
+			return Vector3(
+				_component(value, "x", 0), _component(value, "y", 1), _component(value, "z", 2)
+			)
+		TYPE_VECTOR3I:
+			return Vector3i(
+				_component(value, "x", 0), _component(value, "y", 1), _component(value, "z", 2)
+			)
+		TYPE_COLOR:
+			return Color(
+				_component(value, "r", 0),
+				_component(value, "g", 1),
+				_component(value, "b", 2),
+				_component(value, "a", 3, 1.0),
+			)
+		TYPE_RECT2:
+			return Rect2(from_json(value["position"], TYPE_VECTOR2), from_json(value["size"], TYPE_VECTOR2))
+		TYPE_RECT2I:
+			return Rect2i(from_json(value["position"], TYPE_VECTOR2I), from_json(value["size"], TYPE_VECTOR2I))
+		TYPE_NODE_PATH:
+			return NodePath(str(value))
+		TYPE_STRING_NAME:
+			return StringName(str(value))
+		TYPE_INT:
+			return int(value)
+		TYPE_FLOAT:
+			return float(value)
+		TYPE_BOOL:
+			return bool(value)
+		TYPE_STRING:
+			return str(value)
+		_:
+			return value
+
+
+## Read a vector/color component from a dict ({"x": ...}) or array ([...]).
+static func _component(value: Variant, key: String, index: int, default: float = 0.0) -> float:
+	if value is Dictionary:
+		return float(value.get(key, default))
+	if value is Array and index < value.size():
+		return float(value[index])
+	return default

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -75,8 +75,12 @@ static func from_json(value: Variant, type: int) -> Variant:
 				_component(value, "a", 3, 1.0),
 			)
 		TYPE_RECT2:
+			if not _has_rect_keys(value):
+				return Rect2()
 			return Rect2(from_json(value["position"], TYPE_VECTOR2), from_json(value["size"], TYPE_VECTOR2))
 		TYPE_RECT2I:
+			if not _has_rect_keys(value):
+				return Rect2i()
 			return Rect2i(from_json(value["position"], TYPE_VECTOR2I), from_json(value["size"], TYPE_VECTOR2I))
 		TYPE_NODE_PATH:
 			return NodePath(str(value))
@@ -92,6 +96,10 @@ static func from_json(value: Variant, type: int) -> Variant:
 			return str(value)
 		_:
 			return value
+
+
+static func _has_rect_keys(value: Variant) -> bool:
+	return value is Dictionary and value.has("position") and value.has("size")
 
 
 ## Read a vector/color component from a dict ({"x": ...}) or array ([...]).

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -65,6 +65,10 @@ func _test_from_json(failures: Array[String]) -> void:
 	_eq(failures, "fj.string", Coerce.from_json("hi", TYPE_STRING), "hi")
 	# Round-trips through to_json.
 	_eq(failures, "fj.roundtrip", Coerce.from_json(Coerce.to_json(Vector2(3, 4)), TYPE_VECTOR2), Vector2(3, 4))
+	var rect: Variant = Coerce.from_json({"position": [0, 0], "size": [4, 5]}, TYPE_RECT2)
+	_eq(failures, "fj.rect2", rect, Rect2(0, 0, 4, 5))
+	# Malformed Rect2 input must not crash; it degrades to a default.
+	_eq(failures, "fj.rect2.bad", Coerce.from_json("oops", TYPE_RECT2), Rect2())
 
 
 func _test_serialize_tree(failures: Array[String]) -> void:

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -16,6 +16,7 @@ const Probe := preload("res://tests/fixtures/probe.gd")
 func _initialize() -> void:
 	var failures: Array[String] = []
 	_test_type_coerce(failures)
+	_test_from_json(failures)
 	_test_serialize_tree(failures)
 	_test_node_properties(failures)
 	_test_node_info(failures)
@@ -49,6 +50,21 @@ func _test_type_coerce(failures: Array[String]) -> void:
 	_eq(failures, "null", Coerce.to_json(null), null)
 	# A path-less Resource coerces to its class name, never str() instance details.
 	_eq(failures, "resource_classname", Coerce.to_json(Resource.new()), "Resource")
+
+
+func _test_from_json(failures: Array[String]) -> void:
+	# Dict form (symmetric with to_json) and array form both coerce.
+	_eq(failures, "fj.vector2.dict", Coerce.from_json({"x": 1, "y": 2}, TYPE_VECTOR2), Vector2(1, 2))
+	_eq(failures, "fj.vector2.arr", Coerce.from_json([1, 2], TYPE_VECTOR2), Vector2(1, 2))
+	_eq(failures, "fj.vector3", Coerce.from_json({"x": 1, "y": 2, "z": 3}, TYPE_VECTOR3), Vector3(1, 2, 3))
+	_eq(failures, "fj.color", Coerce.from_json({"r": 1, "g": 0, "b": 0, "a": 1}, TYPE_COLOR), Color(1, 0, 0, 1))
+	_eq(failures, "fj.nodepath", Coerce.from_json("a/b", TYPE_NODE_PATH), NodePath("a/b"))
+	_eq(failures, "fj.int", Coerce.from_json(5, TYPE_INT), 5)
+	_eq(failures, "fj.float", Coerce.from_json(2.5, TYPE_FLOAT), 2.5)
+	_eq(failures, "fj.bool", Coerce.from_json(true, TYPE_BOOL), true)
+	_eq(failures, "fj.string", Coerce.from_json("hi", TYPE_STRING), "hi")
+	# Round-trips through to_json.
+	_eq(failures, "fj.roundtrip", Coerce.from_json(Coerce.to_json(Vector2(3, 4)), TYPE_VECTOR2), Vector2(3, 4))
 
 
 func _test_serialize_tree(failures: Array[String]) -> void:

--- a/mcp_server/models/mutation.py
+++ b/mcp_server/models/mutation.py
@@ -1,0 +1,67 @@
+"""Typed results for scene mutation tools (issue #6).
+
+Each result echoes ``dry_run`` so the agent can tell a preview from a real change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class CreateNodeResult(BaseModel):
+    node_path: str
+    created: bool
+    dry_run: bool = False
+
+
+class RenameNodeResult(BaseModel):
+    node_path: str
+    new_name: str
+    renamed: bool
+    old_name: str | None = None
+    dry_run: bool = False
+
+
+class SetPropertyResult(BaseModel):
+    node_path: str
+    property: str
+    value: Any = None
+    set: bool = False
+    dry_run: bool = False
+
+
+class DeleteNodeResult(BaseModel):
+    node_path: str
+    deleted: bool
+    dry_run: bool = False
+
+
+class AttachScriptResult(BaseModel):
+    node_path: str
+    script_path: str
+    attached: bool
+    dry_run: bool = False
+
+
+class ConnectSignalResult(BaseModel):
+    source_path: str
+    signal_name: str
+    target_path: str
+    method_name: str
+    connected: bool
+    dry_run: bool = False
+
+
+class SaveSceneResult(BaseModel):
+    saved: bool
+    path: str | None = None
+    dry_run: bool = False
+
+
+class CreateSceneResult(BaseModel):
+    scene_path: str
+    root_type: str
+    created: bool
+    dry_run: bool = False

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -22,6 +22,7 @@ from mcp_server.config import ServerConfig
 from mcp_server.safety import register_safety_tools
 from mcp_server.tools.health import register_health
 from mcp_server.tools.inspection import register_inspection
+from mcp_server.tools.mutation import register_mutation
 
 logger = logging.getLogger(__name__)
 
@@ -55,5 +56,6 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
     mcp = FastMCP(SERVER_NAME, lifespan=lifespan)
     register_health(mcp, bridge, config)
     register_inspection(mcp, bridge)
+    register_mutation(mcp, bridge)
     register_safety_tools(mcp)
     return mcp

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -53,9 +53,9 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         await require_active_scene(bridge)
         await require_node_exists(bridge, parent_path)
         if dry_run:
-            return CreateNodeResult(
-                node_path=f"{parent_path}/{node_name}", created=False, dry_run=True
-            )
+            # Mirror the addon's scene-relative path (root children have no "./").
+            preview = node_name if parent_path in (".", "") else f"{parent_path}/{node_name}"
+            return CreateNodeResult(node_path=preview, created=False, dry_run=True)
         params = {"parent_path": parent_path, "node_type": node_type, "name": node_name}
         return CreateNodeResult(**await route(bridge, "cmd_create_node", params))
 

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -1,0 +1,176 @@
+"""Scene mutation tools (issue #6).
+
+The first set of editor *changes* an agent can make. Every tool:
+- is tagged ``mutating`` (or ``destructive`` for delete),
+- runs preconditions first (structured failures, never tracebacks),
+- supports ``dry_run=True`` to preview without changing anything,
+- routes to a UndoRedo-wrapped ``cmd_*`` addon handler.
+
+All editor work + UndoRedo lives in the addon; all safety lives here
+(see .claude/rules/architecture.md and safety.py).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.models.mutation import (
+    AttachScriptResult,
+    ConnectSignalResult,
+    CreateNodeResult,
+    CreateSceneResult,
+    DeleteNodeResult,
+    RenameNodeResult,
+    SaveSceneResult,
+    SetPropertyResult,
+)
+from mcp_server.safety import (
+    DESTRUCTIVE,
+    MUTATING,
+    enforce_preconditions,
+    require_active_scene,
+    require_bridge_connected,
+    require_confirmation,
+    require_node_exists,
+)
+from mcp_server.tools._route import route
+
+
+def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register all eight mutation tools on the server."""
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def create_node(
+        parent_path: str, node_type: str, node_name: str, dry_run: bool = False
+    ) -> CreateNodeResult:
+        """Create a node of ``node_type`` named ``node_name`` under ``parent_path``
+        (scene-relative; "." is the root). Reversible via the editor's undo.
+        """
+        await require_active_scene(bridge)
+        await require_node_exists(bridge, parent_path)
+        if dry_run:
+            return CreateNodeResult(
+                node_path=f"{parent_path}/{node_name}", created=False, dry_run=True
+            )
+        params = {"parent_path": parent_path, "node_type": node_type, "name": node_name}
+        return CreateNodeResult(**await route(bridge, "cmd_create_node", params))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def rename_node(node_path: str, new_name: str, dry_run: bool = False) -> RenameNodeResult:
+        """Rename the node at ``node_path`` to ``new_name``."""
+        await require_node_exists(bridge, node_path)
+        if dry_run:
+            return RenameNodeResult(
+                node_path=node_path, new_name=new_name, renamed=False, dry_run=True
+            )
+        params = {"node_path": node_path, "new_name": new_name}
+        return RenameNodeResult(**await route(bridge, "cmd_rename_node", params))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def set_node_property(
+        node_path: str, property: str, value: Any, dry_run: bool = False
+    ) -> SetPropertyResult:
+        """Set ``property`` on the node at ``node_path`` to ``value``. Godot types
+        (Vector2/3, Color, Rect2 as objects; NodePath as string) are coerced by the
+        addon to match the property's declared type.
+        """
+        await require_node_exists(bridge, node_path)
+        if dry_run:
+            return SetPropertyResult(
+                node_path=node_path, property=property, value=value, set=False, dry_run=True
+            )
+        params = {"node_path": node_path, "property": property, "value": value}
+        return SetPropertyResult(**await route(bridge, "cmd_set_node_property", params))
+
+    @mcp.tool(meta=DESTRUCTIVE)
+    @enforce_preconditions
+    async def delete_node(
+        node_path: str, confirm: bool = False, dry_run: bool = False
+    ) -> DeleteNodeResult:
+        """Delete the node at ``node_path``. Destructive: requires ``confirm=True``
+        to actually delete (``dry_run=True`` previews without confirming).
+        """
+        await require_node_exists(bridge, node_path)
+        if dry_run:
+            return DeleteNodeResult(node_path=node_path, deleted=False, dry_run=True)
+        require_confirmation(confirm, "delete_node")
+        params = {"node_path": node_path, "confirm": True}
+        return DeleteNodeResult(**await route(bridge, "cmd_delete_node", params))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def attach_script(
+        node_path: str, script_path: str, dry_run: bool = False
+    ) -> AttachScriptResult:
+        """Attach the existing script at ``script_path`` (a ``res://`` path) to the
+        node at ``node_path``.
+        """
+        await require_node_exists(bridge, node_path)
+        if dry_run:
+            return AttachScriptResult(
+                node_path=node_path, script_path=script_path, attached=False, dry_run=True
+            )
+        params = {"node_path": node_path, "script_path": script_path}
+        return AttachScriptResult(**await route(bridge, "cmd_attach_script", params))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def connect_signal(
+        source_path: str,
+        signal_name: str,
+        target_path: str,
+        method_name: str,
+        dry_run: bool = False,
+    ) -> ConnectSignalResult:
+        """Connect ``signal_name`` on the source node to ``method_name`` on the
+        target node (persisted into the scene).
+        """
+        await require_node_exists(bridge, source_path)
+        await require_node_exists(bridge, target_path)
+        if dry_run:
+            return ConnectSignalResult(
+                source_path=source_path,
+                signal_name=signal_name,
+                target_path=target_path,
+                method_name=method_name,
+                connected=False,
+                dry_run=True,
+            )
+        params = {
+            "source_path": source_path,
+            "signal_name": signal_name,
+            "target_path": target_path,
+            "method_name": method_name,
+        }
+        return ConnectSignalResult(**await route(bridge, "cmd_connect_signal", params))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def save_scene(dry_run: bool = False) -> SaveSceneResult:
+        """Save the currently open scene to disk, reporting the file path."""
+        await require_active_scene(bridge)
+        if dry_run:
+            return SaveSceneResult(saved=False, dry_run=True)
+        return SaveSceneResult(**await route(bridge, "cmd_save_scene"))
+
+    @mcp.tool(meta=MUTATING)
+    @enforce_preconditions
+    async def create_scene(
+        root_type: str, scene_path: str, dry_run: bool = False
+    ) -> CreateSceneResult:
+        """Create a new scene file at ``scene_path`` (``res://…​.tscn``) with a root
+        node of ``root_type``, and open it for editing.
+        """
+        require_bridge_connected(bridge)
+        if dry_run:
+            return CreateSceneResult(
+                scene_path=scene_path, root_type=root_type, created=False, dry_run=True
+            )
+        params = {"root_type": root_type, "scene_path": scene_path}
+        return CreateSceneResult(**await route(bridge, "cmd_create_scene", params))

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -112,6 +112,8 @@ async def test_create_node_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert result.structured_content["created"] is False
+    # Preview path mirrors the addon: a root child is "Player", not "./Player".
+    assert result.structured_content["node_path"] == "Player"
     assert "cmd_create_node" not in _commands(conn)  # nothing was actually created
 
 

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -1,0 +1,167 @@
+"""Contract tests for the scene mutation tools (issue #6).
+
+Drive the real FastMCP server over the in-memory client with a fake addon peer:
+verify safety classes, that ``dry_run`` previews without sending a mutation, that
+``delete_node`` needs ``confirm``, that preconditions surface structured errors,
+and that results map to typed models.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    p = cmd.params
+    match cmd.command:
+        case "cmd_get_active_scene":
+            return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
+        case "cmd_get_node_properties":
+            if p.get("node_path") == "Ghost":
+                return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Ghost'.")
+            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+        case "cmd_create_node":
+            return ResponseEnvelope.success(
+                cmd.id, {"node_path": f"{p['parent_path']}/{p['name']}", "created": True}
+            )
+        case "cmd_rename_node":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "old_name": "Old",
+                    "new_name": p["new_name"],
+                    "renamed": True,
+                },
+            )
+        case "cmd_set_node_property":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "property": p["property"],
+                    "value": p["value"],
+                    "set": True,
+                },
+            )
+        case "cmd_delete_node":
+            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "deleted": True})
+        case "cmd_attach_script":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"node_path": p["node_path"], "script_path": p["script_path"], "attached": True},
+            )
+        case "cmd_connect_signal":
+            return ResponseEnvelope.success(cmd.id, {**p, "connected": True})
+        case "cmd_save_scene":
+            return ResponseEnvelope.success(cmd.id, {"path": "res://m.tscn", "saved": True})
+        case "cmd_create_scene":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"scene_path": p["scene_path"], "root_type": p["root_type"], "created": True},
+            )
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+def _commands(conn: FakeAddonConnection) -> list[str]:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+
+
+async def test_mutation_safety_classes() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["create_node"].meta["safety_class"] == "mutating"
+    assert tools["set_node_property"].meta["safety_class"] == "mutating"
+    assert tools["save_scene"].meta["safety_class"] == "mutating"
+    assert tools["delete_node"].meta["safety_class"] == "destructive"
+
+
+async def test_create_node_real_routes_to_addon() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "create_node", {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"}
+        )
+    assert result.structured_content["created"] is True
+    assert result.structured_content["node_path"] == "./Player"
+    assert "cmd_create_node" in _commands(conn)
+
+
+async def test_create_node_dry_run_sends_no_mutation() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "create_node",
+            {"parent_path": ".", "node_type": "Node2D", "node_name": "Player", "dry_run": True},
+        )
+    assert result.structured_content["dry_run"] is True
+    assert result.structured_content["created"] is False
+    assert "cmd_create_node" not in _commands(conn)  # nothing was actually created
+
+
+async def test_set_property_maps_value_and_flag() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "set_node_property",
+            {"node_path": "Player", "property": "position", "value": {"x": 1, "y": 2}},
+        )
+    assert result.structured_content["set"] is True
+    assert result.structured_content["value"] == {"x": 1, "y": 2}
+
+
+async def test_delete_without_confirm_is_blocked() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "delete_node", {"node_path": "Player"}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "confirm" in str(result.content)
+    assert "cmd_delete_node" not in _commands(conn)  # never reached the addon
+
+
+async def test_delete_with_confirm_proceeds() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool("delete_node", {"node_path": "Player", "confirm": True})
+    assert result.structured_content["deleted"] is True
+    assert "cmd_delete_node" in _commands(conn)
+
+
+async def test_delete_dry_run_needs_no_confirm() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool("delete_node", {"node_path": "Player", "dry_run": True})
+    assert result.structured_content["dry_run"] is True
+    assert result.structured_content["deleted"] is False
+    assert "cmd_delete_node" not in _commands(conn)
+
+
+async def test_missing_node_precondition_is_structured_error() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "create_node",
+            {"parent_path": "Ghost", "node_type": "Node2D", "node_name": "X"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "RESOURCE_NOT_FOUND" in str(result.content)
+    assert "cmd_create_node" not in _commands(conn)

--- a/tests/integration/test_mutation_e2e.py
+++ b/tests/integration/test_mutation_e2e.py
@@ -1,0 +1,110 @@
+"""End-to-end mutation test: live Python bridge ↔ live Godot editor (issue #6).
+
+Boots the headless editor and drives a full mutation roundtrip — create a scene,
+add a node, set a property, rename, save, and delete (with/without confirm) —
+against the real EditorInterface + EditorUndoRedoManager. This is the acceptance
+test "all mutation tools work on a live Godot scene". Skipped without Godot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://localhost:9080"
+SCRATCH = "res://e2e_scratch.tscn"
+SCRATCH_FILE = GODOT_PROJECT / "e2e_scratch.tscn"
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    response = await bridge.send(command, params or {})
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+async def _wait_scene_open(bridge: Bridge) -> None:
+    for _ in range(40):
+        response = await bridge.send("cmd_get_active_scene")
+        if response.ok and (response.result or {}).get("is_open"):
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("the created scene never became the active scene")
+
+
+async def _run_roundtrip() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    for _ in range(60):
+        try:
+            await bridge.connect()
+            break
+        except Exception:
+            await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("could not connect to the addon bridge")
+
+    try:
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node2D", "scene_path": SCRATCH})
+        await _wait_scene_open(bridge)
+
+        created = await _ok(
+            bridge, "cmd_create_node", {"parent_path": ".", "node_type": "Sprite2D", "name": "Hero"}
+        )
+        assert created["created"] is True and created["node_path"] == "Hero"
+
+        was_set = await _ok(
+            bridge,
+            "cmd_set_node_property",
+            {"node_path": "Hero", "property": "position", "value": {"x": 10, "y": 20}},
+        )
+        assert was_set["value"] == {"x": 10.0, "y": 20.0}  # coerced JSON → Vector2 → JSON
+
+        renamed = await _ok(bridge, "cmd_rename_node", {"node_path": "Hero", "new_name": "Player"})
+        assert renamed["new_name"] == "Player"
+
+        tree = await _ok(bridge, "cmd_get_scene_tree")
+        names = [c["name"] for c in tree["tree"]["children"]]
+        assert "Player" in names and "Hero" not in names
+
+        saved = await _ok(bridge, "cmd_save_scene")
+        assert saved["saved"] is True and saved["path"] == SCRATCH
+
+        # Destructive guard is honored addon-side too.
+        blocked = await bridge.send("cmd_delete_node", {"node_path": "Player", "confirm": False})
+        assert blocked.ok is False and blocked.required == "confirm"
+
+        deleted = await _ok(bridge, "cmd_delete_node", {"node_path": "Player", "confirm": True})
+        assert deleted["deleted"] is True
+
+        after = await _ok(bridge, "cmd_get_scene_tree")
+        assert "Player" not in [c["name"] for c in after["tree"]["children"]]
+    finally:
+        await bridge.close()
+
+
+def test_live_editor_mutation_roundtrip() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        asyncio.run(_run_roundtrip())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        SCRATCH_FILE.unlink(missing_ok=True)

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -125,3 +125,25 @@ def test_router_registers_inspection_commands() -> None:
         "cmd_get_node_properties",
     ):
         assert f'"{command}"' in source, f"router must register {command}"
+
+
+def test_router_registers_mutation_commands() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    for command in (
+        "cmd_create_node",
+        "cmd_rename_node",
+        "cmd_set_node_property",
+        "cmd_delete_node",
+        "cmd_attach_script",
+        "cmd_connect_signal",
+        "cmd_save_scene",
+        "cmd_create_scene",
+    ):
+        assert f'"{command}"' in source, f"router must register {command}"
+
+
+def test_mutations_use_undo_redo() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    # Every create/rename/delete/set must register with EditorUndoRedoManager.
+    assert "get_editor_undo_redo" in source
+    assert source.count("create_action") >= 6  # the UndoRedo-wrapped mutations


### PR DESCRIPTION
## Summary

The first set of editor *mutations* an agent can make — all UndoRedo-wrapped, preconditioned, `dry_run`-able, consuming the #14 safety framework. Both sides. Closes #6.

## Acceptance criteria

- [x] All mutation tools work on a live Godot scene — verified by a full real-editor e2e roundtrip
- [x] UndoRedo registered for every create/rename/delete/set — via `EditorInterface.get_editor_undo_redo()`
- [x] Errors return `{ ok:false, error, hint }` — structured throughout (no scene / bad path / bad type)
- [x] MCP tool schemas include typed params + descriptions
- [x] `delete_node` requires `confirm=True` — enforced MCP-side and honored addon-side

## Addon (GDScript)

- `type_coerce.from_json` — JSON → Godot value by `Variant.Type` (Vector2/3 & Color from dict *or* array, Rect2, NodePath/StringName, primitives); round-trips with `to_json`.
- `command_router` gains 8 `cmd_*` handlers. Each tree edit is wrapped in `EditorUndoRedoManager`; signals connect with `CONNECT_PERSIST`; `set_node_property` coerces using the property's declared type; `create_scene` packs + saves via `PackedScene`/`ResourceSaver`.

## MCP server (Python)

- `models/mutation.py` — one typed result per tool, each echoing `dry_run`.
- `tools/mutation.py` — 8 tools: 7 `mutating` + `delete_node` (`destructive`). Each runs preconditions, supports `dry_run` (previews, **sends no mutation**), and is wrapped with `enforce_preconditions`. `delete_node` requires `confirm=True` (dry-run previews without it).

## Test plan

- `uv run pytest -q` → **97 passed** (up from 86). New:
  - `inspect_smoke.gd` from_json cases (dict/array/roundtrip).
  - `test_mutation.py` (contract) — safety classes, `dry_run` sends nothing, `confirm` gate, precondition errors, result mapping.
  - `test_mutation_e2e.py` — boots the real editor and does a full roundtrip: create scene → add Sprite2D → set `position` (Vector2 coercion) → rename → save → delete (with/without confirm), asserting via the scene tree. Cleans up the scratch file.
- `ruff` / `mypy --strict` / zero-skip clean. All Godot APIs verified against current docs.

## Notes

- `attach_script` attaches an **existing** script (new-script *authoring* is the script-workflow issue #10); missing path → `RESOURCE_NOT_FOUND`.
- `create_scene` is a file creation (opens the new scene), not a UndoRedo-tracked tree edit — noted in the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)