### PR TITLE
feat(inspection): suggest closest matching properties on set_node_property failure (closes #109)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -133,9 +133,12 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 | `get_scene_tree` | `max_depth: int = -1` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
 | `get_selected_node` | — | `SelectedNode { selected: NodeInfo? }` | `cmd_get_selected_node` |
 | `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
+| `get_node_property_list` | `node_path: str` | `NodePropertyList { node_path, type, properties[] }` | `cmd_get_node_property_list` |
 
 `SceneNode = { name, type, script?, children: [SceneNode] }`. `get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
+`get_node_property_list` returns every valid property name for a node (useful before calling
+`set_node_property`).
 
 #### Mutation (issue #6) — `mutating` (except `delete_node`)
 

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -20,6 +20,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
 	handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
+	handlers["cmd_get_node_property_list"] = _cmd_get_node_property_list
 
 
 # -- handlers ----------------------------------------------------------------
@@ -57,3 +58,22 @@ func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
 	return _router._ok(Inspect.node_info(node, root))
+
+
+func _cmd_get_node_property_list(params: Dictionary) -> Dictionary:
+	if not params.has("node_path"):
+		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node: Node = root.get_node_or_null(NodePath(str(params["node_path"])))
+	if node == null:
+		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
+	var names: Array = []
+	for entry in node.get_property_list():
+		names.append(str(entry["name"]))
+	return _router._ok({
+		"node_path": str(params["node_path"]),
+		"type": node.get_class(),
+		"properties": names,
+	})

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -54,6 +54,14 @@ class NodeInfo(BaseModel):
     children: list[str] = Field(default_factory=list)
 
 
+class NodePropertyList(BaseModel):
+    """All property names for a node, returned by get_node_property_list."""
+
+    node_path: str
+    type: str = ""
+    properties: list[str] = Field(default_factory=list)
+
+
 class SelectedNode(BaseModel):
     """The selected node, or ``selected=None`` when nothing is selected."""
 

--- a/mcp_server/suggestions.py
+++ b/mcp_server/suggestions.py
@@ -1,0 +1,28 @@
+"""Property-name suggestion engine (issue #109).
+
+Lightweight difflib-based closest-match finder for use when a property name is
+misspelled or doesn't exist on a node/resource/shader. No external dependencies.
+"""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Sequence
+
+
+def suggest(
+    given: str,
+    candidates: Sequence[str],
+    *,
+    n: int = 3,
+    cutoff: float = 0.5,
+) -> list[str]:
+    """Return the top ``n`` closest strings to ``given`` from ``candidates``.
+
+    Uses ``difflib.get_close_matches``; ``cutoff`` is the minimum similarity
+    score (0–1). Empty string yields no suggestions.
+    """
+    if not given or not candidates:
+        return []
+    return difflib.get_close_matches(given, candidates, n=n, cutoff=cutoff)
+

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -14,6 +14,7 @@ from mcp_server.categories import INSPECTION_TAG
 from mcp_server.models.inspection import (
     ActiveScene,
     NodeInfo,
+    NodePropertyList,
     ProjectInfo,
     SceneTree,
     SelectedNode,
@@ -25,7 +26,7 @@ INSPECTION = {INSPECTION_TAG}
 
 
 def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
-    """Register all five inspection tools on the server."""
+    """Register all inspection tools on the server."""
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_project_info() -> ProjectInfo:
@@ -67,3 +68,13 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         if no scene is open.
         """
         return NodeInfo(**await route(bridge, "cmd_get_node_properties", {"node_path": node_path}))
+
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
+    async def get_node_property_list(node_path: str) -> NodePropertyList:
+        """Return the flat list of valid property names for the node at
+        ``node_path``, plus its runtime class name. Use this to discover what
+        properties you can set before calling ``set_node_property``.
+        """
+        return NodePropertyList(
+            **await route(bridge, "cmd_get_node_property_list", {"node_path": node_path})
+        )

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -12,10 +12,13 @@ All editor work + UndoRedo lives in the addon; all safety lives here
 
 from __future__ import annotations
 
+import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import SCENE_EDIT_TAG
@@ -39,9 +42,54 @@ from mcp_server.safety import (
     require_confirmation,
     require_node_exists,
 )
-from mcp_server.tools._route import run_or_preview
+from mcp_server.suggestions import suggest
+from mcp_server.tools._route import route, run_or_preview
 
 SCENE_EDIT = {SCENE_EDIT_TAG}
+
+
+async def _node_property_names(bridge: Bridge, node_path: str) -> list[str]:
+    """Fetch the full property list for a node from the addon.
+    Returns ``[]`` on any non-cancellation failure (best-effort).
+    """
+    try:
+        resp = await bridge.send(
+            "cmd_get_node_property_list", {"node_path": node_path}
+        )
+        if resp.ok and resp.result:
+            return [str(p) for p in resp.result.get("properties", [])]
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        pass
+    return []
+
+
+async def _try_set_with_suggestions(
+    bridge: Bridge,
+    params: dict[str, Any],
+    node_path: str,
+    property: str,
+) -> SetPropertyResult:
+    """Route to the addon; on property-not-found enrich the error with suggestions."""
+    try:
+        result = await route(bridge, "cmd_set_node_property", params)
+        return SetPropertyResult(**result)
+    except ToolError as exc:
+        text = str(exc)
+        if "has no property" in text:
+            props = await _node_property_names(bridge, node_path)
+            sug = suggest(property, props)
+            if sug:
+                hint = (
+                    f"Node has no property '{property}'."
+                    f" Did you mean: {', '.join(sug)}?"
+                    f" [suggestions={json.dumps(sug)}]"
+                )
+            else:
+                hint = f"Node has no property '{property}'."
+            raise ToolError(f"VALIDATION_ERROR: {hint}") from None
+        raise
 
 
 def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
@@ -91,9 +139,9 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "property": property, "value": value}
         preview = {"node_path": node_path, "property": property, "value": value, "set": False}
-        return await run_or_preview(
-            dry_run, SetPropertyResult, preview, bridge, "cmd_set_node_property", params
-        )
+        if dry_run:
+            return SetPropertyResult(**preview, dry_run=True)
+        return await _try_set_with_suggestions(bridge, params, node_path, property)
 
     @mcp.tool(meta=DESTRUCTIVE, tags=SCENE_EDIT)
     @enforce_preconditions

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -141,6 +141,93 @@ async def test_set_property_maps_value_and_flag() -> None:
     assert result.structured_content["value"] == {"x": 1, "y": 2}
 
 
+# -- suggestions (issue #109) --------------------------------------------------
+
+
+def _addon_base(cmd: CommandEnvelope) -> ResponseEnvelope:
+    """Handle bootstrap commands and node checks for suggestion tests."""
+    if cmd.command == "cmd_get_active_scene":
+        return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://main.tscn"})
+    if cmd.command == "cmd_get_node_properties":
+        return ResponseEnvelope.success(
+            cmd.id, {"node_path": cmd.params["node_path"], "type": "Node2D"}
+        )
+    # Return failure for bootstrap commands so FakeAddonConnection auto-replaces
+    # cmd_ping / cmd_get_project_info with its default responder.
+    return ResponseEnvelope.failure(
+        cmd.id, "VALIDATION_ERROR", f"Unknown command '{cmd.command}'."
+    )
+
+
+def _respond_with_suggestions(cmd: CommandEnvelope) -> ResponseEnvelope:
+    if cmd.command == "cmd_get_node_property_list":
+        return ResponseEnvelope.success(
+            cmd.id,
+            {
+                "node_path": cmd.params["node_path"],
+                "type": "CharacterBody2D",
+                "properties": [
+                    "position",
+                    "position_smoothing_enabled",
+                    "global_position",
+                ],
+            },
+        )
+    if cmd.command == "cmd_set_node_property":
+        return ResponseEnvelope.failure(
+            cmd.id,
+            "VALIDATION_ERROR",
+            "Node has no property '{}'.".format(cmd.params.get("property")),
+        )
+    return _addon_base(cmd)
+
+
+async def test_set_node_property_suggests_closest_matches() -> None:
+    conn = FakeAddonConnection(responder=_respond_with_suggestions)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "set_node_property",
+            {"node_path": "Player", "property": "positoin", "value": 1},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "position" in text
+    assert "suggestions=" in text
+
+
+async def test_set_node_property_no_suggestions_when_list_empty() -> None:
+    def _empty(cmd: CommandEnvelope) -> ResponseEnvelope:
+        if cmd.command == "cmd_get_node_property_list":
+            return ResponseEnvelope.success(
+                cmd.id, {"node_path": cmd.params["node_path"], "properties": []}
+            )
+        if cmd.command == "cmd_set_node_property":
+            return ResponseEnvelope.failure(
+                cmd.id, "VALIDATION_ERROR", "Node has no property 'bad'."
+            )
+        return _addon_base(cmd)
+
+    conn = FakeAddonConnection(responder=_empty)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "set_node_property",
+            {"node_path": "Player", "property": "bad", "value": 1},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "has no property 'bad'" in text
+    # No suggestions bracket when the list is empty.
+    assert "suggestions=" not in text
+
+
 async def test_delete_without_confirm_is_blocked() -> None:
     server, conn = _build()
     async with Client(server) as client:

--- a/tests/unit/test_suggestions.py
+++ b/tests/unit/test_suggestions.py
@@ -1,0 +1,33 @@
+"""Unit tests for the suggestion engine (issue #109)."""
+
+from __future__ import annotations
+
+from mcp_server.suggestions import suggest
+
+
+def test_exact_match_is_first() -> None:
+    result = suggest("position", ["position", "global_position"])
+    assert result[0] == "position"
+    assert len(result) >= 1
+
+
+def test_typo_returns_closest() -> None:
+    result = suggest("positoin", ["position", "position_smoothing_enabled", "global_position"])
+    assert result[0] == "position"
+
+
+def test_empty_given_returns_empty() -> None:
+    assert suggest("", ["a", "b"]) == []
+
+
+def test_no_candidates_returns_empty() -> None:
+    assert suggest("x", []) == []
+
+
+def test_below_cutoff_returns_empty() -> None:
+    assert suggest("zzzzzz", ["position"]) == []
+
+
+def test_returns_up_to_n() -> None:
+    result = suggest("pos", ["position", "position_smoothing_enabled", "global_position"], n=2)
+    assert len(result) <= 2


### PR DESCRIPTION
## Summary

When `set_node_property` fails because the target property doesn't exist, the server now queries the addon for the node's full property list and returns the closest matching suggestions (via `difflib.get_close_matches`).

## Changes

- `mcp_server/suggestions.py` — lightweight difflib-based suggestion engine.
- `get_node_property_list(node_path)` — new inspection tool that queries `cmd_get_node_property_list` on the addon and returns all property names + node type.
- `cmd_get_node_property_list` — new addon handler in `handlers/scene_inspect.gd`.
- `set_node_property` — on property-not-found, enriches the error with suggestions: `Node has no property 'X'. Did you mean: position, position_smoothing_enabled? [suggestions=[...]]`.

## Acceptance criteria

- [x] Extend `mcp_server/tools/mutation.py` (`set_node_property`)
- [x] Unit tests for suggestion ranking
- [x] Contract tests verifying `suggestions=` exists in error payload
- [x] Docs updated (`docs/tool-contracts.md`)
- [x] Zero skipped tests