### PR TITLE
feat(analysis): asset dependency, orphan detection, and scene integrity tools (closes #111)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -569,7 +569,7 @@ true when the process exits 0. **Requires export templates installed** for the t
 platform (missing templates surface as errors in the result). Use a generous
 `timeout_seconds`.
 
-#### Static analysis (issue #49) — category: `analysis` (gated off by default)
+#### Static analysis (issue #49, #111) — category: `analysis` (gated off by default)
 
 Project-wide static analysis, computed Python-side from the project's files (no addon
 commands). All `read_only`. The project dir is resolved like the runtime loop
@@ -582,14 +582,25 @@ commands). All `read_only`. The project dir is resolved like the runtime loop
 | `analyze_signal_flow` | `scene=""` | `SignalFlowResult { connections[], count }` |
 | `detect_circular_dependencies` | — | `CircularDependenciesResult { cycles[], count }` |
 | `project_stats` | — | `ProjectStatsResult { scenes, scripts, resources, total_nodes, connections, by_extension, busiest_scenes[] }` |
+| `analyze_dependencies` | `resource_path` | `AnalyzeDependenciesResult { path, type, references[], referencers[] }` |
+| `find_orphaned_resources` | `scan_dir="res://"`, `resource_types` | `FindOrphanedResult { orphaned[]{path, type, estimated_size}, scanned }` |
+| `validate_scene_integrity` | `scene_path` | `ValidateSceneIntegrityResult { valid, errors[]{severity, message, node_path, property}, warnings[] }` |
+| `cross_scene_find_refs` | `target_path` | `CrossSceneRefsResult { scenes[], resources[], scripts[] }` |
 
 `find_unused_resources` flags resource files not referenced by any project file (excluding
 entry points — the main scene, autoloads, plugin scripts). `analyze_signal_flow` parses
 `[connection ...]` from scene files (each `{scene, signal, from, to, method}`).
 `detect_circular_dependencies` finds cycles in the `preload`/`load`/`extends` graph among
 `.gd` files. `project_stats` reports counts, total nodes, connections, a per-extension
-breakdown, and the busiest scenes. Results are **heuristic** text analysis — dynamically
-built resource/script paths aren't tracked, so treat them as a strong hint.
+breakdown, and the busiest scenes.
+
+Issue #111 adds **dependency-aware** analysis: `analyze_dependencies` extracts `res://` and
+`uid://` references from a resource file (recursing into sub-dependencies). `find_orphaned_resources`
+surfaces resource files with no referencers, optionally filtered by Godot type and scoped to a
+directory. `validate_scene_integrity` checks a scene for broken `ext_resource` paths, missing
+scripts, and signal connections pointing to non-existent nodes. `cross_scene_find_refs` scans
+all project files to find who references a given resource. Results remain **heuristic** text
+analysis — dynamically-built paths aren't tracked, so treat them as a strong hint.
 
 #### Batch / refactor (issue #48) — category: `batch` (gated off by default)
 

--- a/mcp_server/analysis.py
+++ b/mcp_server/analysis.py
@@ -43,7 +43,7 @@ RESOURCE_EXTS = {
     ".csv",
 }
 # Text files we scan for ``res://`` references and structure.
-_REF_EXTS = {".tscn", ".tres", ".gd", ".gdshader", ".godot", ".cfg"}
+_REF_EXTS = {".tscn", ".tres", ".gd", ".gdshader", ".godot", ".cfg", ".uid"}
 _SKIP_DIRS = {".godot", ".git", ".import"}
 
 _RES_REF = re.compile(r"res://[^\s\"'()\[\]]+")
@@ -71,6 +71,7 @@ class ProjectIndex:
     texts: dict[str, str] = field(default_factory=dict)  # res:// path -> file text
     referenced: set[str] = field(default_factory=set)  # res:// paths referenced anywhere
     entry_points: set[str] = field(default_factory=set)  # main scene + autoloads + plugins
+    uid_map: dict[str, str] = field(default_factory=dict)  # uid:// -> res:// path
 
 
 def _to_res(project_dir: Path, path: Path) -> str:
@@ -78,8 +79,8 @@ def _to_res(project_dir: Path, path: Path) -> str:
 
 
 def scan(project_dir: Path) -> ProjectIndex:
-    """Walk the project once: index resource files, read text files, and collect every
-    ``res://`` reference plus entry points (main scene, autoloads, plugin scripts).
+    """Walk the project once: index resource files, read text files, collect every
+    ``res://`` reference, uid mappings, and entry points.
     """
     index = ProjectIndex(project_dir=project_dir)
     for path in sorted(project_dir.rglob("*")):
@@ -99,6 +100,12 @@ def scan(project_dir: Path) -> ProjectIndex:
             index.texts[res] = text
             for ref in _RES_REF.findall(text):
                 index.referenced.add(ref.rstrip(".,"))
+            # uid sidecar files: map uid -> resource path
+            if ext == ".uid":
+                uid = text.strip()
+                if uid.startswith("uid://"):
+                    base_res = res.removesuffix(".uid")
+                    index.uid_map[uid] = base_res
     _collect_entry_points(index)
     return index
 
@@ -301,7 +308,8 @@ def analyze_dependencies(index: ProjectIndex, resource_path: str) -> dict[str, A
             seen.add(r)
             unique_refs.append(r)
 
-    # Type inference
+    # Type inference from file suffix (ext_resource types are dependencies,
+    # not the resource's own type, so we don't override here).
     rtype = ""
     ext = Path(resource_path).suffix.lower()
     if ext == ".gd":
@@ -314,12 +322,6 @@ def analyze_dependencies(index: ProjectIndex, resource_path: str) -> dict[str, A
         rtype = "Texture2D"
     elif ext in {".ogg", ".wav", ".mp3"}:
         rtype = "AudioStream"
-    text = index.texts.get(resource_path, "")
-    type_map = _ext_resource_type_map(text)
-    if type_map:
-        # any parsed ext_resource type overrides generic suffix inference
-        first = next(iter(type_map.values()))
-        rtype = first[0]
 
     # referencers = files that reference this path
     referencers: list[str] = sorted(
@@ -448,15 +450,24 @@ def validate_scene_integrity(index: ProjectIndex, scene_path: str) -> dict[str, 
 
 
 def cross_scene_find_refs(index: ProjectIndex, target_path: str) -> dict[str, Any]:
-    """Scan all project files for references to ``target_path`` (or its ``uid://``).
+    """Scan all project files for references to ``target_path``.
+    Also resolves any ``uid://`` sidecar for the target and searches for that uid.
     Returns which scenes, resources, and scripts mention it.
     """
+    search_terms: set[str] = {target_path}
+    # If there's a .uid sidecar, also search for the uid://
+    uid_path = target_path + ".uid"
+    if uid_path in index.texts:
+        uid = index.texts[uid_path].strip()
+        if uid.startswith("uid://"):
+            search_terms.add(uid)
+
     scenes: list[str] = []
     resources: list[str] = []
     scripts: list[str] = []
 
     for res, text in index.texts.items():
-        if target_path in text:
+        if any(term in text for term in search_terms):
             if res.endswith((".tscn", ".scn")):
                 scenes.append(res)
             elif res.endswith(".tres"):

--- a/mcp_server/analysis.py
+++ b/mcp_server/analysis.py
@@ -47,10 +47,18 @@ _REF_EXTS = {".tscn", ".tres", ".gd", ".gdshader", ".godot", ".cfg"}
 _SKIP_DIRS = {".godot", ".git", ".import"}
 
 _RES_REF = re.compile(r"res://[^\s\"'()\[\]]+")
+_UID_REF = re.compile(r"uid://[^\s\"'()\[\]]+")
+_EXT_RESOURCE = re.compile(r'\[ext_resource\s+[^\]]*type="([^"]+)"[^\]]*path="([^"]+)"')
+_EXT_RESOURCE_ID = re.compile(r'\[ext_resource\s+[^\]]*id="([^"]+)"[^\]]*path="([^"]+)"')
+_SUB_RESOURCE = re.compile(r'\[sub_resource\s+[^\]]*type="([^"]+)"')
+_NODE_HEADER = re.compile(r"^\[node ", re.MULTILINE)
+_NODE_HEADER_LINE = re.compile(r'^\[node\s+name="([^"]+)"\s+type="([^"]+)"')
+_SCRIPT_ASSIGN = re.compile(r'script\s*=\s*ExtResource\("([^"]+)"\)')
 _CONNECTION = re.compile(
     r'\[connection signal="([^"]+)" from="([^"]+)" to="([^"]+)" method="([^"]+)"'
 )
-_NODE_HEADER = re.compile(r"^\[node ", re.MULTILINE)
+_SIGNAL_CONN = _CONNECTION
+_NODE_PARENT = re.compile(r'parent="([^"]+)"')
 _SCRIPT_DEP = re.compile(
     r'(?:preload|load)\(\s*"(res://[^"]+\.gd)"\s*\)|extends\s+"(res://[^"]+\.gd)"'
 )
@@ -139,7 +147,7 @@ def analyze_signal_flow(index: ProjectIndex, scene: str = "") -> dict[str, Any]:
             continue
         if scene and res != scene:
             continue
-        for signal, src, dst, method in _CONNECTION.findall(text):
+        for signal, src, dst, method in _SIGNAL_CONN.findall(text):
             connections.append(
                 {"scene": res, "signal": signal, "from": src, "to": dst, "method": method}
             )
@@ -205,7 +213,7 @@ def project_stats(index: ProjectIndex) -> dict[str, Any]:
         if res.endswith((".tscn", ".scn")):
             nodes = len(_NODE_HEADER.findall(text))
             total_nodes += nodes
-            total_connections += len(_CONNECTION.findall(text))
+            total_connections += len(_SIGNAL_CONN.findall(text))
             scenes_by_nodes.append({"scene": res, "nodes": nodes})
     scenes_by_nodes.sort(key=lambda s: s["nodes"], reverse=True)
     return {
@@ -216,4 +224,248 @@ def project_stats(index: ProjectIndex) -> dict[str, Any]:
         "connections": total_connections,
         "by_extension": by_extension,
         "busiest_scenes": scenes_by_nodes[:10],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Issue #111 — asset dependency, orphan detection, scene integrity
+# ---------------------------------------------------------------------------
+
+
+def _ext_resource_map(text: str) -> dict[str, str]:
+    """Map ExtResource id -> path for a scene/resource file."""
+    mapping: dict[str, str] = {}
+    for block in re.findall(r'\[ext_resource\s+[^\]]*\]', text):
+        id_match = re.search(r'id="([^"]+)"', block)
+        path_match = re.search(r'path="([^"]+)"', block)
+        if id_match and path_match:
+            mapping[id_match.group(1)] = path_match.group(1)
+    return mapping
+
+
+def _ext_resource_type_map(text: str) -> dict[str, tuple[str, str]]:
+    """Map ExtResource id -> (type, path) for a scene/resource file."""
+    mapping: dict[str, tuple[str, str]] = {}
+    for block in re.findall(r'\[ext_resource\s+[^\]]*\]', text):
+        id_match = re.search(r'id="([^"]+)"', block)
+        type_match = re.search(r'type="([^"]+)"', block)
+        path_match = re.search(r'path="([^"]+)"', block)
+        if id_match and type_match and path_match:
+            mapping[id_match.group(1)] = (type_match.group(1), path_match.group(1))
+    return mapping
+
+
+def _collect_references(text: str, res: str) -> set[str]:
+    """All res:// / uid:// refs found in a file's text, plus ext_resources."""
+    refs: set[str] = set()
+    refs.update(_RES_REF.findall(text))
+    refs.update(_UID_REF.findall(text))
+    # For scenes/resources, also explicitly parse ext_resource paths
+    if res.endswith((".tscn", ".tres", ".scn")):
+        for block in re.findall(r'\[ext_resource\s+[^\]]*\]', text):
+            path_match = re.search(r'path="([^"]+)"', block)
+            if path_match:
+                refs.add(path_match.group(1))
+    return refs
+
+
+def analyze_dependencies(index: ProjectIndex, resource_path: str) -> dict[str, Any]:
+    """Parse a resource file and extract all ``res://`` / ``uid://`` references.
+    Recurse into sub-dependencies up to a depth limit.
+    """
+    if resource_path not in index.texts and resource_path not in index.resources:
+        return {"path": resource_path, "type": "", "references": [], "referencers": []}
+
+    visited: set[str] = set()
+    references: list[str] = []
+
+    def _dfs(path: str, depth: int) -> None:
+        if depth > 5 or path in visited:
+            return
+        visited.add(path)
+        text = index.texts.get(path, "")
+        if not text:
+            return
+        for ref in sorted(_collect_references(text, path)):
+            if ref.startswith(("res://", "uid://")) and ref not in visited:
+                references.append(ref)
+                if ref in index.texts:
+                    _dfs(ref, depth + 1)
+
+    _dfs(resource_path, 0)
+    # deduplicate while preserving order
+    seen: set[str] = set()
+    unique_refs: list[str] = []
+    for r in references:
+        if r not in seen:
+            seen.add(r)
+            unique_refs.append(r)
+
+    # Type inference
+    rtype = ""
+    ext = Path(resource_path).suffix.lower()
+    if ext == ".gd":
+        rtype = "GDScript"
+    elif ext in {".tscn", ".scn"}:
+        rtype = "PackedScene"
+    elif ext == ".tres":
+        rtype = "Resource"
+    elif ext in {".png", ".jpg", ".jpeg", ".svg", ".webp", ".bmp"}:
+        rtype = "Texture2D"
+    elif ext in {".ogg", ".wav", ".mp3"}:
+        rtype = "AudioStream"
+    text = index.texts.get(resource_path, "")
+    type_map = _ext_resource_type_map(text)
+    if type_map:
+        # any parsed ext_resource type overrides generic suffix inference
+        first = next(iter(type_map.values()))
+        rtype = first[0]
+
+    # referencers = files that reference this path
+    referencers: list[str] = sorted(
+        res for res, text in index.texts.items() if resource_path in _collect_references(text, res)
+    )
+
+    return {
+        "path": resource_path,
+        "type": rtype,
+        "references": unique_refs,
+        "referencers": referencers,
+    }
+
+
+def find_orphaned_resources(
+    index: ProjectIndex, scan_dir: str = "res://", resource_types: list[str] | None = None
+) -> dict[str, Any]:
+    """Resource files not referenced by any project file (excluding entry points).
+    ``scan_dir`` narrows the scope (default whole project). ``resource_types`` filters
+    by Godot type string (e.g. ``["Texture2D"]``); when omitted, all resource types
+    are considered. Excludes ``.godot/`` and ``addons/`` by default.
+    """
+    orphaned: list[dict[str, Any]] = []
+    for res, path in index.resources.items():
+        if not res.startswith(scan_dir):
+            continue
+        # skip .godot cache and addons by default
+        if "/.godot/" in res or "/addons/" in res:
+            continue
+        if res in index.referenced or res in index.entry_points:
+            continue
+        ext = path.suffix.lower()
+        rtype = ""
+        if ext in {".png", ".jpg", ".jpeg", ".svg", ".webp", ".bmp"}:
+            rtype = "Texture2D"
+        elif ext in {".ogg", ".wav", ".mp3"}:
+            rtype = "AudioStream"
+        elif ext == ".tres":
+            rtype = "Resource"
+        elif ext in {".tscn", ".scn"}:
+            rtype = "PackedScene"
+        elif ext == ".gd":
+            rtype = "GDScript"
+        if resource_types and rtype not in resource_types:
+            continue
+        estimated_size = path.stat().st_size if path.exists() else 0
+        orphaned.append({"path": res, "type": rtype, "estimated_size": estimated_size})
+    orphaned.sort(key=lambda o: o["path"])
+    return {"orphaned": orphaned, "scanned": len(index.resources)}
+
+
+def validate_scene_integrity(index: ProjectIndex, scene_path: str) -> dict[str, Any]:
+    """Validate a scene file for broken references and malformed signal connections.
+    Returns ``valid`` only when zero errors are found; warnings are non-blocking.
+    """
+    text = index.texts.get(scene_path, "")
+    if not text:
+        return {
+            "valid": False,
+            "errors": [{"severity": "error", "message": f"Scene not found: {scene_path}"}],
+            "warnings": [],
+        }
+
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    ext_map = _ext_resource_map(text)
+    ext_type_map = _ext_resource_type_map(text)
+
+    # broken ext_resource paths
+    for _rid, (rtype, path) in ext_type_map.items():
+        if path.startswith("res://") and path not in index.resources:
+            errors.append(
+                {
+                    "severity": "error",
+                    "message": f"Missing ext_resource: {path} ({rtype})",
+                    "node_path": "",
+                    "property": "",
+                }
+            )
+
+    # collect node names for signal target validation
+    node_names: set[str] = set()
+    for line in text.splitlines():
+        m = _NODE_HEADER_LINE.match(line)
+        if m:
+            node_names.add(m.group(1))
+
+    # broken script assignments (resolve ExtResource id -> path)
+    for line in text.splitlines():
+        m = _SCRIPT_ASSIGN.search(line)
+        if m:
+            rid = m.group(1)
+            script_path = ext_map.get(rid)
+            if (
+                script_path
+                and script_path.startswith("res://")
+                and script_path not in index.resources
+            ):
+                errors.append(
+                    {
+                        "severity": "error",
+                        "message": f"Missing script: {script_path}",
+                        "node_path": "",
+                        "property": "script",
+                    }
+                )
+
+    # broken signal connections
+    for signal, src, dst, method in _SIGNAL_CONN.findall(text):
+        for target in (src, dst):
+            if target != "." and target not in node_names:
+                errors.append(
+                    {
+                        "severity": "error",
+                        "message": (
+                            f"Signal '{signal}' connection points to missing node "
+                            f"'{target}' (method '{method}')"
+                        ),
+                        "node_path": target,
+                        "property": "",
+                    }
+                )
+
+    return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def cross_scene_find_refs(index: ProjectIndex, target_path: str) -> dict[str, Any]:
+    """Scan all project files for references to ``target_path`` (or its ``uid://``).
+    Returns which scenes, resources, and scripts mention it.
+    """
+    scenes: list[str] = []
+    resources: list[str] = []
+    scripts: list[str] = []
+
+    for res, text in index.texts.items():
+        if target_path in text:
+            if res.endswith((".tscn", ".scn")):
+                scenes.append(res)
+            elif res.endswith(".tres"):
+                resources.append(res)
+            elif res.endswith(".gd"):
+                scripts.append(res)
+
+    return {
+        "scenes": sorted(set(scenes)),
+        "resources": sorted(set(resources)),
+        "scripts": sorted(set(scripts)),
     }

--- a/mcp_server/models/analysis.py
+++ b/mcp_server/models/analysis.py
@@ -1,4 +1,4 @@
-"""Typed results for static analysis tools (issue #49)."""
+"""Typed results for static analysis tools (issue #49, #111)."""
 
 from __future__ import annotations
 
@@ -45,3 +45,45 @@ class ProjectStatsResult(BaseModel):
     connections: int = 0
     by_extension: dict[str, int] = Field(default_factory=dict)
     busiest_scenes: list[SceneNodeCount] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Issue #111 — asset dependency, orphan detection, scene integrity
+# ---------------------------------------------------------------------------
+
+
+class AnalyzeDependenciesResult(BaseModel):
+    path: str
+    type: str = ""
+    references: list[str] = Field(default_factory=list)
+    referencers: list[str] = Field(default_factory=list)
+
+
+class OrphanedResource(BaseModel):
+    path: str
+    type: str = ""
+    estimated_size: int = 0
+
+
+class FindOrphanedResult(BaseModel):
+    orphaned: list[OrphanedResource] = Field(default_factory=list)
+    scanned: int = 0
+
+
+class IntegrityIssue(BaseModel):
+    severity: str = "error"
+    message: str
+    node_path: str = ""
+    property: str = ""
+
+
+class ValidateSceneIntegrityResult(BaseModel):
+    valid: bool = True
+    errors: list[IntegrityIssue] = Field(default_factory=list)
+    warnings: list[IntegrityIssue] = Field(default_factory=list)
+
+
+class CrossSceneRefsResult(BaseModel):
+    scenes: list[str] = Field(default_factory=list)
+    resources: list[str] = Field(default_factory=list)
+    scripts: list[str] = Field(default_factory=list)

--- a/mcp_server/tools/analysis.py
+++ b/mcp_server/tools/analysis.py
@@ -1,8 +1,9 @@
-"""Static analysis tools (issue #49).
+"""Static analysis tools (issue #49, #111).
 
 Project-wide static analysis computed Python-side from the project's files (no addon
-commands): unused resources, signal flow, circular script dependencies, and
-scene-complexity stats. Gated `analysis` toolset; all `read_only`.
+commands): unused resources, signal flow, circular script dependencies, scene-complexity
+stats, asset dependencies, orphaned resources, scene integrity, and cross-scene
+reference search. Gated `analysis` toolset; all `read_only`.
 
 The project directory is resolved like the runtime loop (#13): ``GODOT_MCP_PROJECT_DIR``
 else the connected editor's project. Results are heuristic (text analysis), so
@@ -21,10 +22,14 @@ from mcp_server.bridge import Bridge
 from mcp_server.categories import ANALYSIS_TAG
 from mcp_server.config import ServerConfig
 from mcp_server.models.analysis import (
+    AnalyzeDependenciesResult,
     CircularDependenciesResult,
+    CrossSceneRefsResult,
+    FindOrphanedResult,
     ProjectStatsResult,
     SignalFlowResult,
     UnusedResourcesResult,
+    ValidateSceneIntegrityResult,
 )
 from mcp_server.runtime import resolve_project_dir
 from mcp_server.safety import READ_ONLY, PreconditionError, enforce_preconditions
@@ -78,3 +83,46 @@ def register_analysis(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> Non
         connections, a per-extension breakdown, and the busiest scenes by node count.
         """
         return ProjectStatsResult(**analysis.project_stats(await _index()))
+
+    @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
+    @enforce_preconditions
+    async def analyze_dependencies(resource_path: str) -> AnalyzeDependenciesResult:
+        """Parse a resource file and extract all ``res://`` / ``uid://`` references.
+        Recurse into sub-dependencies (depth-limited). Returns the resource's inferred
+        type, its direct/indirect references, and which project files refer to it.
+        """
+        return AnalyzeDependenciesResult(
+            **analysis.analyze_dependencies(await _index(), resource_path)
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
+    @enforce_preconditions
+    async def find_orphaned_resources(
+        scan_dir: str = "res://", resource_types: list[str] | None = None
+    ) -> FindOrphanedResult:
+        """Find resource files not referenced by any project file, excluding entry points
+        and the ``.godot/`` cache. Optionally filter by Godot type (e.g. ``["Texture2D"]``).
+        """
+        return FindOrphanedResult(
+            **analysis.find_orphaned_resources(await _index(), scan_dir, resource_types)
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
+    @enforce_preconditions
+    async def validate_scene_integrity(scene_path: str) -> ValidateSceneIntegrityResult:
+        """Check a scene file for broken ``ext_resource`` / ``sub_resource`` paths, missing
+        scripts, and broken signal connections. Returns errors (blocking) and warnings
+        (non-blocking). ``valid`` is true only when there are zero errors.
+        """
+        return ValidateSceneIntegrityResult(
+            **analysis.validate_scene_integrity(await _index(), scene_path)
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
+    @enforce_preconditions
+    async def cross_scene_find_refs(target_path: str) -> CrossSceneRefsResult:
+        """Scan all project files for references to ``target_path``. Returns which
+        scenes, resources, and scripts mention it.
+        """
+        return CrossSceneRefsResult(**analysis.cross_scene_find_refs(await _index(), target_path))
+

--- a/mcp_server/tools/analysis.py
+++ b/mcp_server/tools/analysis.py
@@ -110,7 +110,7 @@ def register_analysis(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> Non
     @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
     @enforce_preconditions
     async def validate_scene_integrity(scene_path: str) -> ValidateSceneIntegrityResult:
-        """Check a scene file for broken ``ext_resource`` / ``sub_resource`` paths, missing
+        """Check a scene file for broken ``ext_resource`` paths, missing
         scripts, and broken signal connections. Returns errors (blocking) and warnings
         (non-blocking). ``valid`` is true only when there are zero errors.
         """

--- a/tests/contract/test_analysis.py
+++ b/tests/contract/test_analysis.py
@@ -60,6 +60,10 @@ async def test_gated_read_only_in_analysis_toolset(tmp_path: Path) -> None:
         "analyze_signal_flow",
         "detect_circular_dependencies",
         "project_stats",
+        "analyze_dependencies",
+        "find_orphaned_resources",
+        "validate_scene_integrity",
+        "cross_scene_find_refs",
     }
     assert expected <= set(tools)
     assert all(tools[n].meta["safety_class"] == "read_only" for n in expected)
@@ -94,3 +98,111 @@ async def test_missing_project_dir_is_precondition_error(tmp_path: Path) -> None
         result = await client.call_tool("project_stats", {}, raise_on_error=False)
     assert result.is_error
     assert "project_dir" in str(result.content)
+
+
+async def test_analyze_dependencies(tmp_path: Path) -> None:
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n[application]\nrun/main_scene="res://main.tscn"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "icon.png").write_bytes(b"\x89PNG")
+    (tmp_path / "player.gd").write_text(
+        'extends CharacterBody2D\nconst Explosion = preload("res://explosion.tscn")\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "main.tscn").write_text(
+        "[gd_scene format=3]\n"
+        '[ext_resource type="Script" path="res://player.gd" id="1"]\n'
+        '[ext_resource type="Texture2D" path="res://icon.png" id="2"]\n'
+        '[node name="Main" type="Node2D"]\n'
+        '[node name="Player" type="CharacterBody2D" parent="."]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "explosion.tscn").write_bytes(b"\x00")  # binary-ish stub
+    async with Client(_server(tmp_path)) as client:
+        await client.call_tool("enable_toolset", {"category": "analysis"})
+        deps = await client.call_tool(
+            "analyze_dependencies", {"resource_path": "res://player.gd"}
+        )
+    sc = deps.structured_content
+    assert sc["path"] == "res://player.gd"
+    assert "res://explosion.tscn" in sc["references"]
+
+
+async def test_find_orphaned_resources(tmp_path: Path) -> None:
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n[application]\nrun/main_scene="res://main.tscn"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "used.png").write_bytes(b"\x89PNG")
+    (tmp_path / "orphan.png").write_bytes(b"\x89PNG")
+    (tmp_path / "main.tscn").write_text(
+        "[gd_scene format=3]\n"
+        '[ext_resource type="Texture2D" path="res://used.png" id="1"]\n'
+        '[node name="Main" type="Node2D"]\n',
+        encoding="utf-8",
+    )
+    async with Client(_server(tmp_path)) as client:
+        await client.call_tool("enable_toolset", {"category": "analysis"})
+        orphans = await client.call_tool("find_orphaned_resources", {})
+    sc = orphans.structured_content
+    assert any(o["path"] == "res://orphan.png" for o in sc["orphaned"])
+    assert all(o["path"] != "res://used.png" for o in sc["orphaned"])
+    assert sc["scanned"] >= 2
+
+
+async def test_validate_scene_integrity(tmp_path: Path) -> None:
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n[application]\nrun/main_scene="res://main.tscn"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "main.tscn").write_text(
+        "[gd_scene format=3]\n"
+        '[ext_resource type="Script" path="res://missing.gd" id="1"]\n'
+        '[node name="Main" type="Node2D"]\n'
+        '[node name="Child" type="Sprite2D" parent="."]\n'
+        'script = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    async with Client(_server(tmp_path)) as client:
+        await client.call_tool("enable_toolset", {"category": "analysis"})
+        integrity = await client.call_tool(
+            "validate_scene_integrity", {"scene_path": "res://main.tscn"}
+        )
+    sc = integrity.structured_content
+    assert sc["valid"] is False
+    assert any(
+        e["severity"] == "error" and "missing.gd" in e["message"]
+        for e in sc["errors"]
+    )
+
+
+async def test_cross_scene_find_refs(tmp_path: Path) -> None:
+    (tmp_path / "project.godot").write_text(
+        'config_version=5\n[application]\nrun/main_scene="res://main.tscn"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "shared.gd").write_text("extends Node\n", encoding="utf-8")
+    (tmp_path / "a.tscn").write_text(
+        "[gd_scene format=3]\n"
+        '[ext_resource type="Script" path="res://shared.gd" id="1"]\n'
+        '[node name="A" type="Node2D"]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "b.tscn").write_text(
+        "[gd_scene format=3]\n"
+        '[ext_resource type="Script" path="res://shared.gd" id="1"]\n'
+        '[node name="B" type="Node2D"]\n',
+        encoding="utf-8",
+    )
+    async with Client(_server(tmp_path)) as client:
+        await client.call_tool("enable_toolset", {"category": "analysis"})
+        refs = await client.call_tool(
+            "cross_scene_find_refs", {"target_path": "res://shared.gd"}
+        )
+    sc = refs.structured_content
+    assert "res://a.tscn" in sc["scenes"]
+    assert "res://b.tscn" in sc["scenes"]
+    assert sc["scripts"] == []
+    assert sc["resources"] == []

--- a/tests/contract/test_debugger.py
+++ b/tests/contract/test_debugger.py
@@ -67,7 +67,9 @@ async def test_remove_breakpoint() -> None:
     server, _ = _build()
     async with Client(server) as client:
         await client.call_tool("enable_toolset", {"category": "debugger"})
-        result = await client.call_tool("remove_breakpoint", {"path": "res://player.gd", "line": 42})
+        result = await client.call_tool(
+            "remove_breakpoint", {"path": "res://player.gd", "line": 42}
+        )
     sc = result.structured_content
     assert sc["breakpoint_removed"] is True
     assert sc["path"] == "res://player.gd"


### PR DESCRIPTION
## Summary

Implements the four analysis tools proposed in #111 for detecting broken references, orphaned resources, and scene integrity issues — all read-only, gated behind the existing `analysis` toolset.

## New tools

| Tool | Purpose |
|------|---------|
| `analyze_dependencies(resource_path)` | Parse a resource file for res:// / uid:// references, recurse into sub-dependencies, and report who refers back to it. |
| `find_orphaned_resources(scan_dir, resource_types)` | Surface resource files with no referencers. Excludes .godot/ cache, addons/, and entry points. Optional Godot-type filter (e.g. ["Texture2D"]). |
| `validate_scene_integrity(scene_path)` | Check a scene for broken ext_resource paths, missing scripts, and signal connections pointing to non-existent nodes. Returns `valid` + errors/warnings. |
| `cross_scene_find_refs(target_path)` | Scan all project files to find which scenes, resources, and scripts reference a given path. |

## Acceptance criteria

- [x] New tools in `mcp_server/tools/analysis.py` (extend existing)
- [x] File-scanned in Python layer (`mcp_server/analysis.py`) — no addon handlers needed for read-only text analysis
- [x] Contract tests (`tests/contract/test_analysis.py`)
- [x] Tool-contract docs updated (`docs/tool-contracts.md`)
- [x] Zero skipped tests

## Test plan

```bash
# Contract + unit tests
uv run pytest tests/contract/test_analysis.py tests/unit/test_analysis.py -q

# Lint + type check
uv run ruff check .
uv run mypy mcp_server/analysis.py mcp_server/tools/analysis.py mcp_server/models/analysis.py
```