### PR TITLE
feat(docstrings): embed error recovery hints in tool descriptions (#129)

### DIFF
--- a/examples/vampire/.gitignore
+++ b/examples/vampire/.gitignore
@@ -1,0 +1,5 @@
+# E2E scratch files
+tmp_e2e_*
+session_*.tscn
+e2e_scratch.tscn
+default_bus_layout.tres

--- a/mcp_server/tools/input_sim.py
+++ b/mcp_server/tools/input_sim.py
@@ -54,6 +54,11 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
         WHEN NOT TO USE: You need a timed sequence of many inputs — use
         play_input_sequence(events=[...], delay_ms=...) instead. That replays a
         whole macro with configurable delays between events.
+
+        IF THIS FAILS with "No play session":
+          → Call play_scene(scene_path) first, then retry.
+        IF THIS FAILS with "probe not connected":
+          → Register MCPRuntimeProbe as autoload (get_project_info() to check).
         """
         params = {
             "key": key,
@@ -77,6 +82,11 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
         """Send a mouse event at viewport position (``x``, ``y``). With ``button`` empty,
         sends motion (with optional ``relative_x``/``relative_y``); with ``button`` =
         left/right/middle/wheel_up/wheel_down, sends a button press/release (``pressed``).
+
+        IF THIS FAILS with "No play session":
+          → Call play_scene(scene_path) first, then retry.
+        IF THIS FAILS with "probe not connected":
+          → Register MCPRuntimeProbe as autoload (get_project_info() to check).
         """
         params = {
             "x": x,
@@ -95,6 +105,14 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
         """Press or release an input-map action (e.g. "ui_accept", "jump") on the running
         game. ``strength`` (0..1) applies to a press. The action must exist in the
         project's Input Map.
+
+        IF THIS FAILS with "No play session":
+          → Call play_scene(scene_path) first, then retry.
+        IF THIS FAILS with "probe not connected":
+          → Register MCPRuntimeProbe as autoload (get_project_info() to check).
+        IF THIS FAILS with "unknown action":
+          → The action is not in the project's Input Map. Add it via
+            ProjectSettings → InputMap or use simulate_key() with the raw key name.
         """
         params = {"action": action, "pressed": pressed, "strength": strength}
         return SimInputResult(**await route(bridge, "cmd_simulate_action", params))

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -102,6 +102,11 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
     ) -> CreateNodeResult:
         """Create a node of ``node_type`` named ``node_name`` under ``parent_path``
         (scene-relative; "." is the root). Reversible via the editor's undo.
+
+        IF THIS FAILS with "active_scene":
+          -> No scene is open. Call open_scene(path) or create_scene(path) first.
+        IF THIS FAILS with "parent not found":
+          -> parent_path is wrong. Use get_scene_tree() to see actual node paths.
         """
         await require_active_scene(bridge)
         await require_node_exists(bridge, parent_path)
@@ -135,6 +140,12 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         """Set ``property`` on the node at ``node_path`` to ``value``. Godot types
         (Vector2/3, Color, Rect2 as objects; NodePath as string) are coerced by the
         addon to match the property's declared type.
+
+        IF THIS FAILS with "Node not found":
+          -> node_path is wrong. Use get_scene_tree() to see actual paths.
+        IF THIS FAILS with "has no property":
+          -> The property name is wrong. Use get_node_property_list(node_path) to
+             see valid property names for that node type.
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "property": property, "value": value}

--- a/mcp_server/tools/physics.py
+++ b/mcp_server/tools/physics.py
@@ -41,6 +41,10 @@ def register_physics(mcp: FastMCP, bridge: Bridge) -> None:
     ) -> SetupBodyResult:
         """Set physics properties (e.g. mass, gravity_scale) on the body/area at
         ``node_path`` in one call. The node must be a CollisionObject2D/3D.
+
+        IF THIS FAILS with "Node not found":
+          -> The node_path is wrong. Use get_scene_tree() to see the actual
+             node names and paths in the current scene.
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "properties": properties}
@@ -61,6 +65,9 @@ def register_physics(mcp: FastMCP, bridge: Bridge) -> None:
         """Add a collision shape under the body/area at ``node_path``: creates a
         ``collision_node_type`` (CollisionShape2D/3D) holding a ``shape_type`` shape
         (e.g. RectangleShape2D) with ``properties`` (size/radius/…).
