### PR TITLE
feat(input): record live input for replay (closes #68)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -442,6 +442,8 @@ follow-up #68.)
 | `simulate_action` | `action, pressed=True, strength=1.0` | `SimInputResult` |
 | `play_input_sequence` | `events[], delay_ms=0` | `SimInputResult { count = len(events) }` |
 | `get_input_stats` | — | `InputStatsResult { playing, connected, injected }` (read_only) |
+| `record_input` | `include_motion=False` | `RecordResult { recording }` |
+| `stop_recording` | `timeout_ms=2000` | `RecordingResult { ready, connected, events[] }` (read_only) |
 
 `key` is a Godot key name ("A", "Space", "Enter"). `simulate_mouse` sends motion when
 `button` is empty, else a button event (left/right/middle/wheel_up/wheel_down).
@@ -452,6 +454,11 @@ front (bad `type`/missing field/unknown button → `VALIDATION_ERROR`), so `coun
 events sent. All injection requires a live probe (else `PRECONDITION_FAILED`,
 `required=play_session` / `runtime_probe`). `get_input_stats.injected` is the count of
 synthesized events the game has acknowledged — use it to confirm delivery.
+`record_input` (issue #68) captures the input the game receives — key + mouse button, plus
+mouse motion when `include_motion` — via the probe's `_input` hook; `stop_recording`
+returns the buffered `events` in the same `play_input_sequence` format, so a recording
+replays directly (regression). Since `parse_input_event` also fires `_input`, synthesized
+input is recorded too.
 
 #### Runtime inspection (issue #35) — `runtime` toolset, `read_only`
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -137,6 +137,10 @@ func _init() -> void:
 	_handlers["cmd_monitor_property"] = _cmd_monitor_property
 	_handlers["cmd_get_property_samples"] = _cmd_get_property_samples
 	_handlers["cmd_find_ui_elements"] = _cmd_find_ui_elements
+	# Input recording (issue #68) — capture live input for replay.
+	_handlers["cmd_record_input"] = _cmd_record_input
+	_handlers["cmd_stop_recording"] = _cmd_stop_recording
+	_handlers["cmd_get_recording"] = _cmd_get_recording
 
 
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
@@ -2259,6 +2263,36 @@ func _cmd_find_ui_elements(params: Dictionary) -> Dictionary:
 			"request_id": request_id,
 		}])
 	return _ok({"ready": false, "elements": []})
+
+
+# --- input recording (issue #68) -------------------------------------------
+
+func _cmd_record_input(params: Dictionary) -> Dictionary:
+	var guard := _require_live_probe()
+	if not guard["ok"]:
+		return guard
+	_debugger.clear_recorded_input()  # drop any prior recording so stop reads this one
+	_debugger.send_to_probe("godot_mcp:record_start", [{
+		"include_motion": bool(params.get("include_motion", false)),
+	}])
+	return _ok({"recording": true})
+
+
+func _cmd_stop_recording(_params: Dictionary) -> Dictionary:
+	var guard := _require_live_probe()
+	if not guard["ok"]:
+		return guard
+	_debugger.send_to_probe("godot_mcp:record_stop", [])
+	return _ok({"recording": false})
+
+
+func _cmd_get_recording(_params: Dictionary) -> Dictionary:
+	if _debugger == null or not _debugger.is_connected_to_probe():
+		return _ok({"ready": false, "connected": false, "events": []})
+	var payload: Variant = _debugger.get_recorded_input()
+	if payload == null:
+		return _ok({"ready": false, "connected": true, "events": []})
+	return _ok({"ready": true, "connected": true, "events": (payload as Dictionary).get("events", [])})
 
 
 # --- editor screenshots (issue #33) ----------------------------------------

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -2282,6 +2282,9 @@ func _cmd_stop_recording(_params: Dictionary) -> Dictionary:
 	var guard := _require_live_probe()
 	if not guard["ok"]:
 		return guard
+	# Drop any prior recording first so get_recording reflects THIS stop's push, even if
+	# stop_recording is called without a preceding record_input.
+	_debugger.clear_recorded_input()
 	_debugger.send_to_probe("godot_mcp:record_stop", [])
 	return _ok({"recording": false})
 

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -19,6 +19,7 @@ var _input_acks: int = 0  # count of synthesized inputs the game has acknowledge
 var _property_samples: Variant = null  # last godot_mcp:property_samples payload (#35)
 var _ui_elements: Variant = null  # last godot_mcp:ui_elements payload (#35)
 var _ui_pending := "__none__"  # request_id of the in-flight find_ui request (#35)
+var _recorded_input: Variant = null  # last godot_mcp:recorded_input payload (#68)
 
 
 func _has_capture(capture: String) -> bool:
@@ -46,6 +47,9 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 		"godot_mcp:ui_elements":
 			_ui_elements = data[0] if not data.is_empty() else null
 			return true
+		"godot_mcp:recorded_input":
+			_recorded_input = data[0] if not data.is_empty() else null
+			return true
 	return false
 
 
@@ -69,6 +73,7 @@ func _on_stopped() -> void:
 	_property_samples = null
 	_ui_elements = null
 	_ui_pending = "__none__"
+	_recorded_input = null
 
 
 ## Ask the running game's probe to (re)send the scene tree. The reply lands in the cache
@@ -127,3 +132,12 @@ func get_pending_ui_request() -> String:
 func begin_ui_request(request_id: String) -> void:
 	_ui_pending = request_id
 	_ui_elements = null
+
+
+func get_recorded_input() -> Variant:
+	return _recorded_input
+
+
+## Drop the cached recording so stop_recording reads the new capture, not a prior one.
+func clear_recorded_input() -> void:
+	_recorded_input = null

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -43,6 +43,12 @@ func _capture(message: String, data: Array) -> bool:
 		"find_ui":
 			EngineDebugger.send_message("godot_mcp:ui_elements", [_find_ui(_payload(data))])
 			return true
+		"record_start":
+			_record_start(_payload(data))
+			return true
+		"record_stop":
+			_record_stop()
+			return true
 	return false
 
 
@@ -246,6 +252,74 @@ func _ui_element(control: Control) -> Dictionary:
 	if "text" in control:  # Button / Label / LineEdit / …
 		element["text"] = str(control.text)
 	return element
+
+
+# --- input recording (issue #68) -------------------------------------------
+
+const _RECORD_CAP := 2000  # bound the buffer so a long recording can't grow unbounded
+
+var _recording := false
+var _record_motion := false
+var _recorded: Array = []
+
+
+## Capture input the running game receives (in the play_input_sequence event format) so it
+## can be replayed for regression. Runs only while recording is active.
+func _input(event: InputEvent) -> void:
+	if not _recording:
+		return
+	var rec := _serialize_event(event)
+	if not rec.is_empty() and _recorded.size() < _RECORD_CAP:
+		_recorded.append(rec)
+
+
+func _record_start(d: Dictionary) -> void:
+	_record_motion = bool(d.get("include_motion", false))
+	_recorded = []
+	_recording = true
+
+
+func _record_stop() -> void:
+	_recording = false
+	EngineDebugger.send_message("godot_mcp:recorded_input", [{"events": _recorded}])
+
+
+## Serialize an InputEvent into the {type, …} shape play_input_sequence replays, or {} to
+## skip (unhandled event kinds, motion when not requested, unmapped buttons/keys).
+func _serialize_event(event: InputEvent) -> Dictionary:
+	if event is InputEventKey:
+		var key := OS.get_keycode_string(event.keycode)
+		if key.is_empty():
+			return {}
+		return {
+			"type": "key", "key": key, "pressed": event.pressed,
+			"shift": event.shift_pressed, "ctrl": event.ctrl_pressed,
+			"alt": event.alt_pressed, "meta": event.meta_pressed,
+		}
+	if event is InputEventMouseButton:
+		var button := _button_name(event.button_index)
+		if button.is_empty():
+			return {}
+		return {
+			"type": "mouse", "x": event.position.x, "y": event.position.y,
+			"button": button, "pressed": event.pressed,
+		}
+	if event is InputEventMouseMotion:
+		if not _record_motion:
+			return {}
+		return {
+			"type": "mouse", "x": event.position.x, "y": event.position.y,
+			"relative_x": event.relative.x, "relative_y": event.relative.y,
+		}
+	return {}
+
+
+## Reverse of _MOUSE_BUTTONS: button index → name, or "" if not a recognized button.
+func _button_name(index: int) -> String:
+	for name in _MOUSE_BUTTONS:
+		if _MOUSE_BUTTONS[name] == index:
+			return name
+	return ""
 
 
 ## Minimal JSON-safe conversion for monitored property values (common Godot types).

--- a/mcp_server/models/input_sim.py
+++ b/mcp_server/models/input_sim.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class SimInputResult(BaseModel):
@@ -15,3 +17,14 @@ class InputStatsResult(BaseModel):
     playing: bool
     connected: bool = False
     injected: int = 0  # synthesized input events the running game has acknowledged
+
+
+class RecordResult(BaseModel):
+    recording: bool
+
+
+class RecordingResult(BaseModel):
+    ready: bool = False
+    connected: bool = False
+    # Captured events in the play_input_sequence format — pass straight to that tool.
+    events: list[dict[str, Any]] = Field(default_factory=list)

--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -10,6 +10,7 @@ the calling tool is decorated with ``@enforce_preconditions`` (read-only tools a
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastmcp.exceptions import ToolError
@@ -34,3 +35,22 @@ async def route(
             detail = f"{detail} [required={response.required}]"
         raise ToolError(detail)
     return response.result or {}
+
+
+async def poll_ready(
+    bridge: Bridge, command: str, params: dict[str, Any], timeout_ms: int
+) -> dict[str, Any]:
+    """Poll a poll-and-cache command until its result is ``ready`` or ``timeout_ms``
+    elapses (whichever first), returning the last result. Uses an event-loop deadline so
+    the wall-clock bound holds even for small timeouts and accounts for round-trip time.
+    Always makes at least one attempt.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout_ms / 1000
+    result = await route(bridge, command, params)
+    while not result.get("ready"):
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            break
+        await asyncio.sleep(min(0.1, remaining))
+        result = await route(bridge, command, params)
+    return result

--- a/mcp_server/tools/input_sim.py
+++ b/mcp_server/tools/input_sim.py
@@ -11,7 +11,6 @@ is `runtime`, reads are `read_only`.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from fastmcp import FastMCP
@@ -25,7 +24,7 @@ from mcp_server.models.input_sim import (
     SimInputResult,
 )
 from mcp_server.safety import READ_ONLY, RUNTIME
-from mcp_server.tools._route import route
+from mcp_server.tools._route import poll_ready, route
 
 INPUT = {INPUT_TAG}
 
@@ -124,11 +123,5 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
         buffered sequence.
         """
         await route(bridge, "cmd_stop_recording", {})
-        attempts = max(1, timeout_ms // 100)
-        result: dict[str, Any] = {"ready": False, "connected": False, "events": []}
-        for _ in range(attempts):
-            result = await route(bridge, "cmd_get_recording", {})
-            if result.get("ready"):
-                break
-            await asyncio.sleep(0.1)
+        result = await poll_ready(bridge, "cmd_get_recording", {}, timeout_ms)
         return RecordingResult(**result)

--- a/mcp_server/tools/input_sim.py
+++ b/mcp_server/tools/input_sim.py
@@ -1,23 +1,29 @@
 """Input simulation tools (issue #36).
 
-Drive a *running* game over the bridge: synthesize key/mouse/action input and play
-input sequences. Built on the #66 runtime-session rails — the game must be running from
-the editor with the godot-mcp runtime probe autoload, which receives ``godot_mcp:`` input
-messages and calls ``Input.parse_input_event`` / ``Input.action_press`` on itself. Gated
-`input` toolset; injection is `runtime`, stats are `read_only`.
-
-(Recording live input for replay is the follow-up issue #68.)
+Drive a *running* game over the bridge: synthesize key/mouse/action input, play input
+sequences, and record the input the game receives for replay (#68). Built on the #66
+runtime-session rails — the game must be running from the editor with the godot-mcp
+runtime probe autoload, which receives ``godot_mcp:`` input messages and calls
+``Input.parse_input_event`` / ``Input.action_press`` on itself (and buffers events via
+its ``_input`` hook while recording). Gated `input` toolset; injection/recording-control
+is `runtime`, reads are `read_only`.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import INPUT_TAG
-from mcp_server.models.input_sim import InputStatsResult, SimInputResult
+from mcp_server.models.input_sim import (
+    InputStatsResult,
+    RecordingResult,
+    RecordResult,
+    SimInputResult,
+)
 from mcp_server.safety import READ_ONLY, RUNTIME
 from mcp_server.tools._route import route
 
@@ -101,3 +107,28 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
         use it to confirm injected input is reaching the game.
         """
         return InputStatsResult(**await route(bridge, "cmd_get_input_stats", {}))
+
+    @mcp.tool(meta=RUNTIME, tags=INPUT)
+    async def record_input(include_motion: bool = False) -> RecordResult:
+        """Start recording the input the running game receives (key + mouse button;
+        mouse motion only when ``include_motion``). Stop and collect it with
+        ``stop_recording``; the result feeds straight back into ``play_input_sequence``.
+        """
+        params = {"include_motion": include_motion}
+        return RecordResult(**await route(bridge, "cmd_record_input", params))
+
+    @mcp.tool(meta=READ_ONLY, tags=INPUT)
+    async def stop_recording(timeout_ms: int = 2000) -> RecordingResult:
+        """Stop recording and return the captured ``events`` (in the
+        ``play_input_sequence`` format). Polls the addon up to ``timeout_ms`` for the
+        buffered sequence.
+        """
+        await route(bridge, "cmd_stop_recording", {})
+        attempts = max(1, timeout_ms // 100)
+        result: dict[str, Any] = {"ready": False, "connected": False, "events": []}
+        for _ in range(attempts):
+            result = await route(bridge, "cmd_get_recording", {})
+            if result.get("ready"):
+                break
+            await asyncio.sleep(0.1)
+        return RecordingResult(**result)

--- a/mcp_server/tools/runtime_inspect.py
+++ b/mcp_server/tools/runtime_inspect.py
@@ -8,9 +8,7 @@ runtime probe. All `read_only` against the live session, in the `runtime` toolse
 
 from __future__ import annotations
 
-import asyncio
 import uuid
-from typing import Any
 
 from fastmcp import FastMCP
 
@@ -22,7 +20,7 @@ from mcp_server.models.runtime_inspect import (
     UiElementsResult,
 )
 from mcp_server.safety import READ_ONLY
-from mcp_server.tools._route import route
+from mcp_server.tools._route import poll_ready, route
 
 RUNTIME_SET = {RUNTIME_TAG}
 
@@ -68,13 +66,7 @@ def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
             # once and we never match a prior identical-filter request's stale result.
             "request_id": uuid.uuid4().hex,
         }
-        # The probe answers asynchronously; poll the addon's cache until it reflects this
-        # request (or the timeout elapses). Bounded, ~100ms cadence.
-        attempts = max(1, timeout_ms // 100)
-        result: dict[str, Any] = {"ready": False, "elements": []}
-        for _ in range(attempts):
-            result = await route(bridge, "cmd_find_ui_elements", params)
-            if result.get("ready"):
-                break
-            await asyncio.sleep(0.1)
+        # The probe answers asynchronously; poll the addon's cache (which dispatches one
+        # scan for this request_id) until it reflects this request or timeout_ms elapses.
+        result = await poll_ready(bridge, "cmd_find_ui_elements", params, timeout_ms)
         return UiElementsResult(**result)

--- a/tests/contract/test_input_sim.py
+++ b/tests/contract/test_input_sim.py
@@ -31,6 +31,19 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             return ResponseEnvelope.success(
                 cmd.id, {"playing": True, "connected": True, "injected": 3}
             )
+        case "cmd_record_input":
+            return ResponseEnvelope.success(cmd.id, {"recording": True})
+        case "cmd_stop_recording":
+            return ResponseEnvelope.success(cmd.id, {"recording": False})
+        case "cmd_get_recording":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "ready": True,
+                    "connected": True,
+                    "events": [{"type": "key", "key": "Space", "pressed": True}],
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -90,3 +103,23 @@ async def test_get_input_stats() -> None:
         stats = await client.call_tool("get_input_stats", {})
     assert stats.structured_content["connected"] is True
     assert stats.structured_content["injected"] == 3
+
+
+async def test_record_and_stop_returns_replayable_events() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "input"})
+        rec = await client.call_tool("record_input", {})
+        stopped = await client.call_tool("stop_recording", {})
+    assert rec.structured_content["recording"] is True
+    events = stopped.structured_content["events"]
+    assert events and events[0]["type"] == "key" and events[0]["key"] == "Space"
+
+
+async def test_record_input_safety_classes() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "input"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["record_input"].meta["safety_class"] == "runtime"
+    assert tools["stop_recording"].meta["safety_class"] == "read_only"

--- a/tests/integration/test_input_recording_e2e.py
+++ b/tests/integration/test_input_recording_e2e.py
@@ -1,0 +1,132 @@
+"""End-to-end input recording test against a live editor (issue #68).
+
+On the #66 rails: synthesized input (Input.parse_input_event) also generates _input
+calls, so the probe's recording hook captures it — record, inject, stop, and the
+captured events come back in the play_input_sequence format (then replay them).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://localhost:9080"
+SCRATCH = "res://tmp_e2e_input_rec.tscn"
+SCRATCH_FILE = GODOT_PROJECT / "tmp_e2e_input_rec.tscn"
+PROJECT_GODOT = GODOT_PROJECT / "project.godot"
+PROBE = "res://addons/godot_mcp/mcp_runtime_probe.gd"
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = await bridge.send(command, params)
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+async def _wait_scene_open(bridge: Bridge) -> None:
+    for _ in range(40):
+        r = await bridge.send("cmd_get_active_scene")
+        if r.ok and (r.result or {}).get("is_open"):
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("scene did not open")
+
+
+async def _wait_connected(bridge: Bridge) -> None:
+    for _ in range(30):
+        state = await _ok(bridge, "cmd_get_game_scene_tree", {})
+        if state.get("connected"):
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError("probe never connected")
+
+
+async def _wait_injected(bridge: Bridge, at_least: int) -> None:
+    for _ in range(20):
+        if (await _ok(bridge, "cmd_get_input_stats", {}))["injected"] >= at_least:
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("injected count not reached")
+
+
+async def _run() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    for _ in range(60):
+        try:
+            await bridge.connect()
+            break
+        except Exception:
+            await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("could not connect to the addon bridge")
+
+    try:
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node2D", "scene_path": SCRATCH})
+        await _wait_scene_open(bridge)
+
+        # precondition: recording with no play session is a structured error
+        no_session = await bridge.send("cmd_record_input", {})
+        assert no_session.ok is False and no_session.error == "PRECONDITION_FAILED"
+
+        await _ok(bridge, "cmd_register_autoload", {"name": "GodotMcpProbe", "path": PROBE})
+        await _ok(bridge, "cmd_play_scene", {"scene_path": SCRATCH})
+        await _wait_connected(bridge)
+
+        # record, then synthesize input (parse_input_event also fires _input -> captured)
+        await _ok(bridge, "cmd_record_input", {})
+        await _ok(bridge, "cmd_simulate_key", {"key": "Space", "pressed": True})
+        await _ok(bridge, "cmd_simulate_mouse", {"x": 7, "y": 9, "button": "left"})
+        await _wait_injected(bridge, 2)
+        await asyncio.sleep(0.3)  # let the _input callbacks land in the buffer
+        await _ok(bridge, "cmd_stop_recording", {})
+
+        events: list[dict[str, Any]] = []
+        for _ in range(30):
+            rec = await _ok(bridge, "cmd_get_recording", {})
+            if rec.get("ready"):
+                events = rec["events"]
+                break
+            await asyncio.sleep(0.2)
+        kinds = {e["type"] for e in events}
+        assert "key" in kinds, f"no key event captured: {events}"
+        assert any(e["type"] == "key" and e.get("key") == "Space" for e in events)
+        assert any(e["type"] == "mouse" and e.get("button") == "left" for e in events)
+
+        # the captured sequence replays straight back through play_input_sequence
+        replayed = await _ok(bridge, "cmd_play_input_sequence", {"events": events})
+        assert replayed["sent"] is True
+
+        await _ok(bridge, "cmd_stop_scene", {})
+    finally:
+        await bridge.close()
+
+
+def test_live_input_recording() -> None:
+    assert GODOT_BIN is not None
+    snapshot = PROJECT_GODOT.read_bytes()
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        asyncio.run(_run())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        SCRATCH_FILE.unlink(missing_ok=True)
+        PROJECT_GODOT.write_bytes(snapshot)

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -350,6 +350,15 @@ def test_router_registers_runtime_inspect_commands() -> None:
     assert "_start_monitor" in probe and "get_global_rect" in probe
 
 
+def test_router_registers_input_recording_commands() -> None:
+    source = (ADDON_DIR / "command_router.gd").read_text()
+    for command in ("cmd_record_input", "cmd_stop_recording", "cmd_get_recording"):
+        assert f'"{command}"' in source, f"router must register {command}"
+    # The probe must capture input via _input and serialize events for replay.
+    probe = (ADDON_DIR / "mcp_runtime_probe.gd").read_text()
+    assert "func _input(" in probe and "_serialize_event" in probe
+
+
 def test_mutations_use_undo_redo() -> None:
     source = (ADDON_DIR / "command_router.gd").read_text()
     # Every create/rename/delete/set must register with EditorUndoRedoManager.


### PR DESCRIPTION
## Summary
Completes the input story (split from #36) on the #66 runtime-session rails: **record** the input the running game receives so it can be replayed via `play_input_sequence` for regression. The probe's `_input` hook buffers events into the same `{type, …}` format the synthesis tools consume.

## Acceptance criteria
- [x] Addon (probe): `_input`/buffer while recording; `godot_mcp:record_start` / `record_stop`; pushes the buffered sequence
- [x] Addon (router): `cmd_record_input` / `cmd_stop_recording` (+ internal `cmd_get_recording`)
- [x] MCP: `record_input` (`runtime`) / `stop_recording` (`read_only`), returning a `play_input_sequence`-consumable sequence
- [x] Docs updated (`docs/tool-contracts.md`)

## Highlights
- Recorded events are in the exact `play_input_sequence` format → a recording replays directly.
- Because `Input.parse_input_event` also fires `_input`, synthesized input is recorded too — which the e2e exploits to verify capture without a real user.

## Test plan
- Contract (`tests/contract/test_input_sim.py`): record → stop returns replayable events; record_input=`runtime` / stop_recording=`read_only`.
- Live e2e (`tests/integration/test_input_recording_e2e.py`): real headless editor — precondition with no session; record, synthesize a key + mouse-button, stop, assert both captured in replay format, then replay them via `play_input_sequence`. `project.godot` snapshot/restored. Passed locally.
- Static checks (`tests/unit/test_addon_manifest.py`): router commands + probe (`_input`, `_serialize_event`).
- Preflight: ruff clean, mypy --strict clean, `pytest tests/contract tests/unit` (205 passed), zero-skip clean, addon loads/enables cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)