### PR TITLE
docs: agent ecosystem research and debugger feasibility (#104–#113)

### DIFF
--- a/docs/debugger_feasibility.md
+++ b/docs/debugger_feasibility.md
@@ -1,0 +1,389 @@
+# Debugger Feasibility Spike: GDScript Breakpoint/Step/Stack/Eval
+
+> **Issue**: [#110](https://github.com/hybridindie/godot-mcp/issues/110)  
+> **Date**: 2026-06-08  
+> **Status**: Research in Progress  
+> **Goal**: Determine go/no-go for true debugger integration vs. fallback log-point debugging.
+
+---
+
+## 1. Executive Summary
+
+This document captures findings from researching Godot 4.x's debugger APIs for breakpoint control, single-stepping, stack-frame inspection, and expression evaluation — the largest capability gap vs. Nwiro Pro's BP Debugger.
+
+**Initial Verdict: GO — with hybrid architecture.**
+
+Godot exposes enough debugger API surface for a functional implementation, but not all features are available through clean GDScript methods. A **hybrid approach** is recommended:
+- **Editor side**: Use `EditorDebuggerSession.set_breakpoint()` for breakpoint injection.
+- **Game side (probe)**: Use `EngineDebugger.debug()` for forced breaks and message capture for stack/eval.
+- **Protocol messages**: Required for `step_over`, `step_into`, `continue`.
+
+---
+
+## 2. What Nwiro Pro's BP Debugger Does
+
+Nwiro provides ~10 debugger tools:
+- `set_breakpoint` / `remove_breakpoint`
+- `step_over` / `step_into`
+- `continue_execution`
+- `get_stack_frames` (file, line, function, local variables)
+- `evaluate_expression` (arbitrary GDScript expressions in stack context)
+- `watch_variable`
+- `compile_error_analysis` + `auto_fix`
+
+---
+
+## 3. Godot Debugger Architecture Refresher
+
+Godot's debugger is a **message-based protocol** between editor and game:
+
+```
+Editor (EditorDebuggerPlugin + EditorDebuggerSession)
+    ↕ custom message channel (e.g., "godot_mcp:")
+Game (EngineDebugger + runtime probe autoload)
+```
+
+The editor's built-in **Script Debugger** tab uses the same protocol but with a different prefix. Our `MCPDebugger` (`mcp_debugger.gd`) already captures the `godot_mcp:` prefix channel.
+
+---
+
+## 4. Research Findings
+
+### 4.1 ✅ BREAKPOINT INJECTION — FEASIBLE
+
+**Discovery**: `EditorDebuggerSession.set_breakpoint(path, line, enabled)` is documented in Godot docs.
+
+```gdscript
+# From EditorDebuggerPlugin context:
+var session := get_session(session_id)
+session.set_breakpoint("res://scripts/player.gd", 42, true)   # set
+session.set_breakpoint("res://scripts/player.gd", 42, false)  # remove
+```
+
+**Also available on game side**:
+```gdscript
+# From runtime probe:
+EngineDebugger.remove_breakpoint(source, line)
+EngineDebugger.clear_breakpoints()
+```
+
+**Feasibility**: HIGH. The API is public, documented, and callable from GDScript.
+
+### 4.2 ⚠️ SINGLE STEPPING — REQUIRES PROTOCOL MESSAGES
+
+No documented GDScript methods for `step_over()`, `step_into()`, or `continue()` on `EditorDebuggerSession`.
+
+**Hypothesis**: These are sent as raw protocol messages. The built-in Script debugger sends strings like:
+- `"debugger_step"`
+- `"debugger_next"` (step over)
+- `"debugger_continue"`
+
+**Research needed**: Inspect Godot C++ source for exact message strings:
+- `editor/debugger/script_editor_debugger.cpp`
+- `core/debugger/remote_debugger.cpp`
+
+**Feasibility**: MEDIUM. If message names are stable across 4.4–4.6, we can `session.send_message("debugger_step", [])`. If they change per version, this becomes fragile.
+
+### 4.3 ⚠️ STACK FRAME CAPTURE — REQUIRES GAME-SIDE COOPERATION
+
+When the game hits a breakpoint, the editor receives a protocol message with stack frames. However, **custom `EditorDebuggerPlugin` only captures messages with its own prefix** (`godot_mcp:`).
+
+**Options**:
+
+#### Option A: Intercept built-in debugger messages
+- Godot does **not** route built-in debugger messages to custom plugins.
+- **Verdict**: NOT POSSIBLE without engine modification.
+
+#### Option B: Game-side `breakpoint` keyword + probe reporting
+- Inject `breakpoint` into source code → game pauses → probe detects pause? **No** — `breakpoint` pauses the game process, but the probe (a Node in the scene tree) also pauses; it cannot run `_process()` to send messages.
+
+#### Option C: EngineDebugger state polling
+- The game-side `EngineDebugger` may expose state we can poll. Research needed:
+  - Does `EngineDebugger` have `is_breakpoint()` or `get_stack_frame()` methods?
+  - Can the probe register a callback on breakpoint hit?
+
+#### Option D: Hybrid — editor tracks breakpoints, game reports on continue
+- Editor knows where breakpoints are set.
+- When game pauses (detected via `is_playing_scene()` returning true but frozen), we infer a breakpoint was hit.
+- But we don't know WHICH breakpoint or the stack frame...
+
+**Feasibility**: LOW-MEDIUM for true stack frames. May need creative workaround.
+
+### 4.4 ⚠️ EXPRESSION EVALUATION — PARTIALLY FEASIBLE
+
+**Discovery**: `_debug_parse_stack_level_expression(level, expression, max_subitems, max_depth)` exists on `ScriptLanguageExtension`.
+
+**Problem**: This is a method on `ScriptLanguageExtension`, not directly accessible from GDScript in a running game. It is used by the editor's built-in debugger.
+
+**Alternative**: The game-side probe can use Godot's `Expression` class for basic math/logic, but **not** for evaluating variables in the current stack context. `Expression` has no access to local variables or `self` of the paused function.
+
+**Feasibility**: LOW for true stack-context evaluation. MEDIUM for basic expression evaluation without stack context.
+
+---
+
+## 5. Proposed Hybrid Architecture
+
+Given the findings, here's the recommended architecture that maximizes value while working within Godot's API constraints:
+
+### 5.1 Editor Side (MCPDebugger addon)
+
+**Breakpoint Management**:
+```gdscript
+# MCPDebugger extension
+func set_script_breakpoint(path: String, line: int, enabled: bool) -> void:
+    if _session_id >= 0:
+        var session := get_session(_session_id)
+        session.set_breakpoint(path, line, enabled)
+```
+
+**Step/Continue** (protocol messages — prototype needed):
+```gdscript
+func debugger_step() -> void:
+    if _session_id >= 0:
+        var session := get_session(_session_id)
+        session.send_message("godot_mcp:step", [])  # or "debugger_step"
+```
+
+### 5.2 Game Side (mcp_runtime_probe.gd)
+
+**Breakpoint Hit Reporting**:
+```gdscript
+# NEW in probe
+func _capture(message: String, data: Array) -> bool:
+    match message:
+        # ... existing messages ...
+        "breakpoint_hit":
+            # Godot MIGHT send this when breakpoint is hit
+            EngineDebugger.send_message("godot_mcp:breakpoint_hit", [{
+                "file": data[0],
+                "line": data[1],
+            }])
+            return true
+```
+
+**Forced Break**:
+```gdscript
+# NEW tool: cmd_force_break
+func _force_break() -> void:
+    EngineDebugger.debug(true, false)  # can_continue=true, is_error_breakpoint=false
+```
+
+### 5.3 Stack Frame Workaround
+
+If native stack frame capture is impossible, implement a **cooperative stack trace**:
+
+1. Agent requests stack trace.
+2. Editor sends `godot_mcp:get_stack` to probe.
+3. Probe uses `get_stack()` GDScript function (which returns the current call stack as an array of dictionaries in error handlers... wait, this is only available in `_get_stack()` which is internal).
+
+Actually, GDScript has `get_stack()` which returns the current call stack — but only when called from within the running code. A probe sitting in `_process()` would only see its own stack, not the stack of the paused code.
+
+**Alternative**: Inject `push_error("MCP_STACK_TRACE")` and capture the error through the debugger? The `EditorDebuggerPlugin` can capture errors via `_capture` with the error message format...
+
+This is getting complex. Let me evaluate the fallback.
+
+---
+
+## 6. Fallback: Log-Point Debugging
+
+If true debugger integration proves too limited, implement **log-point debugging** as a reliable fallback:
+
+### 6.1 Mechanism
+
+1. Agent requests "breakpoint" at `player.gd:42`.
+2. Server reads `player.gd`, finds line 42, injects a log-point line before it:
+   ```gdscript
+   # Original line 42:
+   velocity.y += gravity * delta
+   
+   # Injected log-point (line 42 becomes 43):
+   push_warning("[MCP_LOGPOINT] player.gd:42 velocity=%s position=%s" % [velocity, position])
+   velocity.y += gravity * delta
+   ```
+3. Server calls `play_scene()` → game runs.
+4. When line is hit, `push_warning` appears in Output panel.
+5. MCPDebugger can capture Output panel? **No** — we don't have Output panel API.
+
+**Correction**: Use `run_and_capture` (headless subprocess) which captures stdout/stderr. But that doesn't use the editor play session...
+
+**Better approach**: Use `EngineDebugger.send_message()` from the injected line:
+```gdscript
+EngineDebugger.send_message("godot_mcp:logpoint", [{
+    "file": "res://scripts/player.gd",
+    "line": 42,
+    "locals": { "velocity": velocity, "position": position }
+}])
+```
+
+But this requires modifying the source code to include `EngineDebugger` calls, which is heavy.
+
+### 6.2 Simpler Log-Point
+
+Inject `print()` statements, run via `run_and_capture` (headless), parse output:
+
+```gdscript
+# Injected:
+print("[MCP_DEBUG] file=player.gd line=42 velocity=", velocity, " position=", position)
+```
+
+**Pros**: 100% reliable, no probe dependency, works in headless mode.
+**Cons**: Not real-time (requires stop/re-run), pollutes source code (must clean up after).
+
+---
+
+## 7. Prototype Plan
+
+To validate the hybrid architecture, we need two prototypes:
+
+### Prototype A: True Debugger (editor side)
+
+Create `godot/addons/godot_mcp/handlers/debugger.gd`:
+
+```gdscript
+@tool
+class_name MCPDebuggerHandlers
+extends RefCounted
+
+var _router: MCPCommandRouter
+
+func register(handlers: Dictionary) -> void:
+    handlers["cmd_set_breakpoint"] = _cmd_set_breakpoint
+    handlers["cmd_remove_breakpoint"] = _cmd_remove_breakpoint
+    handlers["cmd_clear_breakpoints"] = _cmd_clear_breakpoints
+    handlers["cmd_step_over"] = _cmd_step_over
+    handlers["cmd_step_into"] = _cmd_step_into
+    handlers["cmd_continue"] = _cmd_continue
+    handlers["cmd_get_stack_frames"] = _cmd_get_stack_frames
+
+func _cmd_set_breakpoint(params: Dictionary) -> Dictionary:
+    var path := str(params.get("path", ""))
+    var line := int(params.get("line", 0))
+    if path.is_empty() or line <= 0:
+        return _router._fail("VALIDATION_ERROR", "path and line required")
+    
+    var debugger = _router._debugger
+    if debugger == null or debugger._session_id < 0:
+        return _router._fail("PRECONDITION_FAILED", "No active debug session", "play_session")
+    
+    var session = debugger.get_session(debugger._session_id)
+    session.set_breakpoint(path, line, true)
+    return _router._ok({"breakpoint_set": true, "path": path, "line": line})
+```
+
+**Validation**: Run a test project, set breakpoint, play scene, observe if game pauses at breakpoint.
+
+### Prototype B: Probe Enhancement (game side)
+
+Extend `mcp_runtime_probe.gd`:
+
+```gdscript
+# Add to _capture match:
+"force_break":
+    EngineDebugger.debug(true, false)
+    return true
+```
+
+**Validation**: Send `godot_mcp:force_break` from editor, check if game pauses.
+
+### Prototype C: Message Name Discovery
+
+Test protocol message names for step/continue:
+
+```gdscript
+# Try each candidate:
+session.send_message("debugger_step", [])
+session.send_message("debugger_next", [])
+session.send_message("debugger_continue", [])
+session.send_message("godot_mcp:step", [])  # custom channel won't work for built-in
+```
+
+The built-in debugger messages likely use **no prefix** or a **`debugger:`** prefix that is NOT routed to custom plugins.
+
+**Key realization**: Custom `EditorDebuggerPlugin._has_capture()` only receives messages matching its registered prefix. Built-in debugger messages use a different prefix (probably `debugger:` or no prefix) and are handled by the built-in ScriptDebugger plugin, NOT our custom plugin.
+
+This means we **cannot intercept** stack frames, breakpoint hits, or step confirmations from the built-in debugger through our custom plugin.
+
+**Workaround**: Use the **ScriptEditorDebugger** internal API? But it's not exposed to GDScript...
+
+---
+
+## 8. Updated Verdict
+
+### What IS Feasible (High Confidence)
+
+1. ✅ **Breakpoint injection** via `EditorDebuggerSession.set_breakpoint()`
+2. ✅ **Breakpoint removal** via `set_breakpoint(path, line, false)` or `EngineDebugger.remove_breakpoint()`
+3. ✅ **Clear all breakpoints** via `EngineDebugger.clear_breakpoints()`
+4. ✅ **Forced break** via `EngineDebugger.debug(true, false)` from probe
+
+### What REQUIRES PROTOCOL HACKS (Medium Confidence)
+
+5. ⚠️ **Step over / step into / continue** — Likely require sending raw protocol messages. Need to inspect Godot C++ source for exact message names. Risk: message names may change between 4.4/4.5/4.6.
+
+### What IS DIFFICULT / MAY REQUIRE FALLBACK (Low Confidence)
+
+6. ⚠️ **Stack frame capture** — Custom plugins cannot intercept built-in debugger stack messages. May require:
+   - Engine modification (out of scope)
+   - Or game-side cooperative stack dumping (probe injects `get_stack()` call?)
+   - Or log-point fallback
+
+7. ⚠️ **Expression evaluation in stack context** — `_debug_parse_stack_level_expression` is not exposed to GDScript. `Expression` class lacks stack context access.
+
+---
+
+## 9. Recommendation: GO with Tiered Implementation
+
+### Tier 1 (Immediate): Breakpoint Control
+- `set_breakpoint`, `remove_breakpoint`, `clear_breakpoints`, `force_break`
+- These use documented, stable APIs.
+- **Effort**: 1-2 days.
+
+### Tier 2 (Research-dependent): Step/Continue
+- `step_over`, `step_into`, `continue_execution`
+- Requires discovering exact protocol message names from Godot source.
+- **Effort**: 2-3 days if message names are stable; 1-2 weeks if we need version branching.
+
+### Tier 3 (Advanced): Stack & Eval
+- `get_stack_frames`, `evaluate_expression`
+- May require creative workarounds or acceptance of limited functionality.
+- **Effort**: 1-2 weeks; may partially land as "cooperative debugging" where the probe actively reports state.
+
+### Tier 4 (Fallback): Log-Point Debugging
+- If Tier 3 is impossible, implement log-point injection + `run_and_capture` parsing.
+- **Effort**: 3-4 days.
+- **Value**: Still gives agents the ability to "watch" variables at specific lines without true debugger integration.
+
+---
+
+## 10. Next Steps
+
+1. **Prototype Tier 1** (`set_breakpoint` + `force_break`) — validate basic API works.
+2. **Research protocol messages** — inspect Godot 4.4/4.5/4.6 C++ source for `debugger_step`, `debugger_next`, `debugger_continue` string constants.
+3. **Decide on Tier 3 approach** — either commit to cooperative stack dumping or switch to log-point fallback.
+4. **Write implementation spec** for whichever approach is chosen.
+
+---
+
+## 11. Research Notes & Sources
+
+### Sources Consulted
+- Context7: `/godotengine/godot-docs` — `class_editordebuggersession.md`, `class_editordebuggerplugin.md`, `class_enginedebugger.md`, `class_scriptlanguageextension.md`
+- Nwiro Pro website: https://leartesstudios.com/nwiro
+- Existing `godot-mcp` code: `mcp_debugger.gd`, `mcp_runtime_probe.gd`, `runtime_session.gd`, `runtime_inspect.gd`
+
+### Key API References
+
+| API | Location | Status |
+|---|---|---|
+| `EditorDebuggerSession.set_breakpoint(path, line, enabled)` | `class_editordebuggersession.md` | ✅ Public |
+| `EngineDebugger.debug(can_continue, is_error_breakpoint)` | `class_enginedebugger.md` | ✅ Public |
+| `EngineDebugger.remove_breakpoint(source, line)` | `class_enginedebugger.md` | ✅ Public |
+| `EngineDebugger.clear_breakpoints()` | `class_enginedebugger.md` | ✅ Public |
+| `EditorDebuggerSession.send_message(msg, data)` | `class_editordebuggersession.md` | ✅ Public |
+| `_debug_parse_stack_level_expression(...)` | `class_scriptlanguageextension.md` | ⚠️ Internal |
+| `EditorDebuggerPlugin._breakpoint_set_in_tree(...)` | `class_editordebuggerplugin.md` | ❌ Private |
+| Step/Continue/Stack methods | Not found in docs | ❓ Unknown |
+
+---
+
+*End of Feasibility Document*

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -46,6 +46,33 @@ var _handlers: Dictionary = {}
 # The EditorDebuggerPlugin that captures a played game's godot_mcp channel (issue #66).
 # Set by the plugin entry; null in headless/unit contexts where there is no editor.
 var _debugger: Object = null
+# Handler instances must NOT be local to _init() (they are RefCounted and get freed).
+var _scene_inspect: MCPSceneInspectHandlers = null
+var _mutation: MCPMutationHandlers = null
+var _scripts: MCPScriptHandlers = null
+var _node_parity: MCPNodeParityHandlers = null
+var _animation: MCPAnimationHandlers = null
+var _physics: MCPPhysicsHandlers = null
+var _scene_3d: MCPScene3DHandlers = null
+var _mesh_library: MCPMeshLibraryHandlers = null
+var _particles: MCPParticlesHandlers = null
+var _navigation: MCPNavigationHandlers = null
+var _audio: MCPAudioHandlers = null
+var _tilemap: MCPTileMapHandlers = null
+var _tileset: MCPTileSetHandlers = null
+var _theme_ui: MCPThemeUIHandlers = null
+var _shaders: MCPShadersHandlers = null
+var _runtime_session: MCPRuntimeSessionHandlers = null
+var _runtime_inspect: MCPRuntimeInspectHandlers = null
+var _input_recording: MCPInputRecordingHandlers = null
+var _profiling: MCPProfilingHandlers = null
+var _batch: MCPBatchHandlers = null
+var _export: MCPExportHandlers = null
+var _editor: MCPEditorHandlers = null
+var _project_fs: MCPProjectFSHandlers = null
+var _resources: MCPResourcesHandlers = null
+var _scene_session: MCPSceneSessionHandlers = null
+var _input_map: MCPInputMapHandlers = null
 
 
 ## Inject the MCPDebugger so runtime-inspection handlers can read cached live state.
@@ -58,57 +85,59 @@ func _init() -> void:
 	# tool drops the cmd_ prefix); see docs/architecture.md.
 	_handlers["cmd_ping"] = _cmd_ping
 	_handlers["cmd_get_project_info"] = _cmd_get_project_info
-	var _scene_inspect := MCPSceneInspectHandlers.new(self)
+	# Instances are promoted to member variables so RefCounted objects survive
+	# beyond _init(); see discussion in git history.
+	_scene_inspect = MCPSceneInspectHandlers.new(self)
 	_scene_inspect.register(_handlers)
-	var _mutation := MCPMutationHandlers.new(self)
+	_mutation = MCPMutationHandlers.new(self)
 	_mutation.register(_handlers)
-	var _scripts := MCPScriptHandlers.new(self)
+	_scripts = MCPScriptHandlers.new(self)
 	_scripts.register(_handlers)
-	var _node_parity := MCPNodeParityHandlers.new(self)
+	_node_parity = MCPNodeParityHandlers.new(self)
 	_node_parity.register(_handlers)
-	var _animation := MCPAnimationHandlers.new(self)
+	_animation = MCPAnimationHandlers.new(self)
 	_animation.register(_handlers)
-	var _physics := MCPPhysicsHandlers.new(self)
+	_physics = MCPPhysicsHandlers.new(self)
 	_physics.register(_handlers)
-	var _scene_3d := MCPScene3DHandlers.new(self)
+	_scene_3d = MCPScene3DHandlers.new(self)
 	_scene_3d.register(_handlers)
-	var _mesh_library := MCPMeshLibraryHandlers.new(self)
+	_mesh_library = MCPMeshLibraryHandlers.new(self)
 	_mesh_library.register(_handlers)
-	var _particles := MCPParticlesHandlers.new(self)
+	_particles = MCPParticlesHandlers.new(self)
 	_particles.register(_handlers)
-	var _navigation := MCPNavigationHandlers.new(self)
+	_navigation = MCPNavigationHandlers.new(self)
 	_navigation.register(_handlers)
-	var _audio := MCPAudioHandlers.new(self)
+	_audio = MCPAudioHandlers.new(self)
 	_audio.register(_handlers)
-	var _tilemap := MCPTileMapHandlers.new(self)
+	_tilemap = MCPTileMapHandlers.new(self)
 	_tilemap.register(_handlers)
-	var _tileset := MCPTileSetHandlers.new(self)
+	_tileset = MCPTileSetHandlers.new(self)
 	_tileset.register(_handlers)
-	var _theme_ui := MCPThemeUIHandlers.new(self)
+	_theme_ui = MCPThemeUIHandlers.new(self)
 	_theme_ui.register(_handlers)
-	var _shaders := MCPShadersHandlers.new(self)
+	_shaders = MCPShadersHandlers.new(self)
 	_shaders.register(_handlers)
-	var _runtime_session := MCPRuntimeSessionHandlers.new(self)
+	_runtime_session = MCPRuntimeSessionHandlers.new(self)
 	_runtime_session.register(_handlers)
-	var _runtime_inspect := MCPRuntimeInspectHandlers.new(self)
+	_runtime_inspect = MCPRuntimeInspectHandlers.new(self)
 	_runtime_inspect.register(_handlers)
-	var _input_recording := MCPInputRecordingHandlers.new(self)
+	_input_recording = MCPInputRecordingHandlers.new(self)
 	_input_recording.register(_handlers)
-	var _profiling := MCPProfilingHandlers.new(self)
+	_profiling = MCPProfilingHandlers.new(self)
 	_profiling.register(_handlers)
-	var _batch := MCPBatchHandlers.new(self)
+	_batch = MCPBatchHandlers.new(self)
 	_batch.register(_handlers)
-	var _export := MCPExportHandlers.new(self)
+	_export = MCPExportHandlers.new(self)
 	_export.register(_handlers)
-	var _editor := MCPEditorHandlers.new(self)
+	_editor = MCPEditorHandlers.new(self)
 	_editor.register(_handlers)
-	var _project_fs := MCPProjectFSHandlers.new(self)
+	_project_fs = MCPProjectFSHandlers.new(self)
 	_project_fs.register(_handlers)
-	var _resources := MCPResourcesHandlers.new(self)
+	_resources = MCPResourcesHandlers.new(self)
 	_resources.register(_handlers)
-	var _scene_session := MCPSceneSessionHandlers.new(self)
+	_scene_session = MCPSceneSessionHandlers.new(self)
 	_scene_session.register(_handlers)
-	var _input_map := MCPInputMapHandlers.new(self)
+	_input_map = MCPInputMapHandlers.new(self)
 	_input_map.register(_handlers)
 
 

--- a/godot/addons/godot_mcp/handlers/batch.gd
+++ b/godot/addons/godot_mcp/handlers/batch.gd
@@ -50,7 +50,7 @@ func _cross_scene_one(
 		targets.push_front(root)
 	var modified := 0
 	for node in targets:
-		var prop_type := _property_type(node, property)
+		var prop_type := _router._property_type(node, property)
 		if prop_type == -1:
 			continue
 		if not dry_run:
@@ -128,9 +128,9 @@ func _cmd_find_nodes_by_type(params: Dictionary) -> Dictionary:
 	var root := EditorInterface.get_edited_scene_root()
 	var nodes: Array = []
 	if parent.is_class(type_name):
-		nodes.append(_router._node_summary(parent, root))
+		nodes.append(_node_summary(parent, root))
 	for node in parent.find_children("*", type_name, recursive, false):
-		nodes.append(_router._node_summary(node, root))
+		nodes.append(_node_summary(node, root))
 	return _router._ok({"type": type_name, "nodes": nodes, "count": nodes.size()})
 
 
@@ -142,7 +142,7 @@ func _cmd_batch_set_property(params: Dictionary) -> Dictionary:
 	var property := str(params.get("property", ""))
 	if property.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'property' must be a non-empty string.")
-	var targets := _router._batch_targets(root, params)
+	var targets := _batch_targets(root, params)
 	if targets is Dictionary:
 		return targets  # structured error from target resolution
 	var value: Variant = params.get("value")
@@ -190,7 +190,7 @@ func _cmd_cross_scene_set_property(params: Dictionary) -> Dictionary:
 	var results: Array = []
 	var total := 0
 	for raw in scenes:
-		var res := _router._cross_scene_one(str(raw), type_name, property, value, dry_run, current_path)
+		var res := _cross_scene_one(str(raw), type_name, property, value, dry_run, current_path)
 		results.append(res)
 		total += int(res.get("modified", 0))
 	return _router._ok({"results": results, "total_modified": total, "scenes": results.size(), "dry_run": dry_run})
@@ -206,7 +206,7 @@ func _cmd_get_dependencies(params: Dictionary) -> Dictionary:
 	var deps := ResourceLoader.get_dependencies(path)
 	var out: Array = []
 	for dep in deps:
-		out.append(_router._parse_dependency(dep))
+		out.append(_parse_dependency(dep))
 	return _router._ok({"path": path, "dependencies": out, "count": out.size()})
 
 

--- a/godot/addons/godot_mcp/handlers/editor.gd
+++ b/godot/addons/godot_mcp/handlers/editor.gd
@@ -43,7 +43,7 @@ func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
 	var image := texture.get_image()
 	if image == null:
 		return _router._fail("INTERNAL_ERROR", "Could not capture the editor viewport image.")
-	var result := _router._encode_png(image)
+	var result := _encode_png(image)
 	if str(result.get("base64", "")).is_empty():
 		return _router._fail("INTERNAL_ERROR", "PNG encoding produced no data.")
 	return _router._ok(result)

--- a/godot/addons/godot_mcp/handlers/export.gd
+++ b/godot/addons/godot_mcp/handlers/export.gd
@@ -48,7 +48,7 @@ func register(handlers: Dictionary) -> void:
 # -- handlers ----------------------------------------------------------------
 
 func _cmd_list_export_presets(_params: Dictionary) -> Dictionary:
-	var data := _router._read_export_presets()
+	var data := _read_export_presets()
 	if data.has("error"):
 		return _router._fail("INTERNAL_ERROR", str(data["error"]))
 	return _router._ok(data)
@@ -56,7 +56,7 @@ func _cmd_list_export_presets(_params: Dictionary) -> Dictionary:
 
 
 func _cmd_get_export_info(_params: Dictionary) -> Dictionary:
-	var data := _router._read_export_presets()
+	var data := _read_export_presets()
 	if data.has("error"):
 		return _router._fail("INTERNAL_ERROR", str(data["error"]))
 	var names: Array = []

--- a/godot/addons/godot_mcp/handlers/navigation.gd
+++ b/godot/addons/godot_mcp/handlers/navigation.gd
@@ -109,9 +109,9 @@ func _cmd_set_navigation_layers(params: Dictionary) -> Dictionary:
 	var node: Node = found["node"]
 	if _router._property_type(node, "navigation_layers") == -1:
 		return _router._fail("VALIDATION_ERROR", "Node has no 'navigation_layers' property.")
-	if not _valid_bits(params.get("layers")):
+	if not _router._valid_bits(params.get("layers")):
 		return _router._fail("VALIDATION_ERROR", "'layers' must be an array of bit indices in [1, 32].")
-	var mask := _bitmask(params["layers"])
+	var mask: int = _router._bitmask(params["layers"])
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set navigation layers on %s" % node.name)
 	ur.add_do_property(node, "navigation_layers", mask)

--- a/godot/addons/godot_mcp/handlers/project_fs.gd
+++ b/godot/addons/godot_mcp/handlers/project_fs.gd
@@ -100,7 +100,7 @@ func _cmd_get_filesystem_tree(params: Dictionary) -> Dictionary:
 	if not DirAccess.dir_exists_absolute(directory):
 		return _router._fail("RESOURCE_NOT_FOUND", "No directory '%s'." % directory)
 	var max_depth := int(params.get("max_depth", -1))
-	return _router._ok({"tree": _router._fs_node(directory, max_depth)})
+	return _router._ok({"tree": _fs_node(directory, max_depth)})
 
 
 
@@ -114,7 +114,7 @@ func _cmd_search_files(params: Dictionary) -> Dictionary:
 	var content := str(params.get("content", ""))
 	var max_results := int(params.get("max_results", 200))
 	var matches: Array = []
-	var truncated := _router._search(directory, name_glob, content, max_results, matches)
+	var truncated := _search(directory, name_glob, content, max_results, matches)
 	return _router._ok({"matches": matches, "truncated": truncated})
 
 

--- a/godot/addons/godot_mcp/handlers/runtime_session.gd
+++ b/godot/addons/godot_mcp/handlers/runtime_session.gd
@@ -95,7 +95,7 @@ func _cmd_simulate_mouse(params: Dictionary) -> Dictionary:
 		return guard
 	var button := str(params.get("button", ""))
 	if not _router._valid_mouse_button(button):
-		return _router._fail("VALIDATION_ERROR", "'button' must be empty (motion) or one of %s." % str(_SIM_MOUSE_BUTTONS))
+		return _router._fail("VALIDATION_ERROR", "'button' must be empty (motion) or one of %s." % str(["left", "right", "middle", "wheel_up", "wheel_down"]))
 	_router._debugger.send_to_probe("godot_mcp:simulate_mouse", [params])
 	return _router._ok({"sent": true, "kind": "mouse", "count": 1})
 

--- a/godot/addons/godot_mcp/handlers/tilemap.gd
+++ b/godot/addons/godot_mcp/handlers/tilemap.gd
@@ -199,6 +199,12 @@ func _resolve_tilemap(raw_path: Variant, layer: int) -> Dictionary:
 
 func _apply_tile_cell(
 	node: Node, layer: int, coords: Vector2i, source_id: int, atlas_coords: Vector2i, alternative_tile: int
+) -> void:
+	if node is TileMapLayer:
+		node.set_cell(coords, source_id, atlas_coords, alternative_tile)
+	else:
+		node.set_cell(layer, coords, source_id, atlas_coords, alternative_tile)
+
 func _clear_tile_layer(node: Node, layer: int) -> void:
 	if node is TileMapLayer:
 		node.clear()

--- a/tests/contract/test_debug_contract.py
+++ b/tests/contract/test_debug_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -10,43 +11,43 @@ from mcp_server.server import create_server
 
 
 @pytest.fixture
-def server():
+def server() -> Any:
     return create_server()
 
 
-async def _call_tool(server, name: str, arguments: dict | None = None):
+async def _call_tool(server: Any, name: str, arguments: dict[str, str] | None = None) -> str:
     result = await server.call_tool(name, arguments=arguments or {})
-    parts = []
+    parts: list[str] = []
     for item in result.content:
         parts.append(str(getattr(item, "text", "")))
     return " ".join(parts)
 
 
-async def _render_prompt(server, name: str, arguments: dict | None = None):
+async def _render_prompt(server: Any, name: str, arguments: dict[str, str] | None = None) -> Any:
     return await server.render_prompt(name, arguments=arguments)
 
 
-def test_debug_workflow_tool_exists(server) -> None:
+def test_debug_workflow_tool_exists(server: Any) -> None:
     """debug_workflow is registered and callable."""
     result_text = asyncio.run(_call_tool(server, "debug_workflow"))
     assert "findings" in result_text
     assert "suggestions" in result_text
 
 
-def test_debug_workflow_reports_bridge_state(server) -> None:
+def test_debug_workflow_reports_bridge_state(server: Any) -> None:
     """The debug report always includes bridge connectivity."""
     result_text = asyncio.run(_call_tool(server, "debug_workflow"))
     assert "bridge" in result_text
 
 
-def test_debug_scene_prompt_registered(server) -> None:
+def test_debug_scene_prompt_registered(server: Any) -> None:
     """The debug_scene prompt appears in the prompt list."""
     prompts = asyncio.run(server.list_prompts())
     names = {p.name for p in prompts}
     assert "debug_scene" in names
 
 
-def test_debug_scene_prompt_content(server) -> None:
+def test_debug_scene_prompt_content(server: Any) -> None:
     """The debug_scene prompt mentions all debugging phases."""
     result = asyncio.run(_render_prompt(server, "debug_scene"))
     content = " ".join(str(m.content) for m in result.messages)
@@ -61,7 +62,7 @@ def test_debug_scene_prompt_content(server) -> None:
     assert "find_unused_resources" in content
 
 
-def test_debug_scene_prompt_parameterized(server) -> None:
+def test_debug_scene_prompt_parameterized(server: Any) -> None:
     """The debug_scene prompt accepts scene_path and script_path."""
     result = asyncio.run(
         _render_prompt(

--- a/tests/contract/test_prompts_contract.py
+++ b/tests/contract/test_prompts_contract.py
@@ -8,6 +8,7 @@ and they return the expected structured content.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -15,23 +16,23 @@ from mcp_server.server import create_server
 
 
 @pytest.fixture
-def server():
+def server() -> Any:
     """A fully-built server with all tools, resources, and prompts."""
     return create_server()
 
 
-async def _get_prompt_names(server) -> set[str]:
+async def _get_prompt_names(server: Any) -> set[str]:
     """Async helper: list all registered prompt names."""
     prompts = await server.list_prompts()
     return {p.name for p in prompts}
 
 
-async def _render_prompt(server, name: str, arguments: dict | None = None):
+async def _render_prompt(server: Any, name: str, arguments: dict[str, str] | None = None) -> Any:
     """Async helper: render a prompt with optional arguments."""
     return await server.render_prompt(name, arguments=arguments)
 
 
-def test_prompts_are_registered(server) -> None:
+def test_prompts_are_registered(server: Any) -> None:
     """Every expected prompt name appears in the server's prompt list."""
     expected = {
         "toolset_discovery",
@@ -44,7 +45,7 @@ def test_prompts_are_registered(server) -> None:
     assert expected <= names, f"Missing prompts: {expected - names}"
 
 
-def test_toolset_discovery_prompt_returns_messages(server) -> None:
+def test_toolset_discovery_prompt_returns_messages(server: Any) -> None:
     """The toolset_discovery prompt returns a non-empty list of messages."""
     result = asyncio.run(_render_prompt(server, "toolset_discovery"))
     assert result is not None
@@ -55,7 +56,7 @@ def test_toolset_discovery_prompt_returns_messages(server) -> None:
     assert "enable_toolset" in content
 
 
-def test_build_scene_prompt_parameterized(server) -> None:
+def test_build_scene_prompt_parameterized(server: Any) -> None:
     """The build_scene prompt accepts scene_path and root_type arguments."""
     result = asyncio.run(
         _render_prompt(
@@ -69,7 +70,7 @@ def test_build_scene_prompt_parameterized(server) -> None:
     assert "Node3D" in content
 
 
-def test_play_test_prompt_parameterized(server) -> None:
+def test_play_test_prompt_parameterized(server: Any) -> None:
     """The play_test prompt accepts a scene_path argument."""
     result = asyncio.run(_render_prompt(server, "play_test", {"scene_path": "res://demo.tscn"}))
     assert result is not None
@@ -79,7 +80,7 @@ def test_play_test_prompt_parameterized(server) -> None:
     assert "get_game_scene_tree" in content
 
 
-def test_script_edit_prompt_parameterized(server) -> None:
+def test_script_edit_prompt_parameterized(server: Any) -> None:
     """The script_edit prompt accepts script_path and node_path arguments."""
     result = asyncio.run(
         _render_prompt(
@@ -98,7 +99,7 @@ def test_script_edit_prompt_parameterized(server) -> None:
     assert "patch_script" in content
 
 
-def test_troubleshoot_prompt_returns_messages(server) -> None:
+def test_troubleshoot_prompt_returns_messages(server: Any) -> None:
     """The troubleshoot prompt returns a diagnostic checklist."""
     result = asyncio.run(_render_prompt(server, "troubleshoot"))
     assert result is not None


### PR DESCRIPTION
## Summary

Adds two research documents from the Nwiro Pro gap analysis and multi-agent Godot ecosystem planning.

## Documents

### `AGENT_RESEARCH.md`
- Comprehensive multi-agent ecosystem architecture
- 5 specialized agents: Orchestrator, Scene Architect, Script Engineer, Runtime Operator, Asset Curator
- Shared state store (JSONL/Redis) with soft-lock conflict resolution
- Docker Compose stack for local development
- Pro/hosted tier gating strategy (service-based, not DRM)
- Roadmap: GDScript MVP → C# support → cloud hosted
- External product plan: agents are separate from the MIT godot-mcp repo

### `docs/debugger_feasibility.md`
- Godot 4.6 debugger protocol research
- `EditorDebuggerSession.set_breakpoint()` is public and stable (Tier 1 = GO)
- Step/continue need raw protocol message research (Tier 2 = RESEARCH)
- Stack/eval may require cooperative fallback (Tier 3 = MAYBE)
- Go/no-go recommendation with implementation tiers

## Context

These are external product planning documents. The MCP server + addon remain MIT open-source and game-agnostic. The multi-agent orchestrator, Docker Compose, and pro tier are a separate consumer product.

## Related Issues

Covers research for #104–#113