+
+        IF THIS FAILS with "Node not found":
+          -> The node_path is wrong. Use get_scene_tree() to verify the path.
         """
         await require_node_exists(bridge, node_path)
         params = {

--- a/mcp_server/tools/runtime_inspect.py
+++ b/mcp_server/tools/runtime_inspect.py
@@ -40,6 +40,14 @@ def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
         absolute path from ``get_game_scene_tree``, e.g. "/root/Main/Player"). The probe
         captures ``samples`` readings, one per frame; collect them with
         ``get_property_samples``. Requires a play session + runtime probe.
+
+        IF THIS FAILS with "No play session":
+          -> Call play_scene(scene_path) first.
+        IF THIS FAILS with "probe not connected":
+          -> Register MCPRuntimeProbe as autoload (get_project_info() to check).
+        IF THIS FAILS with "node not found":
+          -> The node_path is wrong for the LIVE tree. Use get_game_scene_tree()
+             (not get_scene_tree()) to see running node paths.
         """
         params = {"node_path": node_path, "property": property, "samples": samples}
         return MonitorResult(**await route(bridge, "cmd_monitor_property", params))

--- a/mcp_server/tools/runtime_session.py
+++ b/mcp_server/tools/runtime_session.py
@@ -34,6 +34,13 @@ def register_runtime_session(mcp: FastMCP, bridge: Bridge) -> None:
         WHEN NOT TO USE: Headless CI/automation without an editor — use
         run_and_capture() instead. That runs Godot in a subprocess and returns
         logs without an editor session.
+
+        IF THIS FAILS with "scene not found":
+          -> The scene_path is wrong. Use get_project_info() to find the main scene,
+             or get_scene_tree() to see available scenes.
+        IF THIS FAILS with "editor not connected":
+          -> The Godot editor is not running or the addon is disabled. Check
+             get_server_info() for bridge state and follow the troubleshoot prompt.
         """
         params = {"scene_path": scene_path}
         return PlayResult(**await route(bridge, "cmd_play_scene", params))


### PR DESCRIPTION
Closes #129

## What
Embeds **error recovery hints** directly in the docstrings of tools that the eval suite showed had common precondition/validation failures. Agents now get actionable next steps when a tool fails.

## Tools Updated

| Tool | Failure Handled |
|------|----------------|
| `simulate_key` | "No play session" → call play_scene() first |
| `simulate_mouse` | "probe not connected" → register MCPRuntimeProbe |
| `simulate_action` | "unknown action" → add to Input Map or use simulate_key() |
| `play_scene` | "scene not found" → check get_project_info() for main scene |
| `play_scene` | "editor not connected" → troubleshoot bridge |
| `setup_physics_body` | "Node not found" → use get_scene_tree() to verify path |
| `setup_collision` | "Node not found" → use get_scene_tree() to verify path |
| `create_node` | "active_scene" → open_scene() first |
| `create_node` | "parent not found" → verify parent_path |
| `set_node_property` | "Node not found" → verify node_path |
| `set_node_property` | "has no property" → use get_node_property_list() |
| `monitor_property` | "No play session" → call play_scene() first |
| `monitor_property` | "probe not connected" → register MCPRuntimeProbe |
| `monitor_property` | "node not found" → use get_game_scene_tree() (not get_scene_tree) |

## Testing
- Contract tests: 243 passed, 0 failed, 0 skipped
- All hints match error codes from `error-handling.md`

## Related
- Eval results: `evals/results/comprehensive_suite_results.md`
- Issue: #129