### PR TITLE
feat(addon): set minimum Godot version to 4.4 with an enable-time guard (closes #86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ docs/
 
 ### Prerequisites
 
-- **Godot 4.4+** — the addon targets the Godot 4.4 editor API.
+- **Godot 4.4+** — **4.4 is the minimum supported version**; the addon warns on enable if
+  the editor is older. Built against the 4.4 editor API and validated against 4.6.x.
 - **Python 3.11+** — the MCP server.
 - **[uv](https://docs.astral.sh/uv/)** — Python dependency manager (the documented path).
 

--- a/godot/addons/godot_mcp/godot_mcp.gd
+++ b/godot/addons/godot_mcp/godot_mcp.gd
@@ -14,6 +14,10 @@ extends EditorPlugin
 ## correct choice here.
 
 const PLUGIN_NAME := "godot_mcp"
+# Minimum supported Godot version. The addon is built for 4.4+ (UID sidecars, the
+# 4.4-compatible add_control_to_dock choice) and is validated against 4.6.x.
+const MIN_GODOT_MAJOR := 4
+const MIN_GODOT_MINOR := 4
 
 var _dock: MCPStatusDock
 var _bridge: MCPBridge
@@ -22,6 +26,7 @@ var _selection: EditorSelection
 
 
 func _enter_tree() -> void:
+	_warn_if_unsupported_version()
 	_dock = MCPStatusDock.new()
 	add_control_to_dock(DOCK_SLOT_LEFT_UR, _dock)
 
@@ -71,6 +76,19 @@ func _exit_tree() -> void:
 
 func _get_plugin_name() -> String:
 	return PLUGIN_NAME
+
+
+## Warn (don't hard-refuse) when the editor is older than the supported floor, so a user on
+## an unsupported version gets a clear message instead of cryptic parse/runtime errors.
+func _warn_if_unsupported_version() -> void:
+	var info := Engine.get_version_info()
+	var major := int(info.get("major", 0))
+	var minor := int(info.get("minor", 0))
+	if major < MIN_GODOT_MAJOR or (major == MIN_GODOT_MAJOR and minor < MIN_GODOT_MINOR):
+		push_warning(
+			"godot_mcp supports Godot %d.%d+ (running %s). Some features may misbehave on this version."
+			% [MIN_GODOT_MAJOR, MIN_GODOT_MINOR, str(info.get("string", "unknown"))]
+		)
 
 
 ## Push the full current editor state into the dock (used on enable).

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -389,6 +389,16 @@ def test_router_registers_export_commands() -> None:
     assert "export_presets.cfg" in source and "ConfigFile" in source
 
 
+def test_plugin_declares_minimum_godot_version() -> None:
+    # The addon supports Godot 4.4+ and warns (not crashes) on older editors (issue #86).
+    entry = (ADDON_DIR / "godot_mcp.gd").read_text()
+    assert "MIN_GODOT_MAJOR := 4" in entry and "MIN_GODOT_MINOR := 4" in entry
+    assert "_warn_if_unsupported_version" in entry
+    assert "Engine.get_version_info()" in entry
+    # The project also declares the 4.4 feature so the editor flags older opens.
+    assert '"4.4"' in PROJECT_GODOT.read_text()
+
+
 def test_mutations_use_undo_redo() -> None:
     source = (ADDON_DIR / "command_router.gd").read_text()
     # Every create/rename/delete/set must register with EditorUndoRedoManager.


### PR DESCRIPTION
## Summary
Sets and enforces the minimum supported Godot version. The addon is built for **4.4+** (UID sidecars, the 4.4-compatible `add_control_to_dock` over 4.6's `EditorDock`) and validated against 4.6.x; this makes the floor explicit and fails friendly on older editors.

## Changes
- `godot_mcp.gd`: `MIN_GODOT_MAJOR`/`MIN_GODOT_MINOR` constants and `_warn_if_unsupported_version()` (called first in `_enter_tree`) — `push_warning` with the running version when below 4.4. A warning, not a hard refuse: most capability still works, and it's clearer than cryptic parse/runtime errors.
- README: "4.4 is the minimum supported version (addon warns on older); validated against 4.6.x."
- Test: static manifest assertion for the constants + guard + the `project.godot` `"4.4"` feature.

## Notes
- `project.godot` already declares `features=("4.4")`. CI doesn't run Godot, so the enable-time warning is the practical enforcement point.

## Test plan
- `tests/unit/test_addon_manifest.py::test_plugin_declares_minimum_godot_version`.
- Live addon-load e2e passes on 4.6.3 (guard present, no warning since 4.6 ≥ 4.4).
- Preflight: ruff clean, mypy --strict clean (full, 148 files), 254 contract+unit, zero-skip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)