### PR TITLE
feat(runtime): live property monitor + UI element finder (closes #35)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -469,8 +469,10 @@ with #66). Requires a play session + the runtime probe.
 series with `get_property_samples` (which reports a validation `error` for a bad
 node/property). `find_ui_elements` returns matching Control nodes — each
 `UiElement { path, name, node_class, visible, rect{x,y,w,h}, text }` —
-and polls the probe up to `timeout_ms` for a fresh result; the `rect` pairs with
-`simulate_mouse` to click located UI. Replies use the same poll-and-cache as the live tree.
+and polls the probe up to `timeout_ms` for a fresh result. Each invocation carries an
+internal `request_id` (constant across its poll), so the addon dispatches exactly one
+full-Control scan per call and never returns a prior identical-filter request's stale
+result. The `rect` pairs with `simulate_mouse` to click located UI.
 
 #### Safety introspection (issue #14) — `read_only`
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -453,6 +453,25 @@ events sent. All injection requires a live probe (else `PRECONDITION_FAILED`,
 `required=play_session` / `runtime_probe`). `get_input_stats.injected` is the count of
 synthesized events the game has acknowledged — use it to confirm delivery.
 
+#### Runtime inspection (issue #35) — `runtime` toolset, `read_only`
+
+Inspect a *running* game on the #66 rails (the third piece, `get_game_scene_tree`, shipped
+with #66). Requires a play session + the runtime probe.
+
+| Tool | Params | Returns |
+|------|--------|---------|
+| `monitor_property` | `node_path, property, samples=30` | `MonitorResult { monitoring, node_path, property, samples }` |
+| `get_property_samples` | — | `PropertySamplesResult { ready, connected, node_path, property, samples[], error }` |
+| `find_ui_elements` | `name_contains="", class_filter="", visible_only=False, timeout_ms=2000` | `UiElementsResult { ready, elements[] }` |
+
+`monitor_property` captures `samples` readings of a live node's property (one per frame —
+`node_path` is an absolute path from `get_game_scene_tree`); collect the `[{frame, value}]`
+series with `get_property_samples` (which reports a validation `error` for a bad
+node/property). `find_ui_elements` returns matching Control nodes — each
+`UiElement { path, name, node_class, visible, rect{x,y,w,h}, text }` —
+and polls the probe up to `timeout_ms` for a fresh result; the `rect` pairs with
+`simulate_mouse` to click located UI. Replies use the same poll-and-cache as the live tree.
+
 #### Safety introspection (issue #14) — `read_only`
 
 | Tool | Params | Returns |

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -133,6 +133,10 @@ func _init() -> void:
 	_handlers["cmd_simulate_action"] = _cmd_simulate_action
 	_handlers["cmd_play_input_sequence"] = _cmd_play_input_sequence
 	_handlers["cmd_get_input_stats"] = _cmd_get_input_stats
+	# Runtime inspection (issue #35) — property monitor + UI finder against the running game.
+	_handlers["cmd_monitor_property"] = _cmd_monitor_property
+	_handlers["cmd_get_property_samples"] = _cmd_get_property_samples
+	_handlers["cmd_find_ui_elements"] = _cmd_find_ui_elements
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
@@ -2203,6 +2207,54 @@ func _require_live_probe() -> Dictionary:
 	if _debugger == null or not _debugger.is_connected_to_probe():
 		return _fail("PRECONDITION_FAILED", "The godot_mcp runtime probe is not connected; add it as an autoload in the game.", "runtime_probe")
 	return {"ok": true}
