### PR TITLE
docs: refresh README/architecture/CLAUDE for the completed ecosystem (closes #77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Current state
 
-The engine is built: scaffold (#1), addon + status dock (#2), WebSocket bridge (#3), FastMCP server (#4), read-only inspection tools (#5), the safety framework (#14), and safe scene mutation tools (#6) are merged. Remaining godot-mcp work: script read/patch (#10), `godot://` resources (#11), and the runtime loop (#13). The GitHub issues are the authoritative spec; read the relevant issue before implementing a piece.
+The planned ecosystem is **feature-complete**: the engine (scaffold #1, addon + dock #2, bridge #3, server #4, inspection #5, safety #14, mutation #6, scripts #10, `godot://` resources #11, runtime loop #13, toolset gating #26) plus every content domain and capability — physics #41, animation #39, 3D scene #40, particles #42, navigation #43, audio #44, tilemap #45, theme/UI #46, shaders #47, the runtime session bridge #66 (live inspection #35, input sim #36 + recording #68, profiling #38), play-testing/QA #37, batch refactor #48, static analysis #49, and export #50 — are merged. 116 tools across 22 gated toolsets (plus always-on `core`). New work now means new GitHub issues; the issues remain the authoritative spec, so read the relevant one before implementing. `docs/tool-contracts.md` is the source of truth for the current tool surface.
 
 **godot-mcp is a generic, game-agnostic Godot MCP server.** It exposes Godot editor capabilities (inspection, scene mutation, scripts, runtime) over MCP — it has no built-in game vocabulary. Any specific game (e.g. a tower-defense roguelite) is a **separate project** that consumes this server; its domain models, semantic tools, and prompts live in that project, not here.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ A **generic, game-agnostic** system for **AI-driven Godot development**. An AI c
 server — generic editor control (inspection, scene mutation, scripts, runtime), with no
 built-in game vocabulary. A specific game is a separate project that consumes this server.
 
-> **Status:** engine built — bridge, server, inspection, safety, and scene mutation tools
-> are merged; script/resource/runtime tools are next. The open
-> GitHub issues are the authoritative spec — see `gh issue list`.
+> **Status:** feature-complete across the planned ecosystem — inspection, scene mutation,
+> scripts, resources, project/filesystem, screenshots, the full content domains (physics,
+> animation, 3D, particles, navigation, audio, tilemap, theme/UI, shaders), the runtime
+> session bridge (live inspection, input simulation/recording, profiling), play-testing/QA,
+> batch refactor, static analysis, and export are all merged. 116 tools across 22 gated
+> toolsets (plus always-on `core`). See [`docs/tool-contracts.md`](docs/tool-contracts.md)
+> for the full surface.
 
 ## Architecture
 
@@ -46,20 +50,33 @@ godot/
   project.godot              minimal Godot project so the addon is loadable
   addons/godot_mcp/
     plugin.cfg               addon manifest (Godot 4.4+)
-    godot_mcp.gd             EditorPlugin entry point (fleshed out in issue #2)
+    godot_mcp.gd             EditorPlugin entry point (dock, bridge, debugger plugin)
+    mcp_bridge.gd            TCPServer + WebSocketPeer; receives command envelopes
+    command_router.gd        routes cmd_* envelopes to handlers (the only Godot-touching code)
+    mcp_dock.gd              read-only status dock (connection/scene/recent commands)
+    scene_inspect.gd         JSON-safe scene-tree / node serialization
+    type_coerce.gd           Godot ↔ JSON type coercion (Vector2/3, Color, …)
+    mcp_debugger.gd          EditorDebuggerPlugin: captures a played game's godot_mcp channel
+    mcp_runtime_probe.gd     game-side autoload for live runtime inspection/input (see below)
 mcp_server/                  FastMCP server (Python 3.11+)
-  main.py                    stdio entrypoint (bootstrapped in issue #4)
+  main.py                    stdio / Streamable-HTTP entrypoint
+  server.py                  server factory: wires the bridge + registers all tool groups
+  bridge.py                  async WebSocket client (id correlation, timeout, backoff)
+  toolsets.py / categories.py  the gated toolset system (enable_toolset)
+  safety.py                  safety classes, preconditions, dry_run/confirm
+  runtime.py                 headless run / export subprocess (GodotRunner)
+  qa.py / analysis.py        play-testing + static-analysis logic (pure, off the bridge)
   tools/                     @mcp.tool() handlers (delegation only)
-  resources/                 godot://… read-only resources (issue #11)
-  prompts/                   workflow prompt templates (issue #12)
-  models/                    Pydantic domain models (issue #7)
+  resources/                 godot://… read-only resources
+  models/                    Pydantic typed tool I/O
+  prompts/                   reserved (no prompts shipped — the planned set was game-specific)
 tests/
-  contract/                  envelope shapes + tool schemas
-  integration/               server ↔ fake/real bridge
+  contract/                  envelope shapes + tool schemas (fake bridge)
+  integration/               live headless-editor e2e (skipped when Godot isn't installed)
   unit/                      isolated logic
 docs/
-  architecture.md            bridge contract + JSON envelope format
-  tool-contracts.md          tool/resource/prompt schema spec
+  architecture.md            bridge contract, JSON envelope, runtime session bridge
+  tool-contracts.md          the full tool/resource surface, per toolset
 ```
 
 ## Local dev setup
@@ -95,10 +112,12 @@ pytest
 
 ### Bootstrap (Godot / addon)
 
-1. Open the `godot/` folder as a project in Godot **4.4+**.
+1. Open the `godot/` folder as a project in Godot **4.4+** (or copy `addons/godot_mcp/`
+   into your own project's `addons/`).
 2. Enable the addon: **Project → Project Settings → Plugins → godot_mcp → Enable**.
-3. The status dock appears once issue #2 lands; the bridge listens on
-   `ws://localhost:9080` by default (configurable, localhost-only, no auth in v1).
+3. A read-only status dock appears (connection state, project/scene/selected node, recent
+   commands); the bridge listens on `ws://localhost:9080` by default (configurable,
+   localhost-only, no auth in v1).
 
 ### Running the server
 
@@ -118,8 +137,10 @@ Configuration (all optional, env vars):
 | `GODOT_MCP_TRANSPORT` | `stdio` | `stdio` or `http` |
 | `GODOT_MCP_HTTP_HOST` / `GODOT_MCP_HTTP_PORT` | `127.0.0.1` / `9090` | HTTP bind (when `transport=http`) |
 | `GODOT_MCP_BRIDGE_URL` | `ws://localhost:9080` | Godot addon WebSocket URL |
+| `GODOT_MCP_GODOT_BIN` | auto-discovered | Godot executable for headless run/export (else `PATH` / known locations) |
+| `GODOT_MCP_PROJECT_DIR` | connected editor's project | project dir for the runner, export, and static analysis |
 | `GODOT_MCP_LOG_LEVEL` | `INFO` | log level (JSON logs → stderr) |
-| `GODOT_MCP_PERMISSION_MODE` | `ask` | tool permission mode (enforced in issue #14) |
+| `GODOT_MCP_PERMISSION_MODE` | `ask` | reserved permission mode (plumbed in config; not yet enforced — safety is via per-tool classes + `dry_run`/`confirm`) |
 
 ### Connecting an MCP client
 
@@ -154,6 +175,44 @@ server version and Godot bridge connection state.
 
 Both assume the command runs from the repo root (so `uv` resolves this project's
 environment). Use an absolute path or a `--directory` if launching elsewhere.
+
+## Toolsets (keeping the tool surface small)
+
+With ~116 tools, exposing them all at once would degrade an agent's tool selection, so
+tools are grouped into **toolsets** and most are **gated off by default**. Only `core`
+(diagnostics + toolset management) and `inspection` are exposed initially. The agent turns
+others on at runtime with the always-available meta-tools:
+
+- `list_toolsets` — discover the toolsets and which are enabled.
+- `enable_toolset(category)` / `disable_toolset(category)` — expose/hide a toolset's tools
+  (fires `tools/list_changed`). This only changes tool *exposure*; it never touches the project.
+
+Available toolsets: `inspection`, `scene_edit`, `scripts`, `resources_edit`, `project`,
+`editor`, `physics`, `animation`, `scene_3d`, `particles`, `navigation`, `audio`, `tilemap`,
+`theme_ui`, `shader`, `runtime`, `input`, `testing`, `profiling`, `batch`, `analysis`,
+`export`. Each tool is tagged with one category and a **safety class**
+(`read_only` / `mutating` / `destructive` / `runtime`); `mutating`/`destructive` tools take
+`dry_run`, and `destructive` ones require `confirm=true`. `list_tools_by_safety_class`
+reports the grouping. See [`docs/tool-contracts.md`](docs/tool-contracts.md) for the full,
+per-toolset surface.
+
+## Live runtime tools (the probe autoload)
+
+Inspecting or driving a **running** game — the `runtime` tools (`play_scene`,
+`get_game_scene_tree`, `monitor_property`, `find_ui_elements`), `input`
+(`simulate_*`, `play_input_sequence`, `record_input`), `testing`, and the live half of
+`profiling` — works by launching the game **from the editor** so it connects to the editor's
+debugger. Because a custom debugger plugin can't read the engine's remote tree, the running
+game must cooperate via a small **probe autoload** that godot-mcp ships:
+
+1. In your game's project, add `res://addons/godot_mcp/mcp_runtime_probe.gd` as an
+   **autoload** (Project → Project Settings → Globals/Autoload). Any node name works.
+2. Then `play_scene` → the probe connects, and the runtime/input/profiling tools work
+   against the live game. It no-ops outside a debug session, so it's safe to leave enabled.
+
+Without the probe, those tools report `connected: false` (with a hint) rather than failing —
+the editor-control, scene-edit, and static tools need no probe. (`run_and_capture` and
+`export_project` instead run Godot as a headless subprocess and don't use the probe.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ godot/
     plugin.cfg               addon manifest (Godot 4.4+)
     godot_mcp.gd             EditorPlugin entry point (dock, bridge, debugger plugin)
     mcp_bridge.gd            TCPServer + WebSocketPeer; receives command envelopes
-    command_router.gd        routes cmd_* envelopes to handlers (the only Godot-touching code)
+    command_router.gd        dispatches cmd_* envelopes to the cmd_* Godot-API handlers
     mcp_dock.gd              read-only status dock (connection/scene/recent commands)
     scene_inspect.gd         JSON-safe scene-tree / node serialization
     type_coerce.gd           Godot ↔ JSON type coercion (Vector2/3, Color, …)
@@ -210,9 +210,13 @@ game must cooperate via a small **probe autoload** that godot-mcp ships:
 2. Then `play_scene` → the probe connects, and the runtime/input/profiling tools work
    against the live game. It no-ops outside a debug session, so it's safe to leave enabled.
 
-Without the probe, those tools report `connected: false` (with a hint) rather than failing —
-the editor-control, scene-edit, and static tools need no probe. (`run_and_capture` and
-`export_project` instead run Godot as a headless subprocess and don't use the probe.)
+Without the probe, those tools never hang — they either report `connected: false` with a
+hint (e.g. `get_game_scene_tree`, `get_performance_monitors`) or return a structured
+`PRECONDITION_FAILED` (`required: play_session` before you `play_scene`, or
+`required: runtime_probe` when playing without the autoload — e.g. `simulate_*`,
+`monitor_property`, `record_input`). The editor-control, scene-edit, and static tools need
+no probe. (`run_and_capture` and `export_project` instead run Godot as a headless
+subprocess and don't use the probe.)
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,8 +149,37 @@ to Godot" (Article II): running the game for verification is *process execution*
 not *editor control*, and Godot exposes no public GDScript API to read the editor's
 Output/error log, so the addon cannot capture a separate game process's stdio. The
 bridge stays the only path for editor control; the runner is isolated in
-`mcp_server/runtime.py` with an injected subprocess so it stays testable. Interactive
-in-editor play/stop (via `EditorInterface.play_*`) is a possible later addition.
+`mcp_server/runtime.py` with an injected subprocess so it stays testable. The runner also
+drives `export_project` (issue #50) — `godot --headless --export-release|--export-debug` —
+for the same reason (process execution, not editor control).
+
+## Runtime session bridge (issue #66)
+
+To inspect or drive a *running* game (issues #35 inspection, #36/#68 input, #38 profiling),
+the game must be launched **from the editor** so it connects back to the editor's remote
+debugger — a fifth interaction path, distinct from the headless subprocess above:
+
+```
+server ──cmd_play_scene──> addon ──EditorInterface.play_*──> game process
+game ──EngineDebugger("godot_mcp:…")──> editor debugger ──> MCPDebugger (EditorDebuggerPlugin)
+```
+
+Why this shape: a custom `EditorDebuggerPlugin` only receives messages with its own prefix
+and there is no public API to read the engine's built-in remote scene tree, so live
+interaction needs **game-side cooperation**. The consuming project opts in by adding the
+shipped `addons/godot_mcp/mcp_runtime_probe.gd` as an **autoload**; it registers an
+`EngineDebugger` capture on the `godot_mcp:` channel and answers queries (scene tree,
+property samples, find-UI, input injection, performance monitors).
+
+- `mcp_debugger.gd` (`MCPDebugger`, an `EditorDebuggerPlugin` added in `_enter_tree`)
+  captures the channel, tracks session start/stop, and **caches** the probe's replies.
+- Because the WebSocket bridge is synchronous (one request → one response), the round-trip
+  to the running game is **poll-and-cache**: a command sends a request to the probe and
+  returns the latest cached reply; the MCP tool polls until the result is fresh (a
+  `request_id` for find-UI; a clear-on-new for property samples). This avoids making the
+  core bridge async.
+- Without the probe autoload, runtime tools return `connected: false` (with a hint) or a
+  `PRECONDITION_FAILED` (`required: play_session` / `runtime_probe`) — never a hang.
 
 ## Health check
 


### PR DESCRIPTION
## Summary
Documentation-only refresh. An audit confirmed `docs/tool-contracts.md` already covers all 116 tools across the 22 gated toolsets; this updates the prose docs that had lagged and adds two missing user-facing topics.

## Changes
- **README**: feature-complete status; accurate addon file layout (dropped "(issue #N)" placeholders; `prompts/` noted unused); config table adds `GODOT_MCP_GODOT_BIN` / `GODOT_MCP_PROJECT_DIR` and corrects `permission_mode` (reserved, not enforced); reworded addon bootstrap. **New sections:** the gated **Toolsets** model (`enable_toolset`, default surface = `core` + `inspection`, the 22 toolsets, safety classes) and the **runtime probe autoload** setup for the live runtime/input/profiling tools.
- **docs/architecture.md**: new **Runtime session bridge (#66)** section (editor play → editor debugger → `MCPDebugger` + probe, poll-and-cache); updated the runtime-execution note (export uses the runner; editor-play is shipped, not "a possible later addition").
- **CLAUDE.md**: "Current state" reflects the completed ecosystem and points at `docs/tool-contracts.md` as the tool-surface source of truth.

## Verification
- Audited: all 116 registered `@mcp.tool` names appear in `tool-contracts.md`; every documented `cmd_*` exists in the addon router; no remaining stale "is next / lands / issue #N" status phrasing (only a contributor template line).
- No code changed, so server preflight (ruff/mypy/tests) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)