### PR TITLE
fix(addon): resolve compilation errors + RefCounted GC bug from handler refactor

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -46,6 +46,33 @@ var _handlers: Dictionary = {}
 # The EditorDebuggerPlugin that captures a played game's godot_mcp channel (issue #66).
 # Set by the plugin entry; null in headless/unit contexts where there is no editor.
 var _debugger: Object = null
+# Handler instances must NOT be local to _init() (they are RefCounted and get freed).
+var _scene_inspect: MCPSceneInspectHandlers = null
+var _mutation: MCPMutationHandlers = null
+var _scripts: MCPScriptHandlers = null
+var _node_parity: MCPNodeParityHandlers = null
+var _animation: MCPAnimationHandlers = null
+var _physics: MCPPhysicsHandlers = null
+var _scene_3d: MCPScene3DHandlers = null
+var _mesh_library: MCPMeshLibraryHandlers = null
+var _particles: MCPParticlesHandlers = null
+var _navigation: MCPNavigationHandlers = null
+var _audio: MCPAudioHandlers = null
+var _tilemap: MCPTileMapHandlers = null
+var _tileset: MCPTileSetHandlers = null
+var _theme_ui: MCPThemeUIHandlers = null
+var _shaders: MCPShadersHandlers = null
+var _runtime_session: MCPRuntimeSessionHandlers = null
+var _runtime_inspect: MCPRuntimeInspectHandlers = null
+var _input_recording: MCPInputRecordingHandlers = null
+var _profiling: MCPProfilingHandlers = null
+var _batch: MCPBatchHandlers = null
+var _export: MCPExportHandlers = null
+var _editor: MCPEditorHandlers = null
+var _project_fs: MCPProjectFSHandlers = null
+var _resources: MCPResourcesHandlers = null
+var _scene_session: MCPSceneSessionHandlers = null
+var _input_map: MCPInputMapHandlers = null
 
 
 ## Inject the MCPDebugger so runtime-inspection handlers can read cached live state.
@@ -58,57 +85,59 @@ func _init() -> void:
 	# tool drops the cmd_ prefix); see docs/architecture.md.
 	_handlers["cmd_ping"] = _cmd_ping
 	_handlers["cmd_get_project_info"] = _cmd_get_project_info
-	var _scene_inspect := MCPSceneInspectHandlers.new(self)
+	# Instances are promoted to member variables so RefCounted objects survive
+	# beyond _init(); see discussion in git history.
+	_scene_inspect = MCPSceneInspectHandlers.new(self)
 	_scene_inspect.register(_handlers)
-	var _mutation := MCPMutationHandlers.new(self)
+	_mutation = MCPMutationHandlers.new(self)
 	_mutation.register(_handlers)
-	var _scripts := MCPScriptHandlers.new(self)
+	_scripts = MCPScriptHandlers.new(self)
 	_scripts.register(_handlers)
-	var _node_parity := MCPNodeParityHandlers.new(self)
+	_node_parity = MCPNodeParityHandlers.new(self)
 	_node_parity.register(_handlers)
-	var _animation := MCPAnimationHandlers.new(self)
+	_animation = MCPAnimationHandlers.new(self)
 	_animation.register(_handlers)
-	var _physics := MCPPhysicsHandlers.new(self)
+	_physics = MCPPhysicsHandlers.new(self)
 	_physics.register(_handlers)
-	var _scene_3d := MCPScene3DHandlers.new(self)
+	_scene_3d = MCPScene3DHandlers.new(self)
 	_scene_3d.register(_handlers)
-	var _mesh_library := MCPMeshLibraryHandlers.new(self)
+	_mesh_library = MCPMeshLibraryHandlers.new(self)
 	_mesh_library.register(_handlers)
-	var _particles := MCPParticlesHandlers.new(self)
+	_particles = MCPParticlesHandlers.new(self)
 	_particles.register(_handlers)
-	var _navigation := MCPNavigationHandlers.new(self)
+	_navigation = MCPNavigationHandlers.new(self)
 	_navigation.register(_handlers)
-	var _audio := MCPAudioHandlers.new(self)
+	_audio = MCPAudioHandlers.new(self)
 	_audio.register(_handlers)
-	var _tilemap := MCPTileMapHandlers.new(self)
+	_tilemap = MCPTileMapHandlers.new(self)
 	_tilemap.register(_handlers)