+
+
+# --- runtime inspection (issue #35) ----------------------------------------
+
+func _cmd_monitor_property(params: Dictionary) -> Dictionary:
+	var guard := _require_live_probe()
+	if not guard["ok"]:
+		return guard
+	var node_path := str(params.get("node_path", ""))
+	var property := str(params.get("property", ""))
+	if node_path.is_empty() or property.is_empty():
+		return _fail("VALIDATION_ERROR", "'node_path' and 'property' are required.")
+	var samples := clampi(int(params.get("samples", 30)), 1, 300)
+	_debugger.clear_property_samples()  # drop any prior capture so get_ reflects this one
+	_debugger.send_to_probe("godot_mcp:monitor_property", [{
+		"node_path": node_path, "property": property, "samples": samples,
+	}])
+	return _ok({"monitoring": true, "node_path": node_path, "property": property, "samples": samples})
+
+
+func _cmd_get_property_samples(_params: Dictionary) -> Dictionary:
+	if _debugger == null or not _debugger.is_connected_to_probe():
+		return _ok({"ready": false, "connected": false, "samples": []})
+	var payload: Variant = _debugger.get_property_samples()
+	if payload == null:
+		return _ok({"ready": false, "connected": true, "samples": []})
+	var result: Dictionary = (payload as Dictionary).duplicate()
+	result["connected"] = true
+	return _ok(result)
+
+
+func _cmd_find_ui_elements(params: Dictionary) -> Dictionary:
+	var guard := _require_live_probe()
+	if not guard["ok"]:
+		return guard
+	var request := {
+		"name_contains": str(params.get("name_contains", "")),
+		"class_filter": str(params.get("class_filter", "")),
+		"visible_only": bool(params.get("visible_only", false)),
+	}
+	# Re-request each call; return the cached result once it matches these filters (the
+	# tool polls until ready, mirroring the poll-and-cache used for the live scene tree).
+	_debugger.send_to_probe("godot_mcp:find_ui", [request])
+	var payload: Variant = _debugger.get_ui_elements()
+	var ready: bool = payload is Dictionary and (payload as Dictionary).get("request") == request
+	if not ready:
+		return _ok({"ready": false, "elements": []})
+	return _ok({"ready": true, "elements": (payload as Dictionary).get("elements", [])})
 
 
 # --- editor screenshots (issue #33) ----------------------------------------

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -2242,19 +2242,23 @@ func _cmd_find_ui_elements(params: Dictionary) -> Dictionary:
 	var guard := _require_live_probe()
 	if not guard["ok"]:
 		return guard
-	var request := {
-		"name_contains": str(params.get("name_contains", "")),
-		"class_filter": str(params.get("class_filter", "")),
-		"visible_only": bool(params.get("visible_only", false)),
-	}
-	# Re-request each call; return the cached result once it matches these filters (the
-	# tool polls until ready, mirroring the poll-and-cache used for the live scene tree).
-	_debugger.send_to_probe("godot_mcp:find_ui", [request])
+	# Each tool invocation carries a stable request_id (constant across its poll loop). We
+	# dispatch the (expensive) full-Control scan to the probe exactly once per request_id
+	# and match the cached result by that id — so repeated polls don't re-scan, and reusing
+	# identical filters can't return a prior request's stale result.
+	var request_id := str(params.get("request_id", ""))
 	var payload: Variant = _debugger.get_ui_elements()
-	var ready: bool = payload is Dictionary and (payload as Dictionary).get("request") == request
-	if not ready:
-		return _ok({"ready": false, "elements": []})
-	return _ok({"ready": true, "elements": (payload as Dictionary).get("elements", [])})
+	if payload is Dictionary and (payload as Dictionary).get("request_id") == request_id:
+		return _ok({"ready": true, "elements": (payload as Dictionary).get("elements", [])})
+	if _debugger.get_pending_ui_request() != request_id:
+		_debugger.begin_ui_request(request_id)
+		_debugger.send_to_probe("godot_mcp:find_ui", [{
+			"name_contains": str(params.get("name_contains", "")),
+			"class_filter": str(params.get("class_filter", "")),
+			"visible_only": bool(params.get("visible_only", false)),
+			"request_id": request_id,
+		}])
+	return _ok({"ready": false, "elements": []})
 
 
 # --- editor screenshots (issue #33) ----------------------------------------

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -18,6 +18,7 @@ var _scene_tree: Variant = null  # last godot_mcp:scene_tree payload (Dictionary
 var _input_acks: int = 0  # count of synthesized inputs the game has acknowledged (#36)
 var _property_samples: Variant = null  # last godot_mcp:property_samples payload (#35)
 var _ui_elements: Variant = null  # last godot_mcp:ui_elements payload (#35)
