### PR TITLE
tools: toolset gating — category tags + dynamic enable_toolset (closes #26)

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -39,6 +39,15 @@ Check before mutating, and fail with a structured precondition error (see [[erro
 - `require_active_scene` — a scene is open.
 - `require_node_exists(path)` — target path resolves.
 
+## Toolset gating & tool count (issue #26)
+
+A large flat tool surface degrades agent tool-selection and burns context. Keep the *exposed* surface small even as the catalog grows toward full Godot coverage:
+
+- Tag every tool with **exactly one category** (`tags={...}` from `mcp_server/categories.py`) in addition to its `safety_class` meta. `core` is always exposed; other categories are gated.
+- **New categories register gated off** — added to `TOOLSETS` but not `DEFAULT_ENABLED`. The agent turns them on with `enable_toolset` (which uses FastMCP `enable(tags=…)` and fires `tools/list_changed`). Default exposure stays `core` + `inspection`.
+- **Prefer fewer, richer tools over many micro-tools.** Design create-with-config (`create_node(..., properties?, script?)`) and batch setters over one-tool-per-field. One tool per noun with a few clear verbs — never a single `do(action, params)` dispatcher (it discards the per-tool schemas/descriptions that guide the agent).
+- **Never merge across safety classes** (e.g. don't fold `delete` into a fat `node` tool — it buries the `confirm` gate).
+
 ## Resources & prompts
 
 - **Resources** (`@mcp.resource("godot://...")`) are read-only and return JSON strings. No side effects. Mutations always go through tools.

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -141,7 +141,7 @@ UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
 |------|--------|---------|
 | `list_tools_by_safety_class` | — | `{ "read_only": [...], "mutating": [...], ... }` |
 
-#### Toolset gating (issue #26) — `core`, `read_only`
+#### Toolset gating (issue #26) — `read_only` (category: `core`)
 
 To keep the exposed surface small, tools are grouped into **categories** (`core`,
 `inspection`, `scene_edit`, …). `core` is always on; the default exposure is

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -141,6 +141,24 @@ UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
 |------|--------|---------|
 | `list_tools_by_safety_class` | — | `{ "read_only": [...], "mutating": [...], ... }` |
 
+#### Toolset gating (issue #26) — `core`, `read_only`
+
+To keep the exposed surface small, tools are grouped into **categories** (`core`,
+`inspection`, `scene_edit`, …). `core` is always on; the default exposure is
+`core` + `inspection`. Other categories (starting with `scene_edit`) are gated off
+until enabled. These meta-tools are always available:
+
+| Tool | Params | Returns | Notes |
+|------|--------|---------|-------|
+| `list_toolsets` | — | `[ToolsetInfo { name, enabled, description }]` | discover categories |
+| `enable_toolset` | `category` | `ToolsetInfo` | expose a category's tools (fires `list_changed`) |
+| `disable_toolset` | `category` | `ToolsetInfo` | hide a category again |
+
+`enable_toolset`/`disable_toolset` reject unknown categories and `core` with a
+structured `ToolError`. They change tool *exposure* only — never the Godot project
+— so they are `read_only`. The default-off-for-new-categories rule means the live
+surface stays small as the catalog grows (see `.claude/rules/mcp-tools.md`).
+
 ## Resources
 
 - `@mcp.resource("godot://…")` handlers are **read-only** and return JSON strings; no side

--- a/mcp_server/categories.py
+++ b/mcp_server/categories.py
@@ -1,0 +1,13 @@
+"""Tool category tags (issue #26).
+
+Bare string constants in a dependency-free leaf module so both the safety/toolset
+machinery and the tool modules can tag tools without import cycles. Every tool is
+tagged with exactly one of these; `core` is always exposed, the rest are gated
+(see toolsets.py).
+"""
+
+from __future__ import annotations
+
+CORE_TAG = "core"
+INSPECTION_TAG = "inspection"
+SCENE_EDIT_TAG = "scene_edit"

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -21,6 +21,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
+from mcp_server.categories import CORE_TAG
 from mcp_server.models.envelope import ErrorCode, ResponseEnvelope
 
 
@@ -159,7 +160,7 @@ async def grouped_by_safety_class(mcp: FastMCP) -> dict[str, list[str]]:
 def register_safety_tools(mcp: FastMCP) -> None:
     """Register the agent-facing safety introspection tool."""
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
     async def list_tools_by_safety_class() -> dict[str, list[str]]:
         """List every available tool grouped by its safety class
         (read_only / mutating / destructive / runtime). Call this to learn which

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,6 +23,7 @@ from mcp_server.safety import register_safety_tools
 from mcp_server.tools.health import register_health
 from mcp_server.tools.inspection import register_inspection
 from mcp_server.tools.mutation import register_mutation
+from mcp_server.toolsets import ToolsetManager, register_toolset_tools
 
 logger = logging.getLogger(__name__)
 
@@ -58,4 +59,10 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
     register_inspection(mcp, bridge)
     register_mutation(mcp, bridge)
     register_safety_tools(mcp)
+
+    # Gate the tool surface by category, then apply the default exposure (core +
+    # inspection on; scene_edit and future categories off until enabled).
+    manager = ToolsetManager(mcp)
+    register_toolset_tools(mcp, manager)
+    manager.apply_defaults()
     return mcp

--- a/mcp_server/tools/health.py
+++ b/mcp_server/tools/health.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 
 from mcp_server import __version__
 from mcp_server.bridge import Bridge
+from mcp_server.categories import CORE_TAG
 from mcp_server.config import ServerConfig
 from mcp_server.models.health import HealthStatus
 from mcp_server.safety import READ_ONLY
@@ -30,7 +31,7 @@ def build_health(bridge: Bridge, config: ServerConfig) -> HealthStatus:
 def register_health(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> None:
     """Register health_check on the given server."""
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
     async def health_check() -> HealthStatus:
         """Report server version and whether the Godot editor bridge is connected.
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
+from mcp_server.categories import INSPECTION_TAG
 from mcp_server.models.inspection import (
     ActiveScene,
     NodeInfo,
@@ -20,25 +21,27 @@ from mcp_server.models.inspection import (
 from mcp_server.safety import READ_ONLY
 from mcp_server.tools._route import route
 
+INSPECTION = {INSPECTION_TAG}
+
 
 def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
     """Register all five inspection tools on the server."""
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_project_info() -> ProjectInfo:
         """Get project-level context: name, Godot version, main scene, autoloads,
         and project-defined input actions. Call this to orient before editing.
         """
         return ProjectInfo(**await route(bridge, "cmd_get_project_info"))
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_active_scene() -> ActiveScene:
         """Get the currently open scene's path and name. Returns ``is_open=False``
         when no scene is open (not an error).
         """
         return ActiveScene(**await route(bridge, "cmd_get_active_scene"))
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_scene_tree(max_depth: int = -1) -> SceneTree:
         """Get the open scene as a recursive tree of {name, type, script, children}.
 
@@ -48,7 +51,7 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         """
         return SceneTree(**await route(bridge, "cmd_get_scene_tree", {"max_depth": max_depth}))
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_selected_node() -> SelectedNode:
         """Get the node currently selected in the editor — its path, type, script,
         properties, and child names. Returns ``selected=None`` when nothing is
@@ -56,7 +59,7 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         """
         return SelectedNode(**await route(bridge, "cmd_get_selected_node"))
 
-    @mcp.tool(meta=READ_ONLY)
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_node_properties(node_path: str) -> NodeInfo:
         """Get a node's detail by scene-relative path (e.g. "Player/Sprite2D"):
         type, attached script, exported/set properties, and child names. Errors

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
+from mcp_server.categories import SCENE_EDIT_TAG
 from mcp_server.models.mutation import (
     AttachScriptResult,
     ConnectSignalResult,
@@ -38,11 +39,13 @@ from mcp_server.safety import (
 )
 from mcp_server.tools._route import route
 
+SCENE_EDIT = {SCENE_EDIT_TAG}
+
 
 def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
     """Register all eight mutation tools on the server."""
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def create_node(
         parent_path: str, node_type: str, node_name: str, dry_run: bool = False
@@ -59,7 +62,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"parent_path": parent_path, "node_type": node_type, "name": node_name}
         return CreateNodeResult(**await route(bridge, "cmd_create_node", params))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def rename_node(node_path: str, new_name: str, dry_run: bool = False) -> RenameNodeResult:
         """Rename the node at ``node_path`` to ``new_name``."""
@@ -71,7 +74,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"node_path": node_path, "new_name": new_name}
         return RenameNodeResult(**await route(bridge, "cmd_rename_node", params))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def set_node_property(
         node_path: str, property: str, value: Any, dry_run: bool = False
@@ -88,7 +91,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"node_path": node_path, "property": property, "value": value}
         return SetPropertyResult(**await route(bridge, "cmd_set_node_property", params))
 
-    @mcp.tool(meta=DESTRUCTIVE)
+    @mcp.tool(meta=DESTRUCTIVE, tags=SCENE_EDIT)
     @enforce_preconditions
     async def delete_node(
         node_path: str, confirm: bool = False, dry_run: bool = False
@@ -103,7 +106,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"node_path": node_path, "confirm": True}
         return DeleteNodeResult(**await route(bridge, "cmd_delete_node", params))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def attach_script(
         node_path: str, script_path: str, dry_run: bool = False
@@ -119,7 +122,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"node_path": node_path, "script_path": script_path}
         return AttachScriptResult(**await route(bridge, "cmd_attach_script", params))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def connect_signal(
         source_path: str,
@@ -150,7 +153,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         }
         return ConnectSignalResult(**await route(bridge, "cmd_connect_signal", params))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def save_scene(dry_run: bool = False) -> SaveSceneResult:
         """Save the currently open scene to disk, reporting the file path."""
@@ -159,7 +162,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
             return SaveSceneResult(saved=False, dry_run=True)
         return SaveSceneResult(**await route(bridge, "cmd_save_scene"))
 
-    @mcp.tool(meta=MUTATING)
+    @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
     async def create_scene(
         root_type: str, scene_path: str, dry_run: bool = False

--- a/mcp_server/toolsets.py
+++ b/mcp_server/toolsets.py
@@ -1,0 +1,116 @@
+"""Toolset gating: category tags + dynamic enable/disable (issue #26).
+
+A large flat tool surface degrades agent tool-selection and burns context, so we
+keep the *live* surface small. Every tool carries a category tag; `core` is always
+on; other categories ship gated off and the agent turns them on with
+`enable_toolset`. As the catalog grows toward full Godot coverage, the exposed set
+stays small. Built on FastMCP's tag-based `enable`/`disable` (which emit
+`tools/list_changed`).
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel
+
+from mcp_server.categories import CORE_TAG, INSPECTION_TAG, SCENE_EDIT_TAG
+from mcp_server.safety import READ_ONLY
+
+# Toggleable toolsets (category → agent-facing description). `core` is not here.
+TOOLSETS: dict[str, str] = {
+    INSPECTION_TAG: "Read-only project, scene, and node inspection.",
+    SCENE_EDIT_TAG: "Create, modify, and delete nodes, scripts, signals, and scenes "
+    "(mutating + destructive).",
+}
+
+# Enabled at startup (plus `core`, which is always on). Everything else is gated
+# off until the agent enables it — keeping the default surface small and read-only.
+DEFAULT_ENABLED: frozenset[str] = frozenset({INSPECTION_TAG})
+
+
+class ToolsetInfo(BaseModel):
+    """One toolset's current exposure state."""
+
+    name: str
+    enabled: bool
+    description: str
+
+
+class ToolsetManager:
+    """Tracks which toolsets are exposed and drives FastMCP's tag enable/disable.
+
+    One per server (long-lived, not per-request). For a single stdio client this is
+    simple session state; under shared HTTP it would be process-wide (acceptable in
+    v1 — documented).
+    """
+
+    def __init__(self, mcp: FastMCP, default_enabled: frozenset[str] = DEFAULT_ENABLED) -> None:
+        self._mcp = mcp
+        self._enabled: set[str] = {CORE_TAG} | set(default_enabled)
+
+    def apply_defaults(self) -> None:
+        """Set the initial exposure: enable defaults, gate the rest off.
+
+        Call once after all tools are registered.
+        """
+        for category in TOOLSETS:
+            if category in self._enabled:
+                self._mcp.enable(tags={category})
+            else:
+                self._mcp.disable(tags={category})
+
+    def enable(self, category: str) -> ToolsetInfo:
+        self._check_toggleable(category)
+        self._enabled.add(category)
+        self._mcp.enable(tags={category})
+        return self._info(category)
+
+    def disable(self, category: str) -> ToolsetInfo:
+        self._check_toggleable(category)
+        self._enabled.discard(category)
+        self._mcp.disable(tags={category})
+        return self._info(category)
+
+    def status(self) -> list[ToolsetInfo]:
+        core = ToolsetInfo(
+            name=CORE_TAG,
+            enabled=True,
+            description="Always-on diagnostics and toolset management.",
+        )
+        return [core, *(self._info(c) for c in TOOLSETS)]
+
+    def _info(self, category: str) -> ToolsetInfo:
+        return ToolsetInfo(
+            name=category, enabled=category in self._enabled, description=TOOLSETS[category]
+        )
+
+    def _check_toggleable(self, category: str) -> None:
+        if category == CORE_TAG:
+            raise ToolError("The 'core' toolset is always enabled and cannot be toggled.")
+        if category not in TOOLSETS:
+            known = ", ".join(TOOLSETS)
+            raise ToolError(f"Unknown toolset '{category}'. Available: {known}.")
+
+
+def register_toolset_tools(mcp: FastMCP, manager: ToolsetManager) -> None:
+    """Register the always-on toolset introspection/management tools."""
+
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
+    async def list_toolsets() -> list[ToolsetInfo]:
+        """List the available toolsets (tool categories) and whether each is currently
+        enabled. Enable a toolset with enable_toolset before using its tools.
+        """
+        return manager.status()
+
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
+    async def enable_toolset(category: str) -> ToolsetInfo:
+        """Expose a toolset's tools (e.g. "scene_edit") for this session. Returns the
+        toolset's new state. Does not change anything in the Godot project.
+        """
+        return manager.enable(category)
+
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
+    async def disable_toolset(category: str) -> ToolsetInfo:
+        """Hide a toolset's tools again to keep the active tool surface small."""
+        return manager.disable(category)

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -85,6 +85,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 async def test_mutation_safety_classes() -> None:
     server, _ = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         tools = {t.name: t for t in await client.list_tools()}
     assert tools["create_node"].meta["safety_class"] == "mutating"
     assert tools["set_node_property"].meta["safety_class"] == "mutating"
@@ -95,6 +96,7 @@ async def test_mutation_safety_classes() -> None:
 async def test_create_node_real_routes_to_addon() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool(
             "create_node", {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"}
         )
@@ -106,6 +108,7 @@ async def test_create_node_real_routes_to_addon() -> None:
 async def test_create_node_dry_run_sends_no_mutation() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool(
             "create_node",
             {"parent_path": ".", "node_type": "Node2D", "node_name": "Player", "dry_run": True},
@@ -120,6 +123,7 @@ async def test_create_node_dry_run_sends_no_mutation() -> None:
 async def test_set_property_maps_value_and_flag() -> None:
     server, _ = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool(
             "set_node_property",
             {"node_path": "Player", "property": "position", "value": {"x": 1, "y": 2}},
@@ -131,6 +135,7 @@ async def test_set_property_maps_value_and_flag() -> None:
 async def test_delete_without_confirm_is_blocked() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool(
             "delete_node", {"node_path": "Player"}, raise_on_error=False
         )
@@ -142,6 +147,7 @@ async def test_delete_without_confirm_is_blocked() -> None:
 async def test_delete_with_confirm_proceeds() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool("delete_node", {"node_path": "Player", "confirm": True})
     assert result.structured_content["deleted"] is True
     assert "cmd_delete_node" in _commands(conn)
@@ -150,6 +156,7 @@ async def test_delete_with_confirm_proceeds() -> None:
 async def test_delete_dry_run_needs_no_confirm() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool("delete_node", {"node_path": "Player", "dry_run": True})
     assert result.structured_content["dry_run"] is True
     assert result.structured_content["deleted"] is False
@@ -159,6 +166,7 @@ async def test_delete_dry_run_needs_no_confirm() -> None:
 async def test_missing_node_precondition_is_structured_error() -> None:
     server, conn = _build()
     async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
         result = await client.call_tool(
             "create_node",
             {"parent_path": "Ghost", "node_type": "Node2D", "node_name": "X"},

--- a/tests/contract/test_toolsets.py
+++ b/tests/contract/test_toolsets.py
@@ -1,0 +1,81 @@
+"""Contract tests for toolset gating (issue #26)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _server() -> FastMCP:
+    config = ServerConfig()
+    bridge = Bridge(config.bridge, connector=connector_for(FakeAddonConnection()))
+    return create_server(config, bridge=bridge)
+
+
+async def _tool_names(client: Client[Any]) -> set[str]:
+    return {t.name for t in await client.list_tools()}
+
+
+async def test_default_surface_is_core_plus_inspection() -> None:
+    async with Client(_server()) as client:
+        names = await _tool_names(client)
+    # core + inspection exposed by default...
+    assert {"health_check", "list_toolsets", "enable_toolset", "get_scene_tree"} <= names
+    # ...but scene_edit (mutations) are gated off.
+    assert "create_node" not in names
+    assert "delete_node" not in names
+
+
+async def test_enable_toolset_exposes_scene_edit() -> None:
+    async with Client(_server()) as client:
+        before = await _tool_names(client)
+        assert "create_node" not in before
+        result = await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        assert result.structured_content["enabled"] is True
+        after = await _tool_names(client)
+    assert "create_node" in after and "save_scene" in after
+
+
+async def test_disable_toolset_hides_inspection_again() -> None:
+    async with Client(_server()) as client:
+        assert "get_scene_tree" in await _tool_names(client)
+        await client.call_tool("disable_toolset", {"category": "inspection"})
+        names = await _tool_names(client)
+    assert "get_scene_tree" not in names
+    assert "health_check" in names  # core stays
+
+
+async def test_list_toolsets_reports_state() -> None:
+    async with Client(_server()) as client:
+        result = await client.call_tool("list_toolsets", {})
+    by_name = {t["name"]: t for t in result.structured_content["result"]}
+    assert by_name["inspection"]["enabled"] is True
+    assert by_name["scene_edit"]["enabled"] is False
+    assert by_name["core"]["enabled"] is True
+
+
+async def test_unknown_toolset_is_structured_error() -> None:
+    async with Client(_server()) as client:
+        result = await client.call_tool(
+            "enable_toolset", {"category": "physics"}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "Unknown toolset" in str(result.content)
+
+
+async def test_core_cannot_be_toggled() -> None:
+    async with Client(_server()) as client:
+        result = await client.call_tool(
+            "disable_toolset", {"category": "core"}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "core" in str(result.content)


### PR DESCRIPTION
## Summary

Keeps the *exposed* tool surface small so agents don't drown as the catalog grows toward full Godot coverage. Tags + a dynamic `enable_toolset` meta-tool — **no static tiers** (per discussion, they're redundant with dynamic enabling). Closes #26.

## How it works

- Every tool carries **one category tag** (`core` / `inspection` / `scene_edit`; future `physics`/`animation`/…) alongside its `safety_class` meta.
- **`core` is always on**: `health_check`, `list_tools_by_safety_class`, and the new `list_toolsets` / `enable_toolset` / `disable_toolset`.
- **Default exposure = `core` + `inspection`** (read-only). `scene_edit` (mutations) and every future category ship **gated off**; the agent calls `enable_toolset("scene_edit")` to edit (fires `tools/list_changed`).
- Implemented with FastMCP `mcp.enable/disable(tags=…)`.

Result over real stdio: **10 tools exposed by default**, the 8 mutations hidden until enabled — and the live surface stays small no matter how big the catalog gets.

## Acceptance

- [x] Default `list_tools` = core + inspection; `scene_edit` hidden until enabled
- [x] `enable_toolset`/`disable_toolset` change the live list; unknown/`core` rejected with structured `ToolError`
- [x] Read-only-by-default surface (nice safety affordance — mutations opt-in)
- [x] Suite green

## Notes

- Bare tag constants live in a dependency-free `categories.py` to avoid import cycles.
- Convention added to `mcp-tools.md`: new categories register gated-off; prefer create-with-config + batch over micro-tools; never merge across safety classes.
- Mutation **contract** tests now `enable_toolset("scene_edit")` first (mirrors real agent flow); the e2e tests use the bridge directly and are unaffected.
- Toolset state is per-server; under shared HTTP it'd be process-wide (fine for v1, documented).

## Test plan

- `uv run pytest -q` → **103 passed**. New `test_toolsets.py` covers the default surface, enable/disable round-trips, `list_toolsets` state, and unknown/`core` errors.
- `ruff` / `mypy --strict` / zero-skip clean. Verified the real stdio entrypoint exposes 10 tools by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)