### PR TITLE
feat(debugger): Tier 2 step control (closes #110)

### DIFF
--- a/godot/addons/godot_mcp/handlers/debugger.gd
+++ b/godot/addons/godot_mcp/handlers/debugger.gd
@@ -18,6 +18,12 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_remove_breakpoint"] = _cmd_remove_breakpoint
 	handlers["cmd_clear_breakpoints"] = _cmd_clear_breakpoints
 	handlers["cmd_force_break"] = _cmd_force_break
+# Tier 2: step control via EditorDebuggerSession.send_message
+	handlers["cmd_step_into"] = _cmd_step
+	handlers["cmd_step_over"] = _cmd_step
+	handlers["cmd_step_out"] = _cmd_step
+	handlers["cmd_continue_execution"] = _cmd_continue
+
 
 
 # -- handlers ----------------------------------------------------------------
@@ -81,3 +87,54 @@ func _cmd_force_break(_params: Dictionary) -> Dictionary:
 		return guard
 	_router._debugger.send_to_probe("godot_mcp:force_break", [])
 	return _router._ok({"force_break_sent": true})
+
+
+# Tier 2: step control via EditorDebuggerSession.send_message ----------------
+
+## Maps the MCP tool name (from the command string) to the Godot debugger protocol
+## message string sent to the session.
+const _STEP_COMMANDS: Dictionary = {
+	"cmd_step_into": "step",
+	"cmd_step_over": "next",
+	"cmd_step_out": "out",
+}
+
+
+func _cmd_step(params: Dictionary, command: String) -> Dictionary:
+	var guard := _router._require_debug_session()
+	if not guard["ok"]:
+		return guard
+
+	var debugger := _router._debugger as MCPDebugger
+	var session := debugger.get_session(debugger.get_session_id())
+	if not session.is_breaked():
+		return _router._fail(
+			"PRECONDITION_FAILED",
+			"The game is not paused. Set a breakpoint or force_break first.",
+			"break_state",
+		)
+
+	var msg: String = _STEP_COMMANDS.get(command, "")
+	if msg.is_empty():
+		return _router._fail("INTERNAL_ERROR", "Unknown step command '%s'." % command)
+
+	session.send_message(msg, [])
+	return _router._ok({"stepped": true})
+
+
+func _cmd_continue(_params: Dictionary) -> Dictionary:
+	var guard := _router._require_debug_session()
+	if not guard["ok"]:
+		return guard
+
+	var debugger := _router._debugger as MCPDebugger
+	var session := debugger.get_session(debugger.get_session_id())
+	if not session.is_breaked():
+		return _router._fail(
+			"PRECONDITION_FAILED",
+			"The game is not paused. Set a breakpoint or force_break first.",
+			"break_state",
+		)
+
+	session.send_message("continue", [])
+	return _router._ok({"running": true})

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -22,6 +22,9 @@ var _ui_pending := "__none__"  # request_id of the in-flight find_ui request (#3
 var _recorded_input: Variant = null  # last godot_mcp:recorded_input payload (#68)
 var _performance: Variant = null  # last godot_mcp:performance payload (#38)
 var _breakpoints: Array = []  # tracked breakpoints for issue #110
+var _stack_frames: Variant = null  # last stack_dump payload (Tier 2)
+var _evaluation_result: Variant = null  # last evaluation_return payload (Tier 2)
+var _frame_vars: Variant = null  # last stack_frame_vars payload (Tier 2)
 
 
 func _has_capture(capture: String) -> bool:
@@ -80,6 +83,9 @@ func _on_stopped() -> void:
 	_ui_pending = "__none__"
 	_recorded_input = null
 	_performance = null
+	_stack_frames = null
+	_evaluation_result = null
+	_frame_vars = null
 
 
 ## Ask the running game's probe to (re)send the scene tree. The reply lands in the cache
@@ -151,6 +157,20 @@ func clear_recorded_input() -> void:
 
 func get_performance() -> Variant:
 	return _performance
+
+
+## Cache accessors for Tier 2 debugger tools (step, stack, eval).
+
+func get_cached_stack_frames() -> Variant:
+	return _stack_frames
+
+
+func get_cached_evaluation() -> Variant:
+	return _evaluation_result
+
+
+func get_cached_frame_vars() -> Variant:
+	return _frame_vars
 
 
 ## Return the current session ID so handlers can call get_session().

--- a/mcp_server/models/debugger.py
+++ b/mcp_server/models/debugger.py
@@ -1,4 +1,4 @@
-"""Typed results for debugger breakpoint control tools (issue #110, Tier 1)."""
+"""Typed results for debugger breakpoint control tools (issue #110, Tier 1 + Tier 2)."""
 
 from __future__ import annotations
 
@@ -24,3 +24,15 @@ class ForceBreakResult(BaseModel):
     """Outcome of requesting a forced break in the running game."""
 
     force_break_sent: bool = False
+
+
+class StepResult(BaseModel):
+    """Outcome of a debugger step command."""
+
+    stepped: bool = False
+
+
+class ContinueResult(BaseModel):
+    """Outcome of resuming execution after a breakpoint."""
+
+    running: bool = False

--- a/mcp_server/tools/debugger.py
+++ b/mcp_server/tools/debugger.py
@@ -1,7 +1,12 @@
-"""Debugger breakpoint control tools (issue #110, Tier 1).
+"""Debugger breakpoint control tools (issue #110, Tier 1 + Tier 2).
 
-Control breakpoints in a running editor play session via the debugger session.
-Requires a play session; the game must be connected to the editor debugger.
+Control breakpoints and step execution in a running editor play session via the
+debugger session. Requires a play session; the game must be connected to the
+editor debugger.
+
+Tier 1: set_breakpoint, remove_breakpoint, clear_breakpoints, force_break
+Tier 2: step_into, step_over, step_out, continue_execution
+
 Gated in the ``debugger`` toolset.
 """
 
@@ -14,7 +19,9 @@ from mcp_server.categories import DEBUGGER_TAG
 from mcp_server.models.debugger import (
     BreakpointResult,
     ClearBreakpointsResult,
+    ContinueResult,
     ForceBreakResult,
+    StepResult,
 )
 from mcp_server.safety import RUNTIME
 from mcp_server.tools._route import route
@@ -23,7 +30,7 @@ DEBUGGER = {DEBUGGER_TAG}
 
 
 def register_debugger(mcp: FastMCP, bridge: Bridge) -> None:
-    """Register the debugger breakpoint control tools."""
+    """Register the debugger breakpoint and step control tools."""
 
     @mcp.tool(meta=RUNTIME, tags=DEBUGGER)
     async def set_breakpoint(path: str, line: int) -> BreakpointResult:
@@ -50,3 +57,29 @@ def register_debugger(mcp: FastMCP, bridge: Bridge) -> None:
         Requires a play session with the godot-mcp runtime probe autoload.
         """
         return ForceBreakResult(**await route(bridge, "cmd_force_break", {}))
+
+    # Tier 2: step control --------------------------------------------------
+
+    @mcp.tool(meta=RUNTIME, tags=DEBUGGER)
+    async def step_into() -> StepResult:
+        """Step into the next line of GDScript execution. The game must be paused
+        (e.g. at a breakpoint or after force_break)."""
+        return StepResult(**await route(bridge, "cmd_step_into"))
+
+    @mcp.tool(meta=RUNTIME, tags=DEBUGGER)
+    async def step_over() -> StepResult:
+        """Step over the next line of GDScript execution, treating function calls
+        as a single step. The game must be paused."""
+        return StepResult(**await route(bridge, "cmd_step_over"))
+
+    @mcp.tool(meta=RUNTIME, tags=DEBUGGER)
+    async def step_out() -> StepResult:
+        """Step out of the current function, pausing at the caller's next line
+        of GDScript execution. The game must be paused."""
+        return StepResult(**await route(bridge, "cmd_step_out"))
+
+    @mcp.tool(meta=RUNTIME, tags=DEBUGGER)
+    async def continue_execution() -> ContinueResult:
+        """Resume GDScript execution after a breakpoint or forced break.
+        The game must be paused."""
+        return ContinueResult(**await route(bridge, "cmd_continue_execution"))

--- a/tests/contract/test_debugger_tier2.py
+++ b/tests/contract/test_debugger_tier2.py
@@ -1,0 +1,111 @@
+"""Contract tests for Tier 2 debugger step/continue tools (issue #110 follow-up).
+
+Four new `runtime` tools in the existing `debugger` toolset:
+step_into, step_over, step_out, continue_execution.
+
+All require an active play session with a valid debug session, and the game
+must be paused (either at a breakpoint or after force_break).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    match cmd.command:
+        case (
+            "cmd_set_breakpoint"
+            | "cmd_remove_breakpoint"
+            | "cmd_clear_breakpoints"
+            | "cmd_force_break"
+        ):
+            return ResponseEnvelope.success(cmd.id, {})
+        case "cmd_step_into" | "cmd_step_over" | "cmd_step_out":
+            return ResponseEnvelope.success(cmd.id, {"stepped": True})
+        case "cmd_continue_execution":
+            return ResponseEnvelope.success(cmd.id, {"running": True})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+def _commands(conn: FakeAddonConnection) -> list[str]:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+
+
+async def test_gated_in_debugger_toolset() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        assert "step_into" not in {t.name for t in await client.list_tools()}
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        names = {t.name for t in await client.list_tools()}
+    assert {
+        "set_breakpoint",
+        "remove_breakpoint",
+        "clear_breakpoints",
+        "force_break",
+        "step_into",
+        "step_over",
+        "step_out",
+        "continue_execution",
+    } <= names
+
+
+async def test_step_into() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("step_into", {})
+    assert result.structured_content["stepped"] is True
+    assert "cmd_step_into" in _commands(conn)
+
+
+async def test_step_over() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("step_over", {})
+    assert result.structured_content["stepped"] is True
+    assert "cmd_step_over" in _commands(conn)
+
+
+async def test_step_out() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("step_out", {})
+    assert result.structured_content["stepped"] is True
+    assert "cmd_step_out" in _commands(conn)
+
+
+async def test_continue_execution() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("continue_execution", {})
+    assert result.structured_content["running"] is True
+    assert "cmd_continue_execution" in _commands(conn)
+
+
+async def test_tier2_tools_are_runtime_class() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "debugger"})
+        for name in ("step_into", "step_over", "step_out", "continue_execution"):
+            tool = next(t for t in await client.list_tools() if t.name == name)
+            assert tool.meta is not None
+            assert tool.meta.get("safety_class") == "runtime"


### PR DESCRIPTION
## Summary

Implements the Tier 2 debugger tools recommended by the feasibility report (`docs/debugger_feasibility.md`).

## Tier 2 tools (gated `debugger` toolset, `runtime` class)

| Tool | Protocol message | Description |
|------|-----------------|-------------|
| `step_into` | `step` | Step into the next line |
| `step_over` | `next` | Step over (treat function call as one step) |
| `step_out` | `out` | Step out of current function |
| `continue_execution` | `continue` | Resume execution after breakpoint |

All tools:
- Require an active debug session (`_require_debug_session`)
- Require the game to be in a break state (`session.is_breaked()`) — validated addon-side with `PRECONDITION_FAILED` / `required=break_state`
- Send protocol messages via `EditorDebuggerSession.send_message()` — the same mechanism Godot's Script Debugger UI uses

## Addon changes

- Added `MCPDebugger._stack_frames`, `._evaluation_result`, `._frame_vars` caches (structural, for future stack/eval tools)
- Added `_cmd_step` and `_cmd_continue` handlers in `godot/addons/godot_mcp/handlers/debugger.gd`
- Added `MCPDebugger.get_cached_stack_frames()` / `.get_cached_evaluation()` / `.get_cached_frame_vars()`

## Server changes

- Added `StepResult` and `ContinueResult` to `mcp_server/models/debugger.py`
- Registered `step_into`, `step_over`, `step_out`, `continue_execution` in `mcp_server/tools/debugger.py`

## Test plan

```
uv run pytest tests/contract tests/unit -q
uv run ruff check .
./.claude/hooks/check-no-skipped-tests.sh
```

All green: 367 passed, lint clean, zero skips.

## References

- Feasibility report: `docs/debugger_feasibility.md`
- Godot source: `core/debugger/remote_debugger.cpp` (lines ~500–550)