+var _ui_pending := "__none__"  # request_id of the in-flight find_ui request (#35)
 
 
 func _has_capture(capture: String) -> bool:
@@ -67,6 +68,7 @@ func _on_stopped() -> void:
 	_input_acks = 0
 	_property_samples = null
 	_ui_elements = null
+	_ui_pending = "__none__"
 
 
 ## Ask the running game's probe to (re)send the scene tree. The reply lands in the cache
@@ -113,3 +115,15 @@ func clear_property_samples() -> void:
 
 func get_ui_elements() -> Variant:
 	return _ui_elements
+
+
+## request_id of the in-flight find_ui request (so the router dispatches a scan only once
+## per invocation rather than re-scanning on every poll).
+func get_pending_ui_request() -> String:
+	return _ui_pending
+
+
+## Mark a new find_ui request as in-flight and drop any prior (stale) result.
+func begin_ui_request(request_id: String) -> void:
+	_ui_pending = request_id
+	_ui_elements = null

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -16,6 +16,8 @@ var _session_active: bool = false
 var _probe_ready: bool = false
 var _scene_tree: Variant = null  # last godot_mcp:scene_tree payload (Dictionary) or null
 var _input_acks: int = 0  # count of synthesized inputs the game has acknowledged (#36)
+var _property_samples: Variant = null  # last godot_mcp:property_samples payload (#35)
+var _ui_elements: Variant = null  # last godot_mcp:ui_elements payload (#35)
 
 
 func _has_capture(capture: String) -> bool:
@@ -37,6 +39,12 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 		"godot_mcp:input_ack":
 			_input_acks += 1
 			return true
+		"godot_mcp:property_samples":
+			_property_samples = data[0] if not data.is_empty() else null
+			return true
+		"godot_mcp:ui_elements":
+			_ui_elements = data[0] if not data.is_empty() else null
+			return true
 	return false
 
 
@@ -57,6 +65,8 @@ func _on_stopped() -> void:
 	_probe_ready = false
 	_scene_tree = null
 	_input_acks = 0
+	_property_samples = null
+	_ui_elements = null
 
 
 ## Ask the running game's probe to (re)send the scene tree. The reply lands in the cache
@@ -89,3 +99,17 @@ func send_to_probe(message: String, data: Array = []) -> void:
 
 func get_input_acks() -> int:
 	return _input_acks
+
+
+func get_property_samples() -> Variant:
+	return _property_samples
+
+
+## Drop the cached samples so a fresh monitor_property doesn't read the prior capture
+## (the next get_property_samples reports ready=false until the new series arrives).
+func clear_property_samples() -> void:
+	_property_samples = null
+
+
+func get_ui_elements() -> Variant:
+	return _ui_elements

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -214,7 +214,7 @@ func _find_ui(d: Dictionary) -> Dictionary:
 		bool(d.get("visible_only", false)),
 		out,
 	)
-	return {"request": d, "elements": out}
+	return {"request_id": str(d.get("request_id", "")), "elements": out}
 
 
 func _collect_controls(

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -37,6 +37,12 @@ func _capture(message: String, data: Array) -> bool:
 		"play_input_sequence":
 			_play_input_sequence(_payload(data))
 			return true
+		"monitor_property":
+			_start_monitor(_payload(data))
+			return true
+		"find_ui":
+			EngineDebugger.send_message("godot_mcp:ui_elements", [_find_ui(_payload(data))])
+			return true
 	return false
 
 
@@ -136,3 +142,122 @@ func _node_to_dict(node: Node, depth: int) -> Dictionary:
 		"path": String(node.get_path()),
 		"children": children,
 	}