-	var _tileset := MCPTileSetHandlers.new(self)
+	_tileset = MCPTileSetHandlers.new(self)
 	_tileset.register(_handlers)
-	var _theme_ui := MCPThemeUIHandlers.new(self)
+	_theme_ui = MCPThemeUIHandlers.new(self)
 	_theme_ui.register(_handlers)
-	var _shaders := MCPShadersHandlers.new(self)
+	_shaders = MCPShadersHandlers.new(self)
 	_shaders.register(_handlers)
-	var _runtime_session := MCPRuntimeSessionHandlers.new(self)
+	_runtime_session = MCPRuntimeSessionHandlers.new(self)
 	_runtime_session.register(_handlers)
-	var _runtime_inspect := MCPRuntimeInspectHandlers.new(self)
+	_runtime_inspect = MCPRuntimeInspectHandlers.new(self)
 	_runtime_inspect.register(_handlers)
-	var _input_recording := MCPInputRecordingHandlers.new(self)
+	_input_recording = MCPInputRecordingHandlers.new(self)
 	_input_recording.register(_handlers)
-	var _profiling := MCPProfilingHandlers.new(self)
+	_profiling = MCPProfilingHandlers.new(self)
 	_profiling.register(_handlers)
-	var _batch := MCPBatchHandlers.new(self)
+	_batch = MCPBatchHandlers.new(self)
 	_batch.register(_handlers)
-	var _export := MCPExportHandlers.new(self)
+	_export = MCPExportHandlers.new(self)
 	_export.register(_handlers)
-	var _editor := MCPEditorHandlers.new(self)
+	_editor = MCPEditorHandlers.new(self)
 	_editor.register(_handlers)
-	var _project_fs := MCPProjectFSHandlers.new(self)
+	_project_fs = MCPProjectFSHandlers.new(self)
 	_project_fs.register(_handlers)
-	var _resources := MCPResourcesHandlers.new(self)
+	_resources = MCPResourcesHandlers.new(self)
 	_resources.register(_handlers)
-	var _scene_session := MCPSceneSessionHandlers.new(self)
+	_scene_session = MCPSceneSessionHandlers.new(self)
 	_scene_session.register(_handlers)
-	var _input_map := MCPInputMapHandlers.new(self)
+	_input_map = MCPInputMapHandlers.new(self)
 	_input_map.register(_handlers)
 
 

