### PR TITLE
fix(addon): make connect_signal idempotent for existing scene connections

### DIFF
--- a/godot/addons/godot_mcp/handlers/mutation.gd
+++ b/godot/addons/godot_mcp/handlers/mutation.gd
@@ -168,17 +168,11 @@ func _cmd_connect_signal(params: Dictionary) -> Dictionary:
 			"VALIDATION_ERROR",
 			"Source '%s' has no signal '%s'. Available: %s." % [source.name, signal_name, _signal_names_hint(source)]
 		)
-	# has_method() already resolves script methods and built-in virtuals (e.g.
-	# _ready); the script method-list is a fallback for tool-script methods that
-	# aren't yet registered on the instance.
-	if not _has_callable_method(target, method_name):
-		return _router._fail(
-			"VALIDATION_ERROR",
-			"Target '%s' has no method '%s'. Attach a script defining it, or choose an existing method." % [target.name, method_name]
-		)
 	var callable := Callable(target, method_name)
-	# Idempotent: a connection already present (often persisted in the scene
-	# file) is success, not failure — re-running the same connect is a no-op.
+	# Check the idempotent path FIRST: a connection already present (often
+	# persisted in the scene file) is success, not failure — and short-circuiting
+	# here means a method-resolution quirk can never turn an existing connection
+	# into a false failure (the original bug class in #152).
 	if source.is_connected(signal_name, callable):
 		return _router._ok({
 			"source_path": str(params.get("source_path")),
@@ -188,6 +182,14 @@ func _cmd_connect_signal(params: Dictionary) -> Dictionary:
 			"connected": true,
 			"already_connected": true,
 		})
+	# For a *fresh* connect, the method must resolve. has_method() already covers
+	# script methods and built-in virtuals (e.g. _ready); the script method-list
+	# is a fallback for tool-script methods not yet registered on the instance.
+	if not _has_callable_method(target, method_name):
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Target '%s' has no method '%s'. Attach a script defining it, or choose an existing method." % [target.name, method_name]
+		)
 
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Connect %s" % signal_name)
@@ -217,7 +219,7 @@ func _has_callable_method(node: Node, method_name: String) -> bool:
 
 
 func _signal_names_hint(node: Node) -> String:
-	var names: PackedStringArray = []
+	var names := PackedStringArray()
 	for s in node.get_signal_list():
 		names.append(str(s.get("name", "")))
 		if names.size() >= 8:

--- a/godot/addons/godot_mcp/handlers/mutation.gd
+++ b/godot/addons/godot_mcp/handlers/mutation.gd
@@ -164,12 +164,30 @@ func _cmd_connect_signal(params: Dictionary) -> Dictionary:
 	var signal_name := str(params.get("signal_name", ""))
 	var method_name := str(params.get("method_name", ""))
 	if not source.has_signal(signal_name):
-		return _router._fail("VALIDATION_ERROR", "Source has no signal '%s'." % signal_name)
-	if not target.has_method(method_name):
-		return _router._fail("VALIDATION_ERROR", "Target has no method '%s'." % method_name)
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Source '%s' has no signal '%s'. Available: %s." % [source.name, signal_name, _signal_names_hint(source)]
+		)
+	# has_method() already resolves script methods and built-in virtuals (e.g.
+	# _ready); the script method-list is a fallback for tool-script methods that
+	# aren't yet registered on the instance.
+	if not _has_callable_method(target, method_name):
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Target '%s' has no method '%s'. Attach a script defining it, or choose an existing method." % [target.name, method_name]
+		)
 	var callable := Callable(target, method_name)
+	# Idempotent: a connection already present (often persisted in the scene
+	# file) is success, not failure — re-running the same connect is a no-op.
 	if source.is_connected(signal_name, callable):
-		return _router._fail("VALIDATION_ERROR", "Signal '%s' is already connected to that method." % signal_name)
+		return _router._ok({
+			"source_path": str(params.get("source_path")),
+			"signal_name": signal_name,
+			"target_path": str(params.get("target_path")),
+			"method_name": method_name,
+			"connected": true,
+			"already_connected": true,
+		})
 
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Connect %s" % signal_name)
@@ -183,7 +201,28 @@ func _cmd_connect_signal(params: Dictionary) -> Dictionary:
 		"target_path": str(params.get("target_path")),
 		"method_name": method_name,
 		"connected": true,
+		"already_connected": false,
 	})
+
+
+func _has_callable_method(node: Node, method_name: String) -> bool:
+	if node.has_method(method_name):
+		return true
+	var script: Script = node.get_script()
+	if script != null:
+		for m in script.get_script_method_list():
+			if str(m.get("name", "")) == method_name:
+				return true
+	return false
+
+
+func _signal_names_hint(node: Node) -> String:
+	var names: PackedStringArray = []
+	for s in node.get_signal_list():
+		names.append(str(s.get("name", "")))
+		if names.size() >= 8:
+			break
+	return ", ".join(names)
 
 
 

--- a/godot/addons/godot_mcp/handlers/node_parity.gd
+++ b/godot/addons/godot_mcp/handlers/node_parity.gd
@@ -168,11 +168,15 @@ func _cmd_disconnect_signal(params: Dictionary) -> Dictionary:
 	var method_name := str(params.get("method_name", ""))
 	if not source.has_signal(signal_name):
 		return _router._fail("VALIDATION_ERROR", "Source has no signal '%s'." % signal_name)
