### PR TITLE
resources: godot:// project-context resources + fallback tool (closes #11)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -166,6 +166,27 @@ surface stays small as the catalog grows (see `.claude/rules/mcp-tools.md`).
 - Read-only project context is exposed both as tools (issue #5) and as `godot://`
   resources (issue #11); the two are kept consistent.
 
+### Implemented resources (issue #11)
+
+Addressable, refreshed-on-access snapshots. Each returns a JSON string; on a bridge
+failure it returns valid JSON carrying the structured error (`{ "error", "hint" }`).
+
+| URI | Content | Bridge command |
+|-----|---------|----------------|
+| `godot://project/info` | project name, Godot version, main scene, autoloads, input actions | `cmd_get_project_info` |
+| `godot://scene/current` | open scene `{ is_open, path, name }` | `cmd_get_active_scene` |
+| `godot://scene/tree` | full scene tree (may be large) | `cmd_get_scene_tree` (`max_depth=-1`) |
+| `godot://scene/tree/{max_depth}` | scene tree limited to N child levels (template) | `cmd_get_scene_tree` |
+| `godot://node/selected` | selected node snapshot, or `{ "selected": null }` | `cmd_get_selected_node` |
+
+**Fallback:** `read_resource(uri)` is a `core` `read_only` tool that returns any of the
+above by URI — for clients without resource-protocol support. Unknown URIs return a
+structured `ToolError`.
+
+Game-specific resources from the original issue (`godot://game/towers|enemies|waves|domain`)
+are **out of scope** here — they depend on a game's domain model and belong to the
+separate game project.
+
 ## Prompts
 
 - `@mcp.prompt()` handlers are **step-numbered instruction templates** that tell the agent

--- a/mcp_server/resources/context.py
+++ b/mcp_server/resources/context.py
@@ -1,0 +1,107 @@
+"""Read-only project-context resources (issue #11).
+
+Addressable `godot://…` snapshots so an agent can reference project/scene/node
+state without a tool call each time. Resources are read-only and return JSON
+strings; mutations always go through tools (see .claude/rules/mcp-tools.md).
+
+Only the **generic** resources are implemented here. The game-specific ones in the
+issue (`godot://game/towers|enemies|waves|domain`) depend on a game's domain model
+and belong to the separate game project, not this generic server.
+
+A `read_resource(uri)` tool provides the resources-as-tools fallback for MCP
+clients that don't support the resource protocol.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from mcp_server.bridge import Bridge
+from mcp_server.categories import CORE_TAG
+from mcp_server.safety import READ_ONLY
+
+SCENE_TREE_PREFIX = "godot://scene/tree/"
+
+# Static URI → (bridge command, params). The scene/tree depth template is handled
+# separately. This is the single source of truth for both the resources and the
+# read_resource fallback tool.
+_STATIC: dict[str, tuple[str, dict[str, object]]] = {
+    "godot://project/info": ("cmd_get_project_info", {}),
+    "godot://scene/current": ("cmd_get_active_scene", {}),
+    "godot://scene/tree": ("cmd_get_scene_tree", {"max_depth": -1}),
+    "godot://node/selected": ("cmd_get_selected_node", {}),
+}
+
+
+async def _fetch_json(bridge: Bridge, command: str, params: dict[str, object]) -> str:
+    """Send a command and return its result as a pretty JSON string; on failure,
+    return the structured error as JSON (resources always return valid JSON)."""
+    response = await bridge.send(command, params)
+    if response.ok:
+        return json.dumps(response.result or {}, indent=2)
+    error: dict[str, object] = {"error": response.error, "hint": response.hint}
+    if response.required is not None:
+        error["required"] = response.required
+    return json.dumps(error, indent=2)
+
+
+async def _read_uri(bridge: Bridge, uri: str) -> str:
+    """Resolve any supported godot:// URI to its JSON content. Raises KeyError if
+    the URI is not recognized."""
+    if uri in _STATIC:
+        command, params = _STATIC[uri]
+        return await _fetch_json(bridge, command, params)
+    if uri.startswith(SCENE_TREE_PREFIX):
+        tail = uri[len(SCENE_TREE_PREFIX) :]
+        try:
+            depth = int(tail)
+        except ValueError:
+            raise KeyError(uri) from None
+        return await _fetch_json(bridge, "cmd_get_scene_tree", {"max_depth": depth})
+    raise KeyError(uri)
+
+
+def register_resources(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register the godot:// context resources and the resources-as-tools fallback."""
+
+    @mcp.resource("godot://project/info")
+    async def project_info() -> str:
+        """Project metadata: name, Godot version, main scene, autoloads, input actions."""
+        return await _read_uri(bridge, "godot://project/info")
+
+    @mcp.resource("godot://scene/current")
+    async def scene_current() -> str:
+        """The currently open scene: is_open, path, name (is_open=false when none)."""
+        return await _read_uri(bridge, "godot://scene/current")
+
+    @mcp.resource("godot://scene/tree")
+    async def scene_tree() -> str:
+        """The full active scene tree {name, type, script, children}. May be large —
+        use godot://scene/tree/{max_depth} to limit depth."""
+        return await _read_uri(bridge, "godot://scene/tree")
+
+    @mcp.resource("godot://scene/tree/{max_depth}")
+    async def scene_tree_depth(max_depth: int) -> str:
+        """The active scene tree limited to max_depth child levels (0 = root only)."""
+        return await _fetch_json(bridge, "cmd_get_scene_tree", {"max_depth": max_depth})
+
+    @mcp.resource("godot://node/selected")
+    async def node_selected() -> str:
+        """The currently selected node snapshot, or {"selected": null} when none."""
+        return await _read_uri(bridge, "godot://node/selected")
+
+    @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
+    async def read_resource(uri: str) -> str:
+        """Read a godot:// context resource by URI — the fallback for MCP clients
+        without resource-protocol support. Known URIs: godot://project/info,
+        godot://scene/current, godot://scene/tree, godot://scene/tree/{max_depth},
+        godot://node/selected.
+        """
+        try:
+            return await _read_uri(bridge, uri)
+        except KeyError:
+            known = ", ".join([*_STATIC, f"{SCENE_TREE_PREFIX}{{max_depth}}"])
+            raise ToolError(f"Unknown resource URI '{uri}'. Known: {known}.") from None

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -19,6 +19,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
+from mcp_server.resources.context import register_resources
 from mcp_server.safety import register_safety_tools
 from mcp_server.tools.health import register_health
 from mcp_server.tools.inspection import register_inspection
@@ -58,6 +59,7 @@ def create_server(config: ServerConfig | None = None, bridge: Bridge | None = No
     register_health(mcp, bridge, config)
     register_inspection(mcp, bridge)
     register_mutation(mcp, bridge)
+    register_resources(mcp, bridge)
     register_safety_tools(mcp)
 
     # Gate the tool surface by category, then apply the default exposure (core +

--- a/tests/contract/test_resources.py
+++ b/tests/contract/test_resources.py
@@ -1,0 +1,96 @@
+"""Contract tests for godot:// context resources (issue #11)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    match cmd.command:
+        case "cmd_get_project_info":
+            return ResponseEnvelope.success(cmd.id, {"name": "demo", "godot_version": "4.6.3"})
+        case "cmd_get_active_scene":
+            return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
+        case "cmd_get_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id, {"tree": {"name": "Main", "max_depth": cmd.params.get("max_depth")}}
+            )
+        case "cmd_get_selected_node":
+            return ResponseEnvelope.success(cmd.id, {"selected": None})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+async def test_static_resources_are_listable() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        uris = {str(r.uri) for r in await client.list_resources()}
+        templates = {t.uriTemplate for t in await client.list_resource_templates()}
+    assert {
+        "godot://project/info",
+        "godot://scene/current",
+        "godot://scene/tree",
+        "godot://node/selected",
+    } <= uris
+    assert "godot://scene/tree/{max_depth}" in templates
+
+
+async def test_resource_returns_valid_json() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        contents = await client.read_resource("godot://project/info")
+    payload = json.loads(contents[0].text)
+    assert payload["name"] == "demo"
+
+
+async def test_scene_tree_template_passes_depth() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        contents = await client.read_resource("godot://scene/tree/2")
+    payload = json.loads(contents[0].text)
+    assert payload["tree"]["max_depth"] == 2
+
+
+async def test_resource_failure_is_valid_json_error() -> None:
+    # A bridge failure must still yield valid JSON carrying the structured error.
+    def failing(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.failure(cmd.id, "BRIDGE_DISCONNECTED", "Godot not connected.")
+
+    conn = FakeAddonConnection(responder=failing)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        contents = await client.read_resource("godot://project/info")
+    payload = json.loads(contents[0].text)
+    assert payload["error"] == "BRIDGE_DISCONNECTED"
+
+
+async def test_read_resource_fallback_tool() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        # The fallback tool is in `core`, so it's exposed by default.
+        result = await client.call_tool("read_resource", {"uri": "godot://project/info"})
+        payload = json.loads(result.data)
+        assert payload["name"] == "demo"
+
+        err = await client.call_tool(
+            "read_resource", {"uri": "godot://bogus"}, raise_on_error=False
+        )
+    assert err.is_error
+    assert "Unknown resource URI" in str(err.content)


### PR DESCRIPTION
## Summary

Addressable read-only `godot://` snapshots so an agent can reference project/scene/node state without a tool call each time. Closes #11.

## Implemented (generic only)

| URI | Content |
|-----|---------|
| `godot://project/info` | name, Godot version, main scene, autoloads, input actions |
| `godot://scene/current` | open scene `{ is_open, path, name }` |
| `godot://scene/tree` | full scene tree (may be large) |
| `godot://scene/tree/{max_depth}` | depth-limited tree (template — addresses the "may be large" note) |
| `godot://node/selected` | selected node snapshot |

Each routes to the matching `cmd_*` command and returns a JSON string; a bridge failure returns **valid JSON** carrying the structured error. A `read_resource(uri)` tool (`core`, `read_only`) is the **resources-as-tools fallback** for clients without resource-protocol support (unknown URI → `ToolError`). One URI→command map is shared by the resources and the fallback.

## Scope note

The 4 game-specific resources in the issue (`godot://game/towers|enemies|waves|domain`) are **not implemented** — they depend on a game's domain model and belong to the separate game project (per #24). The remaining 4 generic resources are done.

## Acceptance

- [x] Generic resources listable by an MCP client (+ the depth template)
- [x] Each returns valid, up-to-date JSON; failures are valid JSON errors
- [x] `resources-as-tools` fallback (`read_resource`) works
- [x] URIs stable

## Test plan

- `uv run pytest -q` → **108 passed**. New `test_resources.py`: resources/templates listable, valid JSON, depth template passes `max_depth`, bridge-failure-as-JSON, and the fallback tool (incl. unknown-URI error).
- Resources are thin wrappers over the already-e2e-tested `cmd_*` commands, so no separate live e2e.
- `ruff` / `mypy --strict` / zero-skip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)