+
+
+# --- runtime inspection (issue #35) ----------------------------------------
+
+const _MONITOR_MAX_SAMPLES := 300
+
+var _monitor_target: NodePath = NodePath()
+var _monitor_property := ""
+var _monitor_remaining := 0
+var _monitor_samples: Array = []
+var _monitor_error := ""
+
+
+## Sample the monitored property once per frame until the requested count is reached,
+## then push the completed series to the editor (bounded capture — no perpetual stream).
+func _process(_delta: float) -> void:
+	if _monitor_remaining <= 0:
+		return
+	_monitor_remaining -= 1
+	var node := get_node_or_null(_monitor_target)
+	if node == null:
+		_monitor_error = "node not found at '%s'" % String(_monitor_target)
+		_monitor_remaining = 0
+	else:
+		_monitor_samples.append({
+			"frame": Engine.get_process_frames(),
+			"value": _json_safe(node.get(_monitor_property)),
+		})
+	if _monitor_remaining <= 0:
+		_push_samples()
+
+
+func _start_monitor(d: Dictionary) -> void:
+	_monitor_target = NodePath(str(d.get("node_path", "")))
+	_monitor_property = str(d.get("property", ""))
+	_monitor_samples = []
+	_monitor_error = ""
+	var count := clampi(int(d.get("samples", 30)), 1, _MONITOR_MAX_SAMPLES)
+	var node := get_node_or_null(_monitor_target)
+	if node == null:
+		_monitor_error = "node not found at '%s'" % String(_monitor_target)
+		_monitor_remaining = 0
+		_push_samples()
+		return
+	if not (_monitor_property in node):
+		_monitor_error = "no property '%s' on the node" % _monitor_property
+		_monitor_remaining = 0
+		_push_samples()
+		return
+	_monitor_remaining = count  # _process collects one sample per frame
+
+
+func _push_samples() -> void:
+	EngineDebugger.send_message("godot_mcp:property_samples", [{
+		"node_path": String(_monitor_target),
+		"property": _monitor_property,
+		"samples": _monitor_samples,
+		"error": _monitor_error,
+		"ready": true,
+	}])
+
+
+## Collect live Control nodes matching the filters, with their global rect (for clicking).
+func _find_ui(d: Dictionary) -> Dictionary:
+	var out: Array = []
+	_collect_controls(
+		get_tree().root,
+		str(d.get("name_contains", "")).to_lower(),
+		str(d.get("class_filter", "")),
+		bool(d.get("visible_only", false)),
+		out,
+	)
+	return {"request": d, "elements": out}
+
+
+func _collect_controls(
+	node: Node, name_contains: String, class_filter: String, visible_only: bool, out: Array
+) -> void:
+	if node is Control:
+		var matches := true
+		if not name_contains.is_empty() and not String(node.name).to_lower().contains(name_contains):
+			matches = false
+		if matches and not class_filter.is_empty() and not node.is_class(class_filter):
+			matches = false
+		if matches and visible_only and not node.is_visible_in_tree():
+			matches = false
+		if matches:
+			out.append(_ui_element(node))
+	for child in node.get_children():
+		_collect_controls(child, name_contains, class_filter, visible_only, out)
+
+
+func _ui_element(control: Control) -> Dictionary:
+	var rect := control.get_global_rect()
+	var element := {
+		"path": String(control.get_path()),
+		"name": String(control.name),
+		"node_class": control.get_class(),
+		"visible": control.is_visible_in_tree(),
+		"rect": {"x": rect.position.x, "y": rect.position.y, "w": rect.size.x, "h": rect.size.y},
+	}
+	if "text" in control:  # Button / Label / LineEdit / …
+		element["text"] = str(control.text)
+	return element
+
+
+## Minimal JSON-safe conversion for monitored property values (common Godot types).
+func _json_safe(value: Variant) -> Variant:
+	match typeof(value):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_COLOR:
+			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return value
+		_:
+			return str(value)

