### PR TITLE
type_coerce: accept string forms in from_json (closes #51)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,10 @@ contract tests) before adding a new code.
 Godot types cross the bridge as JSON-safe forms, coerced on the addon side in the
 dedicated `type_coerce.gd` helper (`MCPTypeCoerce`), never inline. The read direction
 (Godot → JSON) landed in issue #5; the write direction (`from_json`, using each property's
-declared type to reconstruct the Godot value) lands with the mutation tools in issue #6.
+declared type to reconstruct the Godot value) landed with the mutation tools in issue #6.
+`from_json` also accepts agent-friendly **string forms** (issue #51): `"Vector2(100, 200)"`,
+`"Rect2(0, 0, 4, 5)"` (via `str_to_var`), and HTML/hex colors `"#ff0000"` / `"#ff0000ff"`
+(via `Color.html`), in addition to the dict/array forms below.
 
 | Godot type | JSON shape |
 |------------|------------|

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -129,7 +129,8 @@ UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
 | `create_scene` | `root_type, scene_path` | `CreateSceneResult { scene_path, root_type, created }` | `mutating` |
 
 - `set_node_property` coerces JSON to the property's declared Godot type via
-  `type_coerce.from_json` (Vector2/3 & Color as `{…}` objects or arrays, NodePath as string).
+  `type_coerce.from_json` (Vector2/3 & Color as `{…}` objects or arrays, NodePath as string,
+  plus string forms like `"Vector2(100, 200)"` and `"#ff0000"` — issue #51).
 - `delete_node` (destructive) requires `confirm=True` to delete; `dry_run=True` previews
   without confirming. The addon also honors the `confirm` flag defensively.
 - `create_scene` writes a new `.tscn`/`.scn` and opens it; it is a file creation, not a

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -53,7 +53,15 @@ static func to_json(value: Variant) -> Variant:
 ## JSON → Godot value of the given Variant.Type (issue #6, write direction).
 ## Vectors/Color accept either the dict form to_json emits ({x, y}) or an array
 ## ([x, y]); NodePath/StringName from string; primitives coerced to the type.
+##
+## Composite types also accept agent-friendly string forms (issue #51):
+##   "Vector2(100, 200)", "Vector3(1, 2, 3)", "Rect2(0, 0, 4, 5)" (via str_to_var)
+##   and HTML/hex colors "#ff0000" / "#ff0000ff" (via Color.html).
 static func from_json(value: Variant, type: int) -> Variant:
+	if value is String:
+		var parsed: Variant = _from_string(value, type)
+		if parsed != null:
+			return parsed
 	match type:
 		TYPE_VECTOR2:
 			return Vector2(_component(value, "x", 0), _component(value, "y", 1))
@@ -96,6 +104,18 @@ static func from_json(value: Variant, type: int) -> Variant:
 			return str(value)
 		_:
 			return value
+
+
+## Parse a string form into a composite type, or null to fall back to dict/array.
+static func _from_string(value: String, type: int) -> Variant:
+	match type:
+		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_RECT2, TYPE_RECT2I:
+			# str_to_var parses "Vector2(100, 200)", "Rect2(0, 0, 4, 5)", etc.
+			var parsed: Variant = str_to_var(value)
+			return parsed if typeof(parsed) == type else null
+		TYPE_COLOR:
+			return Color.html(value) if value.is_valid_html_color() else null
+	return null
 
 
 static func _has_rect_keys(value: Variant) -> bool:

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -106,15 +106,28 @@ static func from_json(value: Variant, type: int) -> Variant:
 			return value
 
 
+# Constructor prefix per composite type, so str_to_var only runs on plausible input.
+const _CTOR_PREFIX := {
+	TYPE_VECTOR2: "Vector2(",
+	TYPE_VECTOR2I: "Vector2i(",
+	TYPE_VECTOR3: "Vector3(",
+	TYPE_VECTOR3I: "Vector3i(",
+	TYPE_RECT2: "Rect2(",
+	TYPE_RECT2I: "Rect2i(",
+}
+
+
 ## Parse a string form into a composite type, or null to fall back to dict/array.
 static func _from_string(value: String, type: int) -> Variant:
-	match type:
-		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_RECT2, TYPE_RECT2I:
-			# str_to_var parses "Vector2(100, 200)", "Rect2(0, 0, 4, 5)", etc.
-			var parsed: Variant = str_to_var(value)
-			return parsed if typeof(parsed) == type else null
-		TYPE_COLOR:
-			return Color.html(value) if value.is_valid_html_color() else null
+	if _CTOR_PREFIX.has(type):
+		# Cheap prefix check first: avoid calling str_to_var (and its parse-error
+		# noise) on strings that clearly aren't the expected constructor form.
+		if not value.strip_edges().begins_with(_CTOR_PREFIX[type]):
+			return null
+		var parsed: Variant = str_to_var(value)
+		return parsed if typeof(parsed) == type else null
+	if type == TYPE_COLOR:
+		return Color.html(value) if value.is_valid_html_color() else null
 	return null
 
 

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -70,6 +70,15 @@ func _test_from_json(failures: Array[String]) -> void:
 	# Malformed Rect2 input must not crash; it degrades to a default.
 	_eq(failures, "fj.rect2.bad", Coerce.from_json("oops", TYPE_RECT2), Rect2())
 
+	# String forms (issue #51): "Vector2(...)" / "Rect2(...)" via str_to_var, hex via Color.html.
+	_eq(failures, "fj.str.vec2", Coerce.from_json("Vector2(100, 200)", TYPE_VECTOR2), Vector2(100, 200))
+	_eq(failures, "fj.str.vec3", Coerce.from_json("Vector3(1, 2, 3)", TYPE_VECTOR3), Vector3(1, 2, 3))
+	_eq(failures, "fj.str.rect2", Coerce.from_json("Rect2(0, 0, 4, 5)", TYPE_RECT2), Rect2(0, 0, 4, 5))
+	_eq(failures, "fj.str.color", Coerce.from_json("#00ff00", TYPE_COLOR), Color(0, 1, 0, 1))
+	_eq(failures, "fj.str.color.alpha", Coerce.from_json("#0000ffff", TYPE_COLOR), Color(0, 0, 1, 1))
+	# A plain string still passes through for TYPE_STRING.
+	_eq(failures, "fj.str.passthrough", Coerce.from_json("hello", TYPE_STRING), "hello")
+
 
 func _test_serialize_tree(failures: Array[String]) -> void:
 	var world := Node2D.new()

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -78,6 +78,8 @@ func _test_from_json(failures: Array[String]) -> void:
 	_eq(failures, "fj.str.color.alpha", Coerce.from_json("#0000ffff", TYPE_COLOR), Color(0, 0, 1, 1))
 	# A plain string still passes through for TYPE_STRING.
 	_eq(failures, "fj.str.passthrough", Coerce.from_json("hello", TYPE_STRING), "hello")
+	# A non-constructor string for a composite type falls back to default (no str_to_var).
+	_eq(failures, "fj.str.vec2.bad", Coerce.from_json("nope", TYPE_VECTOR2), Vector2())
 
 
 func _test_serialize_tree(failures: Array[String]) -> void:

--- a/tests/integration/test_mutation_e2e.py
+++ b/tests/integration/test_mutation_e2e.py
@@ -69,6 +69,14 @@ async def _run_roundtrip() -> None:
         )
         assert was_set["value"] == {"x": 10.0, "y": 20.0}  # coerced JSON → Vector2 → JSON
 
+        # Agent-friendly string form is also coerced (issue #51).
+        as_string = await _ok(
+            bridge,
+            "cmd_set_node_property",
+            {"node_path": "Hero", "property": "position", "value": "Vector2(30, 40)"},
+        )
+        assert as_string["value"] == {"x": 30.0, "y": 40.0}
+
         renamed = await _ok(bridge, "cmd_rename_node", {"node_path": "Hero", "new_name": "Player"})
         assert renamed["new_name"] == "Player"
 


### PR DESCRIPTION
## Summary

Quick quality-of-life win: `type_coerce.from_json` now accepts agent-friendly **string forms** for composite types, alongside the existing dict/array forms. Closes #51.

- `"Vector2(100, 200)"`, `"Vector3(1, 2, 3)"`, `"Rect2(0, 0, 4, 5)"` → via `str_to_var` (accepted only when the parsed type matches the target).
- HTML/hex colors `"#ff0000"` / `"#ff0000ff"` → via `Color.html`, guarded by `String.is_valid_html_color`.
- Malformed strings fall back to the existing dict/array path — never crash.

Pure addon helper change: **`set_node_property` and resource editing accept these forms automatically** (they route through `from_json`). No new tools or toolset.

## Test plan

- `uv run pytest -q` → **131 passed**. New headless `inspect_smoke.gd` cases (string forms + round-trip), plus a real-editor assertion in `test_mutation_e2e` that `set_node_property` accepts `"Vector2(30, 40)"` and reads back `{x:30, y:40}`.
- `ruff` / `mypy --strict` / zero-skip clean. APIs (`str_to_var`, `Color.html`, `is_valid_html_color`) exercised against Godot 4.6.3 via the headless smoke.

Docs: `architecture.md` type-coercion note + `tool-contracts.md` `set_node_property` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)