-	if not target.has_method(method_name):
-		return _router._fail("VALIDATION_ERROR", "Target has no method '%s'." % method_name)
+	# is_connected is the authoritative gate here: a missing/garbage method
+	# simply isn't connected, so we skip a separate has_method pre-check (which
+	# could false-fail on virtual targets) and report the connection state.
 	var callable := Callable(target, method_name)
 	if not source.is_connected(signal_name, callable):
-		return _router._fail("VALIDATION_ERROR", "Signal '%s' is not connected to that method." % signal_name)
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Signal '%s' is not connected from '%s' to '%s.%s'." % [signal_name, source.name, target.name, method_name]
+		)
 
 	# Capture the original flags so undo restores the connection faithfully.
 	var flags := 0

--- a/mcp_server/models/mutation.py
+++ b/mcp_server/models/mutation.py
@@ -51,6 +51,9 @@ class ConnectSignalResult(BaseModel):
     target_path: str
     method_name: str
     connected: bool
+    # True when the connection already existed (e.g. saved in the scene file);
+    # the addon treats that as an idempotent success rather than a failure (#152).
+    already_connected: bool = False
     dry_run: bool = False
 
 

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -61,7 +61,12 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 {"node_path": p["node_path"], "script_path": p["script_path"], "attached": True},
             )
         case "cmd_connect_signal":
-            return ResponseEnvelope.success(cmd.id, {**p, "connected": True})
+            # Mimic the addon: a connection already saved in the scene file is
+            # reported as an idempotent success, not a failure (issue #152).
+            already = p.get("signal_name") == "ready"
+            return ResponseEnvelope.success(
+                cmd.id, {**p, "connected": True, "already_connected": already}
+            )
         case "cmd_save_scene":
             return ResponseEnvelope.success(cmd.id, {"path": "res://m.tscn", "saved": True})
         case "cmd_create_scene":
@@ -127,6 +132,42 @@ async def test_create_node_dry_run_sends_no_mutation() -> None:
     # Preview path mirrors the addon: a root child is "Player", not "./Player".
     assert result.structured_content["node_path"] == "Player"
     assert "cmd_create_node" not in _commands(conn)  # nothing was actually created
+
+
+async def test_connect_signal_reports_already_connected() -> None:
+    # Re-connecting a signal that's already saved in the scene must surface as an
+    # idempotent success (connected + already_connected), not a false failure.
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "connect_signal",
+            {
+                "source_path": "Player",
+                "signal_name": "ready",
+                "target_path": "Background",
+                "method_name": "_ready",
+            },
+        )
+    assert result.structured_content["connected"] is True
+    assert result.structured_content["already_connected"] is True
+
+
+async def test_connect_signal_fresh_connection_not_marked_already() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "connect_signal",
+            {
+                "source_path": "Button",
+                "signal_name": "pressed",
+                "target_path": "Player",
+                "method_name": "_on_pressed",
+            },
+        )
+    assert result.structured_content["connected"] is True
+    assert result.structured_content["already_connected"] is False
 
 
 async def test_set_property_maps_value_and_flag() -> None:


### PR DESCRIPTION
## Summary

Closes #152.

`connect_signal` failed 75–100% of the time in the 2026-06-11 cross-model eval. Root cause: the demo scene already persists `ready → Background._ready`, so the `is_connected()` pre-check returned true and the handler raised `VALIDATION_ERROR "already connected"` — agents had no way to recover.

## Changes (`godot/addons/godot_mcp/handlers/`)

- **`mutation.gd` — idempotent connect**: an already-present connection is now an idempotent success (`{connected: true, already_connected: true}`) instead of a failure. A fresh connect still wraps `EditorUndoRedoManager` with `CONNECT_PERSIST`.
- **Method validation fallback**: checks the target script's method list in addition to `has_method` (which already resolves built-in virtuals like `_ready`).
- **Actionable hints**: signal-missing lists available signals; method-missing names the target and suggests attaching a script — the three failure modes are now distinguishable.
- **`node_parity.gd` — disconnect**: dropped the redundant `has_method` pre-check (could false-fail on virtual targets); `is_connected` is the authoritative gate.
- **`ConnectSignalResult`** gains `already_connected: bool = False`.

## Acceptance criteria

- [x] Existing scene connections don't cause false failures (idempotent success)
- [x] Distinguish error types with actionable hints
- [x] UndoRedo still wraps the (fresh) connect
- [x] `connect_signal` for `ready → _ready` on Background succeeds

## Test plan

- New contract tests pin `already_connected` (true for re-connect, false for fresh) through the typed model.
- GDScript parses clean in the `godot/` project under **Godot 4.6.3** (`--headless --editor --quit`).
- `uv run pytest -q tests/unit tests/contract` → 374 passed; `mypy` clean; `ruff` clean on changed files.

## Notes

- The `test_addon_manifest` 4.4→4.6 one-liner also appears in #155 (identical change; harmless whichever lands first).
- ⚠️ Repo CI is currently red independent of this PR — `evals/` carries pre-existing `ruff` debt (E501/E402/F821) that fails `ruff check .` on `main`. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)