--- a/mcp_server/models/runtime_inspect.py
+++ b/mcp_server/models/runtime_inspect.py
@@ -1,0 +1,49 @@
+"""Typed results for runtime inspection tools (issue #35)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MonitorResult(BaseModel):
+    monitoring: bool
+    node_path: str
+    property: str
+    samples: int = 0
+
+
+class PropertySample(BaseModel):
+    frame: int
+    value: Any = None
+
+
+class PropertySamplesResult(BaseModel):
+    ready: bool = False
+    connected: bool = False
+    node_path: str = ""
+    property: str = ""
+    samples: list[PropertySample] = Field(default_factory=list)
+    error: str = ""
+
+
+class Rect(BaseModel):
+    x: float = 0.0
+    y: float = 0.0
+    w: float = 0.0
+    h: float = 0.0
+
+
+class UiElement(BaseModel):
+    path: str
+    name: str
+    node_class: str = ""
+    visible: bool = False
+    rect: Rect = Field(default_factory=Rect)
+    text: str = ""
+
+
+class UiElementsResult(BaseModel):
+    ready: bool = False
+    elements: list[UiElement] = Field(default_factory=list)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -36,6 +36,7 @@ from mcp_server.tools.physics import register_physics
 from mcp_server.tools.project_fs import register_project_fs
 from mcp_server.tools.resource_files import register_resource_files
 from mcp_server.tools.runtime import register_runtime
+from mcp_server.tools.runtime_inspect import register_runtime_inspect
 from mcp_server.tools.runtime_session import register_runtime_session
 from mcp_server.tools.scene_3d import register_scene_3d
 from mcp_server.tools.scripts import register_scripts
@@ -98,6 +99,7 @@ def create_server(
     register_resources(mcp, bridge)
     register_runtime(mcp, bridge, config, runner)
     register_runtime_session(mcp, bridge)
+    register_runtime_inspect(mcp, bridge)
     register_input_sim(mcp, bridge)
     register_scripts(mcp, bridge, config, runner)
     register_safety_tools(mcp)

--- a/mcp_server/tools/runtime_inspect.py
+++ b/mcp_server/tools/runtime_inspect.py
@@ -9,6 +9,7 @@ runtime probe. All `read_only` against the live session, in the `runtime` toolse
 from __future__ import annotations
 
 import asyncio
+import uuid
 from typing import Any
 
 from fastmcp import FastMCP
@@ -63,6 +64,9 @@ def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
             "name_contains": name_contains,
             "class_filter": class_filter,
             "visible_only": visible_only,
+            # Stable per-invocation id (constant across the poll loop) so the addon scans
+            # once and we never match a prior identical-filter request's stale result.
+            "request_id": uuid.uuid4().hex,
         }
         # The probe answers asynchronously; poll the addon's cache until it reflects this
         # request (or the timeout elapses). Bounded, ~100ms cadence.

--- a/mcp_server/tools/runtime_inspect.py
+++ b/mcp_server/tools/runtime_inspect.py
@@ -1,0 +1,76 @@
+"""Runtime inspection tools (issue #35).
+
+Inspect a *running* game on the #66 runtime-session rails: watch a node property over
+time and locate live UI (Control) elements. Requires a play session with the godot-mcp
+runtime probe. All `read_only` against the live session, in the `runtime` toolset.
+(``get_game_scene_tree`` — the third piece of #35 — already shipped with #66.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.categories import RUNTIME_TAG
+from mcp_server.models.runtime_inspect import (
+    MonitorResult,
+    PropertySamplesResult,
+    UiElementsResult,
+)
+from mcp_server.safety import READ_ONLY
+from mcp_server.tools._route import route
+
+RUNTIME_SET = {RUNTIME_TAG}
+
+
+def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register the runtime inspection tools."""
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def monitor_property(node_path: str, property: str, samples: int = 30) -> MonitorResult:
+        """Start watching ``property`` on the running game's node at ``node_path`` (an
+        absolute path from ``get_game_scene_tree``, e.g. "/root/Main/Player"). The probe
+        captures ``samples`` readings, one per frame; collect them with
+        ``get_property_samples``. Requires a play session + runtime probe.
+        """
+        params = {"node_path": node_path, "property": property, "samples": samples}
+        return MonitorResult(**await route(bridge, "cmd_monitor_property", params))
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def get_property_samples() -> PropertySamplesResult:
+        """Return the time series captured by the most recent ``monitor_property``:
+        ``samples`` is ``[{frame, value}]`` (``ready=false`` until the capture completes;
+        ``error`` set if the node/property was invalid).
+        """
+        return PropertySamplesResult(**await route(bridge, "cmd_get_property_samples", {}))
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def find_ui_elements(
+        name_contains: str = "",
+        class_filter: str = "",
+        visible_only: bool = False,
+        timeout_ms: int = 2000,
+    ) -> UiElementsResult:
+        """Locate live UI (Control) nodes in the running game, each with its path, class,
+        visibility, global ``rect`` (use it with ``simulate_mouse`` to click), and ``text``
+        if any. Filter by ``name_contains`` / ``class_filter`` (e.g. "Button") /
+        ``visible_only``. Requires a play session + runtime probe.
+        """
+        params = {
+            "name_contains": name_contains,
+            "class_filter": class_filter,
+            "visible_only": visible_only,
+        }
+        # The probe answers asynchronously; poll the addon's cache until it reflects this
+        # request (or the timeout elapses). Bounded, ~100ms cadence.
+        attempts = max(1, timeout_ms // 100)
+        result: dict[str, Any] = {"ready": False, "elements": []}
+        for _ in range(attempts):
+            result = await route(bridge, "cmd_find_ui_elements", params)
+            if result.get("ready"):
+                break
+            await asyncio.sleep(0.1)
+        return UiElementsResult(**result)

--- a/tests/contract/test_runtime_inspect.py
+++ b/tests/contract/test_runtime_inspect.py
@@ -1,0 +1,107 @@
+"""Contract tests for runtime inspection tools (issue #35)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    p = cmd.params
+    match cmd.command:
+        case "cmd_monitor_property":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "monitoring": True,
+                    "node_path": p["node_path"],
+                    "property": p["property"],
+                    "samples": p["samples"],
+                },
+            )
+        case "cmd_get_property_samples":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "ready": True,
+                    "connected": True,
+                    "node_path": "/root/Main",
+                    "property": "position",
+                    "samples": [{"frame": 1, "value": {"x": 0, "y": 0}}],
+                    "error": "",
+                },
+            )
+        case "cmd_find_ui_elements":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "ready": True,
+                    "elements": [
+                        {
+                            "path": "/root/Main/Button",
+                            "name": "Button",
+                            "node_class": "Button",
+                            "visible": True,
+                            "rect": {"x": 10, "y": 20, "w": 100, "h": 40},
+                            "text": "Play",
+                        }
+                    ],
+                },
+            )
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+async def test_gated_read_only_in_runtime_toolset() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        assert "find_ui_elements" not in {t.name for t in await client.list_tools()}
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        tools = {t.name: t for t in await client.list_tools()}
+    expected = {"monitor_property", "get_property_samples", "find_ui_elements"}
+    assert expected <= set(tools)
+    assert all(tools[n].meta["safety_class"] == "read_only" for n in expected)
+
+
+async def test_monitor_and_collect_samples() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        mon = await client.call_tool(
+            "monitor_property",
+            {"node_path": "/root/Main", "property": "position", "samples": 5},
+        )
+        samples = await client.call_tool("get_property_samples", {})
+    assert mon.structured_content["monitoring"] is True
+    assert mon.structured_content["samples"] == 5
+    sc = samples.structured_content
+    assert sc["ready"] is True and sc["property"] == "position"
+    assert sc["samples"][0]["value"] == {"x": 0, "y": 0}
+
+
+async def test_find_ui_elements() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "find_ui_elements", {"class_filter": "Button", "visible_only": True}
+        )
+    sc = result.structured_content
+    assert sc["ready"] is True
+    el = sc["elements"][0]
+    assert el["node_class"] == "Button"
+    assert el["text"] == "Play"
+    assert el["rect"]["w"] == 100

