### PR TITLE
feat(runtime): editor play + debug-probe + EditorDebuggerPlugin (closes #66)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -404,6 +404,30 @@ source?, line? }` parsed from stdout/stderr. Project directory is resolved from
 Enable with `enable_toolset("runtime")`. Launches a Godot process directly (see the
 runtime-execution note in [`architecture.md`](architecture.md)).
 
+##### Runtime session bridge (issue #66) — same `runtime` toolset
+
+Control an editor **play session** and inspect the running game live. Unlike
+`run_and_capture` (a detached headless subprocess), these play *from the editor* so the
+game connects to the editor debugger, which the addon's `MCPDebugger`
+(`EditorDebuggerPlugin`) captures. Live inspection requires the game to include the
+**godot-mcp runtime probe** autoload (`addons/godot_mcp/mcp_runtime_probe.gd`), which
+answers `godot_mcp:` debugger queries. Play control is `runtime`; reads are `read_only`.
+
+| Tool | Params | Returns |
+|------|--------|---------|
+| `play_scene` | `scene_path?` | `PlayResult { playing, scene }` |
+| `stop_scene` | — | `PlayResult { playing }` |
+| `is_playing` | — | `PlayResult { playing, scene }` |
+| `get_game_scene_tree` | — | `GameSceneTreeResult { playing, connected, tree?, hint }` (read_only) |
+
+`play_scene` runs `scene_path` (a `res://*.tscn`) or the main scene when omitted.
+`get_game_scene_tree` returns the *running* game's live tree (`GameNode { name, type,
+path, children }`) from the probe; with no play session it is a `PRECONDITION_FAILED`
+(`required=play_session`), and when playing without the probe it returns
+`connected=false` with a `hint` to add the autoload. Replies are cached addon-side
+(poll-and-cache) so the synchronous bridge stays simple. This is the foundation for
+input simulation (#36) and the rest of runtime inspection (#35).
+
 #### Safety introspection (issue #14) — `read_only`
 
 | Tool | Params | Returns |

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -17,6 +17,14 @@ const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
 const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
 
 var _handlers: Dictionary = {}
+# The EditorDebuggerPlugin that captures a played game's godot_mcp channel (issue #66).
+# Set by the plugin entry; null in headless/unit contexts where there is no editor.
+var _debugger: Object = null
+
+
+## Inject the MCPDebugger so runtime-inspection handlers can read cached live state.
+func set_debugger(debugger: Object) -> void:
+	_debugger = debugger
 
 
 func _init() -> void:
@@ -114,6 +122,11 @@ func _init() -> void:
 	_handlers["cmd_read_shader"] = _cmd_read_shader
 	_handlers["cmd_assign_shader_material"] = _cmd_assign_shader_material
 	_handlers["cmd_set_shader_param"] = _cmd_set_shader_param
+	# Runtime session bridge (issue #66) — editor play control (live inspection lands next).
+	_handlers["cmd_play_scene"] = _cmd_play_scene
+	_handlers["cmd_stop_scene"] = _cmd_stop_scene
+	_handlers["cmd_is_playing"] = _cmd_is_playing
+	_handlers["cmd_get_game_scene_tree"] = _cmd_get_game_scene_tree
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
@@ -2047,6 +2060,55 @@ func _to_vec4(value: Variant) -> Vector4:
 			float(value.get("z", 0.0)), float(value.get("w", 0.0))
 		)
 	return Vector4.ZERO
+
+
+# --- runtime session bridge (issue #66) ------------------------------------
+
+func _cmd_play_scene(params: Dictionary) -> Dictionary:
+	var scene_path := str(params.get("scene_path", ""))
+	if scene_path.is_empty():
+		EditorInterface.play_main_scene()
+	else:
+		if not scene_path.begins_with("res://") or not scene_path.ends_with(".tscn"):
+			return _fail("VALIDATION_ERROR", "scene_path must be a res:// .tscn file.")
+		if not FileAccess.file_exists(scene_path):
+			return _fail("RESOURCE_NOT_FOUND", "No scene at '%s'." % scene_path)
+		EditorInterface.play_custom_scene(scene_path)
+	return _ok({
+		"playing": EditorInterface.is_playing_scene(),
+		"scene": EditorInterface.get_playing_scene(),
+	})
+
+
+func _cmd_stop_scene(_params: Dictionary) -> Dictionary:
+	EditorInterface.stop_playing_scene()
+	return _ok({"playing": EditorInterface.is_playing_scene()})
+
+
+func _cmd_is_playing(_params: Dictionary) -> Dictionary:
+	return _ok({
+		"playing": EditorInterface.is_playing_scene(),
+		"scene": EditorInterface.get_playing_scene(),
+	})
+
+
+func _cmd_get_game_scene_tree(_params: Dictionary) -> Dictionary:
+	if not EditorInterface.is_playing_scene():
+		return _fail("PRECONDITION_FAILED", "No play session. Run play_scene first.", "play_session")
+	if _debugger == null:
+		return _fail("INTERNAL_ERROR", "Debugger plugin is unavailable.")
+	if not _debugger.is_connected_to_probe():
+		# Playing, but the probe hasn't announced itself — usually means the consuming
+		# project hasn't added the godot_mcp runtime probe autoload yet.
+		return _ok({
+			"playing": true,
+			"connected": false,
+			"tree": null,
+			"hint": "Add the godot_mcp runtime probe (addons/godot_mcp/mcp_runtime_probe.gd) as an autoload in the game to enable live inspection.",
+		})
+	var tree: Variant = _debugger.get_cached_scene_tree()
+	_debugger.request_scene_tree()  # refresh the cache for the next call
+	return _ok({"playing": true, "connected": true, "tree": tree})
 
 
 # --- editor screenshots (issue #33) ----------------------------------------

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -2069,8 +2069,9 @@ func _cmd_play_scene(params: Dictionary) -> Dictionary:
 	if scene_path.is_empty():
 		EditorInterface.play_main_scene()
 	else:
-		if not scene_path.begins_with("res://") or not scene_path.ends_with(".tscn"):
-			return _fail("VALIDATION_ERROR", "scene_path must be a res:// .tscn file.")
+		var is_scene := scene_path.ends_with(".tscn") or scene_path.ends_with(".scn")
+		if not scene_path.begins_with("res://") or not is_scene:
+			return _fail("VALIDATION_ERROR", "scene_path must be a res:// .tscn or .scn file.")
 		if not FileAccess.file_exists(scene_path):
 			return _fail("RESOURCE_NOT_FOUND", "No scene at '%s'." % scene_path)
 		EditorInterface.play_custom_scene(scene_path)

--- a/godot/addons/godot_mcp/godot_mcp.gd
+++ b/godot/addons/godot_mcp/godot_mcp.gd
@@ -17,6 +17,7 @@ const PLUGIN_NAME := "godot_mcp"
 
 var _dock: MCPStatusDock
 var _bridge: MCPBridge
+var _debugger: MCPDebugger
 var _selection: EditorSelection
 
 
@@ -24,8 +25,15 @@ func _enter_tree() -> void:
 	_dock = MCPStatusDock.new()
 	add_control_to_dock(DOCK_SLOT_LEFT_UR, _dock)
 
+	# Capture the godot_mcp debugger channel from played games (issue #66), and give the
+	# router a handle so runtime-inspection handlers can read the cached live state.
+	_debugger = MCPDebugger.new()
+	add_debugger_plugin(_debugger)
+	var router := MCPCommandRouter.new()
+	router.set_debugger(_debugger)
+
 	# Start the WebSocket bridge and reflect its state in the dock.
-	_bridge = MCPBridge.new()
+	_bridge = MCPBridge.new(router)
 	_bridge.connection_changed.connect(_on_connection_changed)
 	_bridge.command_received.connect(_dock.log_command)
 	add_child(_bridge)
@@ -50,6 +58,10 @@ func _exit_tree() -> void:
 		_bridge.stop()
 		_bridge.queue_free()
 		_bridge = null
+
+	if _debugger != null:
+		remove_debugger_plugin(_debugger)
+		_debugger = null
 
 	if _dock != null:
 		remove_control_from_docks(_dock)

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -1,0 +1,73 @@
+@tool
+class_name MCPDebugger
+extends EditorDebuggerPlugin
+## Captures the ``godot_mcp:`` debugger channel from a running game (issue #66).
+##
+## A custom EditorDebuggerPlugin only receives messages with its own prefix, so the
+## running game must include the godot-mcp runtime probe autoload
+## (``mcp_runtime_probe.gd``), which registers an ``EngineDebugger`` capture and answers
+## our queries. Replies are **cached** here so the synchronous WS command handlers can
+## read live runtime state without making the bridge async (poll-and-cache).
+
+const CAPTURE_PREFIX := "godot_mcp"
+
+var _session_id: int = -1
+var _session_active: bool = false
+var _probe_ready: bool = false
+var _scene_tree: Variant = null  # last godot_mcp:scene_tree payload (Dictionary) or null
+
+
+func _has_capture(capture: String) -> bool:
+	return capture == CAPTURE_PREFIX
+
+
+func _capture(message: String, data: Array, session_id: int) -> bool:
+	match message:
+		"godot_mcp:ready":
+			_probe_ready = true
+			_session_id = session_id
+			request_scene_tree()  # warm the cache as soon as the probe announces itself
+			return true
+		"godot_mcp:pong":
+			return true
+		"godot_mcp:scene_tree":
+			_scene_tree = data[0] if not data.is_empty() else null
+			return true
+	return false
+
+
+func _setup_session(session_id: int) -> void:
+	_session_id = session_id
+	var session := get_session(session_id)
+	session.started.connect(func() -> void: _on_started(session_id))
+	session.stopped.connect(_on_stopped)
+
+
+func _on_started(session_id: int) -> void:
+	_session_active = true
+	_session_id = session_id
+
+
+func _on_stopped() -> void:
+	_session_active = false
+	_probe_ready = false
+	_scene_tree = null
+
+
+## Ask the running game's probe to (re)send the scene tree. The reply lands in the cache
+## on a later frame via _capture; callers read get_cached_scene_tree().
+func request_scene_tree() -> void:
+	if not _session_active or _session_id < 0:
+		return
+	var session := get_session(_session_id)
+	if session != null and session.is_active():
+		session.send_message("godot_mcp:get_scene_tree", [])
+
+
+## True once a play session is live AND its probe has announced itself.
+func is_connected_to_probe() -> bool:
+	return _session_active and _probe_ready
+
+
+func get_cached_scene_tree() -> Variant:
+	return _scene_tree

--- a/godot/addons/godot_mcp/mcp_debugger.gd.uid
+++ b/godot/addons/godot_mcp/mcp_debugger.gd.uid
@@ -1,0 +1,1 @@
+uid://b2eeuidgr805q

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -1,0 +1,46 @@
+extends Node
+## godot-mcp runtime probe (issue #66). Runs **in the game**, not the editor.
+##
+## Add this script as an autoload in the *consuming* game's project to enable godot-mcp
+## live runtime inspection/input while the game runs from the editor. It registers an
+## EngineDebugger message capture on the "godot_mcp" channel and answers queries from the
+## addon's MCPDebugger (editor side). It does nothing outside a debug session, so it is
+## safe to leave enabled (it no-ops in exported/non-debug builds).
+
+const MAX_DEPTH := 32
+
+
+func _ready() -> void:
+	if EngineDebugger.is_active():
+		EngineDebugger.register_message_capture("godot_mcp", _capture)
+		EngineDebugger.send_message("godot_mcp:ready", [])
+
+
+## Capture handler: the "godot_mcp:" prefix is stripped before this is called.
+func _capture(message: String, _data: Array) -> bool:
+	match message:
+		"ping":
+			EngineDebugger.send_message("godot_mcp:pong", [])
+			return true
+		"get_scene_tree":
+			EngineDebugger.send_message("godot_mcp:scene_tree", [_serialize_tree()])
+			return true
+	return false
+
+
+func _serialize_tree() -> Dictionary:
+	return _node_to_dict(get_tree().root, 0)
+
+
+## JSON-safe { name, type, path, children } snapshot of the live node, bounded by depth.
+func _node_to_dict(node: Node, depth: int) -> Dictionary:
+	var children: Array = []
+	if depth < MAX_DEPTH:
+		for child in node.get_children():
+			children.append(_node_to_dict(child, depth + 1))
+	return {
+		"name": String(node.name),
+		"type": node.get_class(),
+		"path": String(node.get_path()),
+		"children": children,
+	}

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd.uid
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://ccjof6txapfes

--- a/mcp_server/models/runtime_session.py
+++ b/mcp_server/models/runtime_session.py
@@ -1,0 +1,26 @@
+"""Typed results for the runtime session bridge (issue #66)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PlayResult(BaseModel):
+    playing: bool
+    scene: str = ""
+
+
+class GameNode(BaseModel):
+    """A node in the *running* game's live scene tree (from the runtime probe)."""
+
+    name: str
+    type: str
+    path: str = ""
+    children: list[GameNode] = Field(default_factory=list)
+
+
+class GameSceneTreeResult(BaseModel):
+    playing: bool
+    connected: bool = False
+    tree: GameNode | None = None
+    hint: str = ""

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -35,6 +35,7 @@ from mcp_server.tools.physics import register_physics
 from mcp_server.tools.project_fs import register_project_fs
 from mcp_server.tools.resource_files import register_resource_files
 from mcp_server.tools.runtime import register_runtime
+from mcp_server.tools.runtime_session import register_runtime_session
 from mcp_server.tools.scene_3d import register_scene_3d
 from mcp_server.tools.scripts import register_scripts
 from mcp_server.tools.shader import register_shader
@@ -95,6 +96,7 @@ def create_server(
     register_editor(mcp, bridge)
     register_resources(mcp, bridge)
     register_runtime(mcp, bridge, config, runner)
+    register_runtime_session(mcp, bridge)
     register_scripts(mcp, bridge, config, runner)
     register_safety_tools(mcp)
 

--- a/mcp_server/tools/runtime_session.py
+++ b/mcp_server/tools/runtime_session.py
@@ -1,0 +1,51 @@
+"""Runtime session bridge tools (issue #66).
+
+Control an editor *play session* and inspect the running game live. Play is launched
+from the editor (so the game connects to the editor debugger, which the addon's
+MCPDebugger captures); live inspection requires the godot-mcp runtime probe autoload in
+the game. Foundation for input simulation (#36) and runtime inspection (#35). Gated in
+the ``runtime`` toolset; play control is `runtime`, reads are `read_only`.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.categories import RUNTIME_TAG
+from mcp_server.models.runtime_session import GameSceneTreeResult, PlayResult
+from mcp_server.safety import READ_ONLY, RUNTIME
+from mcp_server.tools._route import route
+
+RUNTIME_SET = {RUNTIME_TAG}
+
+
+def register_runtime_session(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register the play-control + live-inspection tools."""
+
+    @mcp.tool(meta=RUNTIME, tags=RUNTIME_SET)
+    async def play_scene(scene_path: str = "") -> PlayResult:
+        """Run the game from the editor: play ``scene_path`` (a ``res://*.tscn``) or the
+        project's main scene when omitted. The game connects to the editor debugger, so
+        runtime inspection/input tools can reach it.
+        """
+        params = {"scene_path": scene_path}
+        return PlayResult(**await route(bridge, "cmd_play_scene", params))
+
+    @mcp.tool(meta=RUNTIME, tags=RUNTIME_SET)
+    async def stop_scene() -> PlayResult:
+        """Stop the current editor play session."""
+        return PlayResult(**await route(bridge, "cmd_stop_scene", {}))
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def is_playing() -> PlayResult:
+        """Report whether a play session is running and which scene."""
+        return PlayResult(**await route(bridge, "cmd_is_playing", {}))
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def get_game_scene_tree() -> GameSceneTreeResult:
+        """Get the *running* game's live scene tree ({name, type, path, children}).
+        Requires an active play session with the godot-mcp runtime probe autoload; if the
+        probe isn't connected, returns ``connected=false`` with a ``hint`` to add it.
+        """
+        return GameSceneTreeResult(**await route(bridge, "cmd_get_game_scene_tree", {}))

--- a/tests/contract/test_runtime_session.py
+++ b/tests/contract/test_runtime_session.py
@@ -1,0 +1,103 @@
+"""Contract tests for the runtime session bridge (issue #66)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+_TREE = {
+    "name": "root",
+    "type": "Window",
+    "path": "/root",
+    "children": [{"name": "Main", "type": "Node2D", "path": "/root/Main", "children": []}],
+}
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    p = cmd.params
+    match cmd.command:
+        case "cmd_play_scene":
+            return ResponseEnvelope.success(
+                cmd.id, {"playing": True, "scene": p.get("scene_path") or "<main>"}
+            )
+        case "cmd_stop_scene":
+            return ResponseEnvelope.success(cmd.id, {"playing": False})
+        case "cmd_is_playing":
+            return ResponseEnvelope.success(cmd.id, {"playing": True, "scene": "res://main.tscn"})
+        case "cmd_get_game_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id, {"playing": True, "connected": True, "tree": _TREE}
+            )
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+async def test_gated_in_runtime_toolset_with_safety_classes() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        assert "play_scene" not in {t.name for t in await client.list_tools()}
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert {"play_scene", "stop_scene", "is_playing", "get_game_scene_tree"} <= set(tools)
+    assert tools["play_scene"].meta["safety_class"] == "runtime"
+    assert tools["stop_scene"].meta["safety_class"] == "runtime"
+    assert tools["is_playing"].meta["safety_class"] == "read_only"
+    assert tools["get_game_scene_tree"].meta["safety_class"] == "read_only"
+
+
+async def test_play_stop_and_is_playing() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        played = await client.call_tool("play_scene", {"scene_path": "res://main.tscn"})
+        playing = await client.call_tool("is_playing", {})
+        stopped = await client.call_tool("stop_scene", {})
+    assert played.structured_content["playing"] is True
+    assert played.structured_content["scene"] == "res://main.tscn"
+    assert playing.structured_content["playing"] is True
+    assert stopped.structured_content["playing"] is False
+
+
+async def test_get_game_scene_tree_returns_live_tree() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        result = await client.call_tool("get_game_scene_tree", {})
+    sc = result.structured_content
+    assert sc["connected"] is True
+    assert sc["tree"]["type"] == "Window"
+    assert sc["tree"]["children"][0]["name"] == "Main"
+
+
+async def test_get_game_scene_tree_not_connected() -> None:
+    # The addon reports playing-but-probe-not-connected as a soft result, not an error.
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_get_game_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"playing": True, "connected": False, "tree": None, "hint": "add the probe"},
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        result = await client.call_tool("get_game_scene_tree", {})
+    assert result.structured_content["connected"] is False
+    assert result.structured_content["tree"] is None
+    assert "probe" in result.structured_content["hint"]

--- a/tests/integration/test_runtime_session_e2e.py
+++ b/tests/integration/test_runtime_session_e2e.py
@@ -1,0 +1,119 @@
+"""End-to-end runtime session bridge test against a live editor (issue #66).
+
+Validated headless: play control, the not-connected path (no probe autoload), and the
+full debugger round-trip (register probe -> play -> live scene tree via MCPDebugger).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://localhost:9080"
+SCRATCH = "res://tmp_e2e_runtime_session.tscn"
+SCRATCH_FILE = GODOT_PROJECT / "tmp_e2e_runtime_session.tscn"
+PROJECT_GODOT = GODOT_PROJECT / "project.godot"
+PROBE = "res://addons/godot_mcp/mcp_runtime_probe.gd"
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = await bridge.send(command, params)
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+async def _wait_scene_open(bridge: Bridge) -> None:
+    for _ in range(40):
+        r = await bridge.send("cmd_get_active_scene")
+        if r.ok and (r.result or {}).get("is_open"):
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("scene did not open")
+
+
+async def _wait_playing(bridge: Bridge, want: bool) -> None:
+    for _ in range(20):
+        state = await _ok(bridge, "cmd_is_playing", {})
+        if state["playing"] is want:
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError(f"is_playing never became {want}")
+
+
+async def _run() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    for _ in range(60):
+        try:
+            await bridge.connect()
+            break
+        except Exception:
+            await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("could not connect to the addon bridge")
+
+    try:
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node2D", "scene_path": SCRATCH})
+        await _wait_scene_open(bridge)
+
+        # precondition: querying the live tree with nothing playing is a structured error
+        not_playing = await bridge.send("cmd_get_game_scene_tree", {})
+        assert not_playing.ok is False and not_playing.error == "PRECONDITION_FAILED"
+        assert not_playing.required == "play_session"
+
+        # play WITHOUT the probe autoload -> playing, but not connected to a probe
+        await _ok(bridge, "cmd_play_scene", {"scene_path": SCRATCH})
+        await _wait_playing(bridge, True)
+        no_probe = await _ok(bridge, "cmd_get_game_scene_tree", {})
+        assert no_probe["playing"] is True and no_probe["connected"] is False
+        assert no_probe["tree"] is None and "probe" in no_probe["hint"]
+        await _ok(bridge, "cmd_stop_scene", {})
+        await _wait_playing(bridge, False)
+
+        # register the probe autoload, then play -> the live tree comes back
+        await _ok(bridge, "cmd_register_autoload", {"name": "GodotMcpProbe", "path": PROBE})
+        await _ok(bridge, "cmd_play_scene", {"scene_path": SCRATCH})
+        tree: dict[str, Any] | None = None
+        for _ in range(30):
+            state = await _ok(bridge, "cmd_get_game_scene_tree", {})
+            if state["connected"] and state["tree"]:
+                tree = state["tree"]
+                break
+            await asyncio.sleep(0.5)
+        assert tree is not None, "probe never delivered the live scene tree"
+        assert tree["type"] == "Window"  # the game's root viewport
+        child_types = [c["type"] for c in tree["children"]]
+        assert "Node2D" in child_types  # our played scene root
+        await _ok(bridge, "cmd_stop_scene", {})
+    finally:
+        await bridge.close()
+
+
+def test_live_runtime_session() -> None:
+    assert GODOT_BIN is not None
+    snapshot = PROJECT_GODOT.read_bytes()
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        asyncio.run(_run())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        SCRATCH_FILE.unlink(missing_ok=True)
+        PROJECT_GODOT.write_bytes(snapshot)  # restore (drop the probe autoload)

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -302,6 +302,30 @@ def test_router_registers_shader_commands() -> None:
         assert f'"{command}"' in source, f"router must register {command}"
 
 
+def test_router_registers_runtime_session_commands() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    for command in (
+        "cmd_play_scene",
+        "cmd_stop_scene",
+        "cmd_is_playing",
+        "cmd_get_game_scene_tree",
+    ):
+        assert f'"{command}"' in source, f"router must register {command}"
+
+
+def test_runtime_session_addon_files_present() -> None:
+    # The EditorDebuggerPlugin captures the played game's godot_mcp channel; the probe
+    # autoload (game-side) answers its queries. Both must ship in the addon (issue #66).
+    debugger = ADDON_DIR / "mcp_debugger.gd"
+    probe = ADDON_DIR / "mcp_runtime_probe.gd"
+    assert debugger.exists() and "EditorDebuggerPlugin" in debugger.read_text()
+    assert probe.exists() and "register_message_capture" in probe.read_text()
+    # The plugin entry must register/unregister the debugger plugin and wire it to the router.
+    entry = (ADDON_DIR / "godot_mcp.gd").read_text()
+    assert "add_debugger_plugin" in entry and "remove_debugger_plugin" in entry
+    assert "set_debugger" in entry
+
+
 def test_mutations_use_undo_redo() -> None:
     source = (ADDON_DIR / "command_router.gd").read_text()
     # Every create/rename/delete/set must register with EditorUndoRedoManager.


### PR DESCRIPTION
## Summary
The shared **runtime session bridge** that both #36 (input simulation) and #35 (runtime inspection) require: a way to reach a *running* game from the addon. A custom `EditorDebuggerPlugin` only receives its own-prefixed messages (and can't read the engine's built-in remote tree), so live interaction is done via an editor **play session** + a cooperating game-side **probe autoload**, with replies **cached** addon-side (poll-and-cache) so the synchronous WS bridge stays simple.

## Acceptance criteria
- [x] Addon: editor play control (`cmd_play_scene`/`cmd_stop_scene`/`cmd_is_playing`), `MCPDebugger` (`EditorDebuggerPlugin`) capturing the `godot_mcp:` channel, `mcp_runtime_probe.gd` autoload, and `cmd_get_game_scene_tree` proof-of-life
- [x] MCP: `play_scene`/`stop_scene` (`runtime`), `is_playing`/`get_game_scene_tree` (`read_only`) in the existing `runtime` toolset; typed recursive `GameNode` results
- [x] Godot APIs verified against current 4.6 docs (EditorDebuggerPlugin/Session, EngineDebugger, EditorInterface.play_*)
- [x] Docs updated (`docs/tool-contracts.md`)

## Notes
- **Headless viability validated** with a throwaway spike (since removed): `EditorInterface.play_custom_scene` + a debugger session + the probe round-trip all work under `--headless --editor`.
- Live inspection requires the consuming game to add the probe autoload; without it, `get_game_scene_tree` returns `connected=false` + a `hint` (not an error).

## Test plan
- Contract (`tests/contract/test_runtime_session.py`): toolset gating + safety classes, play/stop/is_playing, live tree round-trip, not-connected soft result.
- Live e2e (`tests/integration/test_runtime_session_e2e.py`): real headless editor — precondition error with no session, not-connected path (play without probe), and the full register-probe → play → live scene tree round-trip (asserts the game root `Window` + the played `Node2D`). `project.godot` is snapshot/restored. Passed locally.
- Static checks (`tests/unit/test_addon_manifest.py`): router registers the new commands; the debugger plugin + probe files ship and the plugin entry wires `add/remove_debugger_plugin` + `set_debugger`.
- Preflight: ruff clean, mypy --strict clean, `pytest tests/contract tests/unit` (193 passed), zero-skip clean, addon loads/enables cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)