### PR TITLE
feat(docker): Dockerfile and compose for HTTP MCP server delivery (closes #105)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,22 @@
 # syntax=docker/dockerfile:1
 FROM python:3.11-slim
 
-# Install uv for fast, reproducible dependency resolution.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# Pin uv to a specific version for reproducible builds.
+COPY --from=ghcr.io/astral-sh/uv:0.6.0 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-# Copy package manifest and lockfile first for layer caching.
+# Copy only package metadata first so `uv sync` can be cached independently
+# of source-code changes.
 COPY pyproject.toml uv.lock ./
 COPY LICENSE ./
-COPY mcp_server/ ./mcp_server/
 COPY README.md ./
 
 # Sync dependencies (production only — no dev group).
 RUN uv sync --no-dev
+
+# Now copy the source — changes here won't invalidate the dependency layer.
+COPY mcp_server/ ./mcp_server/
 
 # HTTP transport is the intended mode inside the container.
 ENV GODOT_MCP_TRANSPORT=http

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+# Install uv for fast, reproducible dependency resolution.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Copy package manifest and lockfile first for layer caching.
+COPY pyproject.toml uv.lock ./
+COPY LICENSE ./
+COPY mcp_server/ ./mcp_server/
+COPY README.md ./
+
+# Sync dependencies (production only — no dev group).
+RUN uv sync --no-dev
+
+# HTTP transport is the intended mode inside the container.
+ENV GODOT_MCP_TRANSPORT=http
+ENV GODOT_MCP_HTTP_HOST=0.0.0.0
+ENV GODOT_MCP_HTTP_PORT=9090
+ENV GODOT_MCP_BRIDGE_URL=ws://host.docker.internal:9080
+
+EXPOSE 9090
+
+# Healthcheck: verify the HTTP server is listening on its port.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import socket; s=socket.socket(); s.connect(('localhost', 9090)); s.close()"
+
+ENTRYPOINT ["uv", "run", "godot-mcp"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# Docker delivery for godot-mcp
+
+Containerized HTTP transport for the godot-mcp server. This lets consumers deploy or run
+the MCP server without a local Python toolchain.
+
+## Build
+
+```bash
+cd docker
+docker compose build
+```
+
+## Run
+
+```bash
+docker compose up
+```
+
+The server listens on `http://localhost:9090`.
+
+## Bridge networking
+
+The default `GODOT_MCP_BRIDGE_URL` is `ws://host.docker.internal:9080`, which reaches a
+Godot editor running on the Docker host. On Linux you may need to add
+`extra_hosts: ["host.docker.internal:host-gateway"]` to the compose service.
+
+## Mounting a project
+
+Uncomment the `volumes` line in `docker-compose.yml` to mount a host project directory:
+
+```yaml
+volumes:
+  - /path/to/your/godot/project:/project:ro
+```
+
+Then set `GODOT_MCP_PROJECT_DIR=/project` so tools like `run_and_capture` resolve paths
+correctly.
+
+## Healthcheck
+
+The container includes a `HEALTHCHECK` that verifies the HTTP server is listening on
+port 9090 via a lightweight socket probe. When healthy, the server is up and accepting
+MCP connections.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,10 @@ services:
     # volumes:
     #   - /path/to/your/godot/project:/project:ro
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:9090/"]
+      # Use the same socket-based probe as the Dockerfile so no extra tooling is needed.
+      test: >
+        ["CMD", "python", "-c",
+        "import socket; s=socket.socket(); s.connect(('localhost', 9090)); s.close()"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mcp-server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "9090:9090"
+    environment:
+      GODOT_MCP_TRANSPORT: http
+      GODOT_MCP_HTTP_HOST: "0.0.0.0"
+      GODOT_MCP_HTTP_PORT: "9090"
+      # Default for a Godot editor running on the Docker host.
+      GODOT_MCP_BRIDGE_URL: ws://host.docker.internal:9080
+      # Optional: point at a project directory mounted from the host.
+      # GODOT_MCP_PROJECT_DIR: /project
+    # volumes:
+    #   - /path/to/your/godot/project:/project:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9090/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3


### PR DESCRIPTION
## Summary

Containerized HTTP transport for the godot-mcp server. Allows consumers to deploy or run the MCP server without a local Python toolchain.

## Deliverables

| File | Purpose |
|------|---------|
|  |  + , production deps only, HTTP defaults, socket-based HEALTHCHECK on port 9090 |
|  | Single  service with bridge URL , port mapping  |
|  | Build, run, bridge networking, and project mount docs |

## Acceptance criteria

- [x] Dockerfile builds successfully
- [x]  runs the server in HTTP mode
- [x] Healthcheck responds correctly (socket probe to port 9090)
- [x] MCP client can connect to 
- [x] Documentation in 

## Test plan

```bash
cd docker
docker compose build
docker compose up
# Server listens on http://localhost:9090
curl http://localhost:9090/mcp
```