--- a/tests/integration/test_runtime_inspect_e2e.py
+++ b/tests/integration/test_runtime_inspect_e2e.py
@@ -1,0 +1,149 @@
+"""End-to-end runtime inspection test against a live editor (issue #35).
+
+On the #66 rails: build a scene with a Button, play it, then locate the live UI element
+and monitor a property over time via the runtime probe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://localhost:9080"
+SCRATCH = "res://tmp_e2e_runtime_inspect.tscn"
+SCRATCH_FILE = GODOT_PROJECT / "tmp_e2e_runtime_inspect.tscn"
+PROJECT_GODOT = GODOT_PROJECT / "project.godot"
+PROBE = "res://addons/godot_mcp/mcp_runtime_probe.gd"
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = await bridge.send(command, params)
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+async def _wait_scene_open(bridge: Bridge) -> None:
+    for _ in range(40):
+        r = await bridge.send("cmd_get_active_scene")
+        if r.ok and (r.result or {}).get("is_open"):
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("scene did not open")
+
+
+async def _wait_connected(bridge: Bridge) -> None:
+    for _ in range(30):
+        state = await _ok(bridge, "cmd_get_game_scene_tree", {})
+        if state.get("connected"):
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError("probe never connected")
+
+
+async def _poll(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    for _ in range(30):
+        r = await _ok(bridge, command, params)
+        if r.get("ready"):
+            return r
+        await asyncio.sleep(0.2)
+    raise AssertionError(f"{command} never became ready")
+
+
+async def _run() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    for _ in range(60):
+        try:
+            await bridge.connect()
+            break
+        except Exception:
+            await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("could not connect to the addon bridge")
+
+    try:
+        # build a scene with a Button, then save it so the played process loads it
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node2D", "scene_path": SCRATCH})
+        await _wait_scene_open(bridge)
+        await _ok(
+            bridge, "cmd_create_node", {"parent_path": ".", "node_type": "Button", "name": "Start"}
+        )
+        await _ok(
+            bridge,
+            "cmd_set_node_property",
+            {"node_path": "Start", "property": "text", "value": "Play"},
+        )
+        await _ok(bridge, "cmd_save_scene", {})
+
+        # precondition: inspection with no play session is a structured error
+        no_session = await bridge.send(
+            "cmd_monitor_property", {"node_path": "/root/x", "property": "position"}
+        )
+        assert no_session.ok is False and no_session.error == "PRECONDITION_FAILED"
+
+        await _ok(bridge, "cmd_register_autoload", {"name": "GodotMcpProbe", "path": PROBE})
+        await _ok(bridge, "cmd_play_scene", {"scene_path": SCRATCH})
+        await _wait_connected(bridge)
+
+        # find the live Button (with text + rect)
+        found = await _poll(bridge, "cmd_find_ui_elements", {"class_filter": "Button"})
+        buttons = [e for e in found["elements"] if e["name"] == "Start"]
+        assert buttons, f"Start button not found in {found['elements']}"
+        button = buttons[0]
+        assert button["node_class"] == "Button"
+        assert button["text"] == "Play"
+        assert "rect" in button and button["visible"] is True
+
+        # monitor a property over time on that live node
+        await _ok(
+            bridge,
+            "cmd_monitor_property",
+            {"node_path": button["path"], "property": "position", "samples": 5},
+        )
+        samples = await _poll(bridge, "cmd_get_property_samples", {})
+        assert samples["error"] == ""
+        assert len(samples["samples"]) == 5
+        assert "value" in samples["samples"][0]
+
+        # monitoring an invalid property reports an error (not a crash)
+        await _ok(
+            bridge,
+            "cmd_monitor_property",
+            {"node_path": button["path"], "property": "no_such_property_xyz", "samples": 3},
+        )
+        bad = await _poll(bridge, "cmd_get_property_samples", {})
+        assert bad["error"] != ""
+
+        await _ok(bridge, "cmd_stop_scene", {})
+    finally:
+        await bridge.close()
+
+
+def test_live_runtime_inspect() -> None:
+    assert GODOT_BIN is not None
+    snapshot = PROJECT_GODOT.read_bytes()
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        asyncio.run(_run())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        SCRATCH_FILE.unlink(missing_ok=True)
+        PROJECT_GODOT.write_bytes(snapshot)

--- a/tests/integration/test_runtime_inspect_e2e.py
+++ b/tests/integration/test_runtime_inspect_e2e.py
@@ -95,8 +95,10 @@ async def _run() -> None:
         await _ok(bridge, "cmd_play_scene", {"scene_path": SCRATCH})
         await _wait_connected(bridge)
 
-        # find the live Button (with text + rect)
-        found = await _poll(bridge, "cmd_find_ui_elements", {"class_filter": "Button"})
+        # find the live Button (with text + rect); request_id is stable across the poll
+        found = await _poll(
+            bridge, "cmd_find_ui_elements", {"class_filter": "Button", "request_id": "e2e-find-1"}
+        )
         buttons = [e for e in found["elements"] if e["name"] == "Start"]
         assert buttons, f"Start button not found in {found['elements']}"
         button = buttons[0]

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -341,6 +341,15 @@ def test_router_registers_input_sim_commands() -> None:
     assert "parse_input_event" in probe and "action_press" in probe
 
 
+def test_router_registers_runtime_inspect_commands() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    for command in ("cmd_monitor_property", "cmd_get_property_samples", "cmd_find_ui_elements"):
+        assert f'"{command}"' in source, f"router must register {command}"
+    # The probe must sample properties and collect Control nodes with their rect.
+    probe = (ADDON_DIR / "mcp_runtime_probe.gd").read_text()
+    assert "_start_monitor" in probe and "get_global_rect" in probe
+
+
 def test_mutations_use_undo_redo() -> None:
     source = (ADDON_DIR / "command_router.gd").read_text()
     # Every create/rename/delete/set must register with EditorUndoRedoManager.


### PR DESCRIPTION
## Summary
Completes runtime inspection on the #66 runtime-session rails — `get_game_scene_tree` shipped with #66, this adds the other two pieces: **watch a node property over time** and **locate live UI (Control) elements** in the running game. All `read_only` against the live session.

## Acceptance criteria
- [x] Addon: `EditorDebuggerPlugin` + probe (from #66); `cmd_get_game_scene_tree` (#66), `cmd_monitor_property`, `cmd_find_ui_elements` (+ `cmd_get_property_samples`)
- [x] MCP: `get_game_scene_tree` (#66), `monitor_property`/`get_property_samples`, `find_ui_elements` — `runtime`/`read_only`
- [x] Uses the `runtime` toolset; reads only against the live session
- [x] Godot APIs verified against current 4.6 docs (Control.get_global_rect / is_visible_in_tree / is_class, property-existence `in`)
- [x] Docs updated (`docs/tool-contracts.md`)

## Highlights
- `monitor_property` captures a bounded per-frame series (validates node/property, reports a structured `error`); the cache is cleared on each new monitor so polling can't read a stale capture.
- `find_ui_elements` returns each Control's path/class/visibility/global **rect**/text — the rect pairs with `simulate_mouse` (#36) to click located UI. The tool polls the addon cache until the result matches its filters (bounded by `timeout_ms`).

## Test plan
- Contract (`tests/contract/test_runtime_inspect.py`): gating + read_only, monitor + collect samples, find_ui_elements.
- Live e2e (`tests/integration/test_runtime_inspect_e2e.py`): real headless editor — build+save a Button scene, play, find the live Button (text + rect), monitor its `position` over 5 frames, and assert the invalid-property error path. `project.godot` snapshot/restored. Passed locally.
- Static checks (`tests/unit/test_addon_manifest.py`): router commands + probe (`_start_monitor`, `get_global_rect`).
- Preflight: ruff clean, mypy --strict clean, `pytest tests/contract tests/unit` (202 passed), zero-skip clean, addon loads/enables cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)