--- a/godot/addons/godot_mcp/handlers/batch.gd
+++ b/godot/addons/godot_mcp/handlers/batch.gd
@@ -50,7 +50,7 @@ func _cross_scene_one(
 		targets.push_front(root)
 	var modified := 0
 	for node in targets:
-		var prop_type := _property_type(node, property)
+		var prop_type := _router._property_type(node, property)
 		if prop_type == -1:
 			continue
 		if not dry_run:
@@ -128,9 +128,9 @@ func _cmd_find_nodes_by_type(params: Dictionary) -> Dictionary:
 	var root := EditorInterface.get_edited_scene_root()
 	var nodes: Array = []
 	if parent.is_class(type_name):
-		nodes.append(_router._node_summary(parent, root))
+		nodes.append(_node_summary(parent, root))
 	for node in parent.find_children("*", type_name, recursive, false):
-		nodes.append(_router._node_summary(node, root))
+		nodes.append(_node_summary(node, root))
 	return _router._ok({"type": type_name, "nodes": nodes, "count": nodes.size()})
 
 
@@ -142,7 +142,7 @@ func _cmd_batch_set_property(params: Dictionary) -> Dictionary:
 	var property := str(params.get("property", ""))
 	if property.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'property' must be a non-empty string.")
-	var targets := _router._batch_targets(root, params)
+	var targets := _batch_targets(root, params)
 	if targets is Dictionary:
 		return targets  # structured error from target resolution
 	var value: Variant = params.get("value")
@@ -190,7 +190,7 @@ func _cmd_cross_scene_set_property(params: Dictionary) -> Dictionary:
 	var results: Array = []
 	var total := 0
 	for raw in scenes:
-		var res := _router._cross_scene_one(str(raw), type_name, property, value, dry_run, current_path)
+		var res := _cross_scene_one(str(raw), type_name, property, value, dry_run, current_path)
 		results.append(res)
 		total += int(res.get("modified", 0))
 	return _router._ok({"results": results, "total_modified": total, "scenes": results.size(), "dry_run": dry_run})
@@ -206,7 +206,7 @@ func _cmd_get_dependencies(params: Dictionary) -> Dictionary:
 	var deps := ResourceLoader.get_dependencies(path)
 	var out: Array = []
 	for dep in deps:
-		out.append(_router._parse_dependency(dep))
+		out.append(_parse_dependency(dep))
 	return _router._ok({"path": path, "dependencies": out, "count": out.size()})
 
 

--- a/godot/addons/godot_mcp/handlers/editor.gd
+++ b/godot/addons/godot_mcp/handlers/editor.gd
@@ -43,7 +43,7 @@ func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
 	var image := texture.get_image()
 	if image == null:
 		return _router._fail("INTERNAL_ERROR", "Could not capture the editor viewport image.")
-	var result := _router._encode_png(image)
+	var result := _encode_png(image)
 	if str(result.get("base64", "")).is_empty():
 		return _router._fail("INTERNAL_ERROR", "PNG encoding produced no data.")
 	return _router._ok(result)

--- a/godot/addons/godot_mcp/handlers/export.gd
+++ b/godot/addons/godot_mcp/handlers/export.gd
@@ -48,7 +48,7 @@ func register(handlers: Dictionary) -> void:
 # -- handlers ----------------------------------------------------------------
 
 func _cmd_list_export_presets(_params: Dictionary) -> Dictionary:
-	var data := _router._read_export_presets()
+	var data := _read_export_presets()
 	if data.has("error"):
 		return _router._fail("INTERNAL_ERROR", str(data["error"]))
 	return _router._ok(data)
@@ -56,7 +56,7 @@ func _cmd_list_export_presets(_params: Dictionary) -> Dictionary:
 
 
 func _cmd_get_export_info(_params: Dictionary) -> Dictionary:
-	var data := _router._read_export_presets()
+	var data := _read_export_presets()
 	if data.has("error"):
 		return _router._fail("INTERNAL_ERROR", str(data["error"]))
 	var names: Array = []

--- a/godot/addons/godot_mcp/handlers/navigation.gd
+++ b/godot/addons/godot_mcp/handlers/navigation.gd
@@ -109,9 +109,9 @@ func _cmd_set_navigation_layers(params: Dictionary) -> Dictionary:
 	var node: Node = found["node"]
 	if _router._property_type(node, "navigation_layers") == -1:
 		return _router._fail("VALIDATION_ERROR", "Node has no 'navigation_layers' property.")
-	if not _valid_bits(params.get("layers")):
+	if not _router._valid_bits(params.get("layers")):
 		return _router._fail("VALIDATION_ERROR", "'layers' must be an array of bit indices in [1, 32].")
-	var mask := _bitmask(params["layers"])
+	var mask: int = _router._bitmask(params["layers"])
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set navigation layers on %s" % node.name)
 	ur.add_do_property(node, "navigation_layers", mask)

--- a/godot/addons/godot_mcp/handlers/project_fs.gd
+++ b/godot/addons/godot_mcp/handlers/project_fs.gd
@@ -100,7 +100,7 @@ func _cmd_get_filesystem_tree(params: Dictionary) -> Dictionary:
 	if not DirAccess.dir_exists_absolute(directory):
 		return _router._fail("RESOURCE_NOT_FOUND", "No directory '%s'." % directory)
 	var max_depth := int(params.get("max_depth", -1))
-	return _router._ok({"tree": _router._fs_node(directory, max_depth)})
+	return _router._ok({"tree": _fs_node(directory, max_depth)})
 
 
 
@@ -114,7 +114,7 @@ func _cmd_search_files(params: Dictionary) -> Dictionary:
 	var content := str(params.get("content", ""))
 	var max_results := int(params.get("max_results", 200))
 	var matches: Array = []
-	var truncated := _router._search(directory, name_glob, content, max_results, matches)
+	var truncated := _search(directory, name_glob, content, max_results, matches)
 	return _router._ok({"matches": matches, "truncated": truncated})
 
 

--- a/godot/addons/godot_mcp/handlers/runtime_session.gd
+++ b/godot/addons/godot_mcp/handlers/runtime_session.gd
@@ -95,7 +95,7 @@ func _cmd_simulate_mouse(params: Dictionary) -> Dictionary:
 		return guard
 	var button := str(params.get("button", ""))
 	if not _router._valid_mouse_button(button):
-		return _router._fail("VALIDATION_ERROR", "'button' must be empty (motion) or one of %s." % str(_SIM_MOUSE_BUTTONS))
+		return _router._fail("VALIDATION_ERROR", "'button' must be empty (motion) or one of %s." % str(["left", "right", "middle", "wheel_up", "wheel_down"]))
 	_router._debugger.send_to_probe("godot_mcp:simulate_mouse", [params])
 	return _router._ok({"sent": true, "kind": "mouse", "count": 1})
 

--- a/godot/addons/godot_mcp/handlers/tilemap.gd
+++ b/godot/addons/godot_mcp/handlers/tilemap.gd
@@ -199,6 +199,12 @@ func _resolve_tilemap(raw_path: Variant, layer: int) -> Dictionary:
 
 func _apply_tile_cell(
 	node: Node, layer: int, coords: Vector2i, source_id: int, atlas_coords: Vector2i, alternative_tile: int
+) -> void:
+	if node is TileMapLayer:
+		node.set_cell(coords, source_id, atlas_coords, alternative_tile)
+	else:
+		node.set_cell(layer, coords, source_id, atlas_coords, alternative_tile)
+
 func _clear_tile_layer(node: Node, layer: int) -> void:
 	if node is TileMapLayer:
 		node.clear()

--- a/tests/contract/test_debug_contract.py
+++ b/tests/contract/test_debug_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -10,43 +11,43 @@ from mcp_server.server import create_server
 
 
 @pytest.fixture
-def server():
+def server() -> Any:
     return create_server()
 
 
-async def _call_tool(server, name: str, arguments: dict | None = None):
+async def _call_tool(server: Any, name: str, arguments: dict[str, str] | None = None) -> str:
     result = await server.call_tool(name, arguments=arguments or {})
-    parts = []
+    parts: list[str] = []
     for item in result.content:
         parts.append(str(getattr(item, "text", "")))
     return " ".join(parts)
 
 
-async def _render_prompt(server, name: str, arguments: dict | None = None):
+async def _render_prompt(server: Any, name: str, arguments: dict[str, str] | None = None) -> Any:
     return await server.render_prompt(name, arguments=arguments)
 
 
-def test_debug_workflow_tool_exists(server) -> None:
+def test_debug_workflow_tool_exists(server: Any) -> None:
     """debug_workflow is registered and callable."""
     result_text = asyncio.run(_call_tool(server, "debug_workflow"))
     assert "findings" in result_text
     assert "suggestions" in result_text
 
 
-def test_debug_workflow_reports_bridge_state(server) -> None:
+def test_debug_workflow_reports_bridge_state(server: Any) -> None:
     """The debug report always includes bridge connectivity."""
     result_text = asyncio.run(_call_tool(server, "debug_workflow"))
     assert "bridge" in result_text
 
 
-def test_debug_scene_prompt_registered(server) -> None:
+def test_debug_scene_prompt_registered(server: Any) -> None:
     """The debug_scene prompt appears in the prompt list."""
     prompts = asyncio.run(server.list_prompts())
     names = {p.name for p in prompts}
     assert "debug_scene" in names
 
 
-def test_debug_scene_prompt_content(server) -> None:
+def test_debug_scene_prompt_content(server: Any) -> None:
     """The debug_scene prompt mentions all debugging phases."""
     result = asyncio.run(_render_prompt(server, "debug_scene"))
     content = " ".join(str(m.content) for m in result.messages)
@@ -61,7 +62,7 @@ def test_debug_scene_prompt_content(server) -> None:
     assert "find_unused_resources" in content
 
 
-def test_debug_scene_prompt_parameterized(server) -> None:
+def test_debug_scene_prompt_parameterized(server: Any) -> None:
     """The debug_scene prompt accepts scene_path and script_path."""
     result = asyncio.run(
         _render_prompt(

--- a/tests/contract/test_prompts_contract.py
+++ b/tests/contract/test_prompts_contract.py
@@ -8,6 +8,7 @@ and they return the expected structured content.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -15,23 +16,23 @@ from mcp_server.server import create_server
 
 
 @pytest.fixture
-def server():
+def server() -> Any:
     """A fully-built server with all tools, resources, and prompts."""
     return create_server()
 
 
-async def _get_prompt_names(server) -> set[str]:
+async def _get_prompt_names(server: Any) -> set[str]:
     """Async helper: list all registered prompt names."""
     prompts = await server.list_prompts()
     return {p.name for p in prompts}
 
 
-async def _render_prompt(server, name: str, arguments: dict | None = None):
+async def _render_prompt(server: Any, name: str, arguments: dict[str, str] | None = None) -> Any:
     """Async helper: render a prompt with optional arguments."""
     return await server.render_prompt(name, arguments=arguments)
 
 
-def test_prompts_are_registered(server) -> None:
+def test_prompts_are_registered(server: Any) -> None:
     """Every expected prompt name appears in the server's prompt list."""
     expected = {
         "toolset_discovery",
@@ -44,7 +45,7 @@ def test_prompts_are_registered(server) -> None:
     assert expected <= names, f"Missing prompts: {expected - names}"
 
 
-def test_toolset_discovery_prompt_returns_messages(server) -> None:
+def test_toolset_discovery_prompt_returns_messages(server: Any) -> None:
     """The toolset_discovery prompt returns a non-empty list of messages."""
     result = asyncio.run(_render_prompt(server, "toolset_discovery"))
     assert result is not None
@@ -55,7 +56,7 @@ def test_toolset_discovery_prompt_returns_messages(server) -> None:
     assert "enable_toolset" in content
 
 
-def test_build_scene_prompt_parameterized(server) -> None:
+def test_build_scene_prompt_parameterized(server: Any) -> None:
     """The build_scene prompt accepts scene_path and root_type arguments."""
     result = asyncio.run(
         _render_prompt(
@@ -69,7 +70,7 @@ def test_build_scene_prompt_parameterized(server) -> None:
     assert "Node3D" in content
 
 
-def test_play_test_prompt_parameterized(server) -> None:
+def test_play_test_prompt_parameterized(server: Any) -> None:
     """The play_test prompt accepts a scene_path argument."""
     result = asyncio.run(_render_prompt(server, "play_test", {"scene_path": "res://demo.tscn"}))
     assert result is not None
@@ -79,7 +80,7 @@ def test_play_test_prompt_parameterized(server) -> None:
     assert "get_game_scene_tree" in content
 
 
-def test_script_edit_prompt_parameterized(server) -> None:
+def test_script_edit_prompt_parameterized(server: Any) -> None:
     """The script_edit prompt accepts script_path and node_path arguments."""
     result = asyncio.run(
         _render_prompt(
@@ -98,7 +99,7 @@ def test_script_edit_prompt_parameterized(server) -> None:
     assert "patch_script" in content
 
 
-def test_troubleshoot_prompt_returns_messages(server) -> None:
+def test_troubleshoot_prompt_returns_messages(server: Any) -> None:
     """The troubleshoot prompt returns a diagnostic checklist."""
     result = asyncio.run(_render_prompt(server, "troubleshoot"))
     assert result is not None


### PR DESCRIPTION
## Summary

Fixes two categories of bugs introduced when inline handlers were split into domain modules (commit 4c83e91, PR #103). Godot 4.6's stricter static analysis and RefCounted lifecycle behavior exposed these.

## Changes

### Commit 1: Compilation fixes in 7 handler modules
- **tilemap.gd**: added missing `_apply_tile_cell` function body
- **batch.gd**: fixed local vs `_router.*` cross-references (`_property_type`, `_node_summary`, `_batch_targets`, `_cross_scene_one`, `_parse_dependency`)
- **runtime_session.gd**: `_SIM_MOUSE_BUTTONS` scope error — changed from shared constant to inline array
- **navigation.gd**: `_valid_bits`/`_bitmask` routing — now calls via `_router`
- **editor.gd**: `_encode_png` now called locally instead of via `_router`
- **export.gd**: `_read_export_presets` now called locally instead of via `_router`
- **project_fs.gd**: `_fs_node`/`_search` now called locally instead of via `_router`

### Commit 2: RefCounted GC bug in command_router.gd
- **Root cause**: handler instances were created as local `var` bindings in `_init()`. Since they are `RefCounted`, Godot freed them when `_init()` returned, making all registered Callables point to null instances.
- **Symptom**: commands like `cmd_get_active_scene` returned empty envelopes: `{id:"cmd_get_active_scene"}` with no `ok`/`result`/`error` fields.
- **Fix**: promoted all 26 handler instances to persistent member variables.

## Testing

- All handler scripts compile cleanly in Godot 4.6 editor
- Bridge smoke test (`cmd_ping`, `cmd_get_project_info`, `cmd_get_scene_tree`) passes
- MCP server connects and commands return proper response envelopes

## Related Issues

Closes #104 (command_router null handlers)
Part of #103 fallout
