### PR TITLE
fix(debugger): check_force_break() helper and documentation (#131)

### DIFF
--- a/docs/debugger_feasibility.md
+++ b/docs/debugger_feasibility.md
@@ -19,7 +19,7 @@ A Tier 2 debugger toolset (`step_*`, `continue`, `get_stack_frames`, `evaluate_e
 | `set_breakpoint` | `session.set_breakpoint(path, line, true)` | `EditorDebuggerSession.set_breakpoint` (direct API) |
 | `remove_breakpoint` | `session.set_breakpoint(path, line, false)` | Direct API |
 | `clear_breakpoints` | `session.set_breakpoint(..., false)` per tracked + probe message | Iterative + probe message |
-| `force_break` | `debugger.send_to_probe("godot_mcp:force_break", [])` | `EngineDebugger.debug(true)` in probe |
+| `force_break` | `debugger.send_to_probe("godot_mcp:force_break", [])` | Flag-based (`check_force_break()`) in probe — see **Limitations** below |
 
 ### Key signals
 
@@ -137,6 +137,22 @@ The evaluator in the game requires a **valid script instance** at the target fra
 {"ok": false, "error": "EVALUATION_ERROR",
  "hint": "Expression could not be evaluated. The frame may be static or the instance freed."}
 ```
+
+---
+
+## Limitations
+
+### `force_break` deadlock (issue #131)
+
+Calling `EngineDebugger.debug(true, false)` from inside `MCPRuntimeProbe._capture()`
+deadlocks: `debug()` blocks until the editor replies with `continue`/`step`, but the
+editor can't send anything because `_capture()` never returns (it is waiting for
+`debug()` to return).
+
+**Workaround**: `force_break` sets `force_break_pending = true` inside `_capture()`;
+the game checks the flag in its `_process` / `_physics_process` loop via
+`MCPRuntimeProbe.check_force_break()` and calls `breakpoint` when true. This
+requires the consuming game to poll the flag — a documented limitation.
 
 ---
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -702,7 +702,7 @@ Control breakpoints, step execution, and inspect the paused call stack in a runn
 | `clear_breakpoints` | — | `ClearBreakpointsResult { breakpoints_cleared }` |
 | `force_break` | — | `ForceBreakResult { force_break_sent }` |
 
-`set_breakpoint` uses `EditorDebuggerSession.set_breakpoint(path, line, true)`; `remove_breakpoint` uses `set_breakpoint(path, line, false)`. `clear_breakpoints` clears on the game side via the probe (when connected) and removes any individually tracked breakpoints on the editor side. `force_break` sends `EngineDebugger.debug(true, false)` through the probe to trigger an immediate break.
+`set_breakpoint` uses `EditorDebuggerSession.set_breakpoint(path, line, true)`; `remove_breakpoint` uses `set_breakpoint(path, line, false)`. `clear_breakpoints` clears on the game side via the probe (when connected) and removes any individually tracked breakpoints on the editor side. `force_break` sets `force_break_pending = true` in the probe; the game must call `MCPRuntimeProbe.check_force_break()` in its main loop (see `docs/debugger_feasibility.md` § Limitations).
 
 **Tier 2 — step control & stack inspection (issue #110 follow-up):**
 

--- a/examples/vampire/scripts/debugger_demo.gd
+++ b/examples/vampire/scripts/debugger_demo.gd
@@ -19,9 +19,7 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	# Check for MCP force_break request
-	if MCPRuntimeProbe.force_break_pending:
-		MCPRuntimeProbe.force_break_pending = false
-		breakpoint
+	MCPRuntimeProbe.check_force_break()
 	
 	if not demo_enabled:
 		return

--- a/examples/vampire/scripts/player.gd
+++ b/examples/vampire/scripts/player.gd
@@ -35,11 +35,9 @@ func _draw() -> void:
 
 func _physics_process(delta: float) -> void:
 	# MCP debugger: check for force_break request
-	if MCPRuntimeProbe.force_break_pending:
-		MCPRuntimeProbe.force_break_pending = false
-		breakpoint
+	MCPRuntimeProbe.check_force_break()
 	
-i 	if not alive:
+	if not alive:
 		return
 	
 	# WASD / arrow key movement

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -15,6 +15,18 @@ const MAX_DEPTH := 32
 var force_break_pending: bool = false  ## Set true by the editor via force_break message.
 
 
+## Check if the editor has requested a force_break and trigger ``breakpoint`` if so.
+## Call this from the game's ``_process`` or ``_physics_process`` loop. Returns
+## ``true`` if a break was triggered, ``false`` otherwise.
+func check_force_break() -> bool:
+	if force_break_pending:
+		force_break_pending = false
+		breakpoint
+		return true
+	return false
+
+
+
 func _ready() -> void:
 	if EngineDebugger.is_active():
 		EngineDebugger.register_message_capture("godot_mcp", _capture)


### PR DESCRIPTION
Closes #131

## What
Fixes the `force_break` reliability issue by:
1. Adding `MCPRuntimeProbe.check_force_break()` helper to encapsulate the flag-check + `breakpoint` call
2. Updating example scripts to use the helper
3. Documenting the deadlock limitation in both feasibility report and tool contracts

## The Problem
Calling `EngineDebugger.debug(true, false)` from inside `MCPRuntimeProbe._capture()` deadlocks because `debug()` blocks until the editor replies with `continue`/`step`, but the editor can't send anything because `_capture()` never returns.

## The Fix
- `force_break` now sets `force_break_pending = true` inside `_capture()`
- `check_force_break()` is a new method that games call from `_process`/`_physics_process`
- Returns `true` if a break was triggered, `false` otherwise

## Files Changed
- `godot/addons/godot_mcp/mcp_runtime_probe.gd`: Added `check_force_break()` method
- `examples/vampire/scripts/debugger_demo.gd`: Replaced inline flag check with helper
- `examples/vampire/scripts/player.gd`: Replaced inline flag check with helper
- `docs/debugger_feasibility.md`: Added **Limitations** section documenting deadlock + workaround
- `docs/tool-contracts.md`: Corrected `force_break` description

## Testing
- Contract tests: 243 passed, 0 failed, 0 skipped
- No logic changes to server-side code (addon-only fix)

## Related
- Issue: #131