### PR TITLE
feat(evals): milestone enforcement to prevent half-task completion

### DIFF
--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -643,12 +643,15 @@ TASK_VALIDATORS: dict[str, Callable[[BridgeConnector], Awaitable[bool]]] = {
 # coverage — together they catch agents that do half a task then call done().
 # Names are the agent-facing (bare) tool names recorded in result.steps["tool"],
 # and a milestone is met only when that tool was called with ok=True (a failed
-# call hasn't achieved the sub-goal). Single-tool tasks are omitted — there the
-# tool_choice score already covers it.
+# call hasn't achieved the sub-goal). The required tools mirror what each task's
+# prompt mandates. Some tasks list a single milestone: there the one meaningful
+# action (e.g. attach_script) can be skipped while unrelated setup/verification
+# calls still succeed — which would otherwise score tool_choice=1.0 falsely.
 TASK_MILESTONES: dict[str, list[str]] = {
     # Mutation
     "mutate_create_and_property": ["create_node", "set_node_property"],
-    "mutate_delete_with_confirm": ["create_node", "delete_node"],
+    # The prompt mandates create_node AND delete_node AND get_scene_tree.
+    "mutate_delete_with_confirm": ["create_node", "delete_node", "get_scene_tree"],
     "mutate_rename": ["create_node", "rename_node"],
     "mutate_attach_script": ["attach_script"],
     # Scripts

--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -638,6 +638,53 @@ TASK_VALIDATORS: dict[str, Callable[[BridgeConnector], Awaitable[bool]]] = {
 }
 
 
+# Required tool calls a task must complete *before* done() counts. Complements
+# TASK_VALIDATORS: validators check the end state, milestones check step
+# coverage — together they catch agents that do half a task then call done().
+# Names are the agent-facing (bare) tool names recorded in result.steps["tool"],
+# and a milestone is met only when that tool was called with ok=True (a failed
+# call hasn't achieved the sub-goal). Single-tool tasks are omitted — there the
+# tool_choice score already covers it.
+TASK_MILESTONES: dict[str, list[str]] = {
+    # Mutation
+    "mutate_create_and_property": ["create_node", "set_node_property"],
+    "mutate_delete_with_confirm": ["create_node", "delete_node"],
+    "mutate_rename": ["create_node", "rename_node"],
+    "mutate_attach_script": ["attach_script"],
+    # Scripts
+    "script_write_and_read": ["write_script", "read_script"],
+    "script_patch": ["patch_script", "read_script"],
+    # Scene session
+    "scene_list_and_open": ["list_open_scenes", "save_all_scenes"],
+    # Signals
+    "signal_connect_ready": ["connect_signal"],
+    # Runtime (each needs a play session bracketed by stop)
+    "runtime_play_and_inspect": ["play_scene", "get_game_scene_tree", "stop_scene"],
+    "runtime_simulate_input": ["play_scene", "simulate_key", "stop_scene"],
+    "runtime_performance": ["play_scene", "get_performance_monitors", "stop_scene"],
+    "runtime_debugger_eval": ["play_scene", "evaluate_expression", "stop_scene"],
+    # End-to-end workflows
+    "workflow_create_character": [
+        "create_node",
+        "attach_script",
+        "set_node_property",
+        "save_scene",
+    ],
+    "workflow_script_and_play": ["write_script", "attach_script", "save_scene", "play_scene"],
+    "workflow_signal_and_test": ["connect_signal", "save_scene", "play_scene"],
+    "workflow_batch_mutation": ["create_node", "find_nodes_by_type", "batch_set_property"],
+}
+
+
+def _unmet_milestones(result: LLMTaskResult, task_name: str) -> list[str]:
+    """Return milestone tools the task required but never *successfully* called."""
+    required = TASK_MILESTONES.get(task_name)
+    if not required:
+        return []
+    succeeded = {s["tool"] for s in result.steps if s.get("ok")}
+    return [tool for tool in required if tool not in succeeded]
+
+
 TASK_PROMPTS: dict[str, str] = {
     # === INSPECTION (4 tasks) ===
     "inspect_scene_tree": (
@@ -1213,11 +1260,24 @@ class LLMTaskRunner:
             ratio = (real_step_count - optimal) / optimal
             score.efficiency = max(0.0, 1.0 - ratio * 0.5)
 
+        # --- MILESTONE CAP ---
+        # If the task defines required sub-steps and any was never successfully
+        # called, the agent finished half the task — cap each component to 0.3
+        # (so overall <= 0.3) regardless of how clean the steps it did run were.
+        unmet = _unmet_milestones(result, task_name)
+        if unmet:
+            score.notes = f"MILESTONE_UNMET: missing {', '.join(unmet)}"
+            score.tool_choice = min(score.tool_choice, 0.3)
+            score.prerequisites = min(score.prerequisites, 0.3)
+            score.recovery = min(score.recovery, 0.3)
+            score.efficiency = min(score.efficiency, 0.3)
+
         # --- VALIDATOR CAP ---
         # If a validator exists and failed, cap the overall score regardless
         # of other metrics. This prevents false-positive passes.
         if validation_passed is False:
-            score.notes = "VALIDATION_FAILED: Task goal not achieved"
+            existing = f"{score.notes}; " if score.notes else ""
+            score.notes = f"{existing}VALIDATION_FAILED: Task goal not achieved"
             # Cap individual scores to signal failure
             score.tool_choice = min(score.tool_choice, 0.5)
             score.prerequisites = min(score.prerequisites, 0.5)

--- a/tests/integration/test_eval_milestones.py
+++ b/tests/integration/test_eval_milestones.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Milestone-enforcement scoring tests (issue #150).
+
+Milestones complement the end-state validators (#145): they verify that each
+required sub-step actually happened, so an agent that does half a task and then
+calls ``done()`` is capped rather than scored as a pass.
+
+``_score_task`` reads only the result + module-level tables (not the bridge),
+so it is unit-testable with a hand-built ``LLMTaskResult``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evals.llm_eval_v2 import (  # noqa: E402
+    TASK_MILESTONES,
+    LLMTaskResult,
+    LLMTaskRunner,
+)
+
+
+def _runner() -> LLMTaskRunner:
+    # _score_task never touches the bridge; a placeholder is fine.
+    return LLMTaskRunner(bridge=None)  # type: ignore[arg-type]
+
+
+def _result(task: str, steps: list[tuple[str, bool]]) -> LLMTaskResult:
+    r = LLMTaskResult(task_name=task)
+    r.steps = [{"tool": t, "ok": ok, "error": None} for t, ok in steps]
+    r.first_attempt_correct = True
+    return r
+
+
+def test_milestones_defined_for_known_multistep_tasks() -> None:
+    assert TASK_MILESTONES["mutate_delete_with_confirm"] == ["create_node", "delete_node"]
+    assert "connect_signal" in TASK_MILESTONES["workflow_signal_and_test"]
+
+
+def test_done_before_milestones_caps_score() -> None:
+    # Created MutTest then called done — never deleted. Milestone unmet.
+    runner = _runner()
+    result = _result("mutate_delete_with_confirm", [("create_node", True), ("done", True)])
+    score = runner._score_task(result, "mutate_delete_with_confirm")
+    assert score.overall <= 0.3, f"half-task should cap at 0.3, got {score.overall}"
+    assert "MILESTONE" in score.notes
+
+
+def test_all_milestones_met_is_not_capped() -> None:
+    runner = _runner()
+    result = _result(
+        "mutate_delete_with_confirm",
+        [("create_node", True), ("delete_node", True), ("done", True)],
+    )
+    score = runner._score_task(result, "mutate_delete_with_confirm")
+    assert score.overall > 0.3, f"completed task wrongly milestone-capped: {score.overall}"
+
+
+def test_milestone_requires_successful_call_not_just_attempt() -> None:
+    # delete_node was called but FAILED — the sub-goal wasn't achieved.
+    runner = _runner()
+    result = _result(
+        "mutate_delete_with_confirm",
+        [("create_node", True), ("delete_node", False), ("done", True)],
+    )
+    score = runner._score_task(result, "mutate_delete_with_confirm")
+    assert score.overall <= 0.3
+
+
+def test_task_without_milestones_is_unaffected() -> None:
+    runner = _runner()
+    result = _result("profiling_fps", [("get_editor_performance", True), ("done", True)])
+    score = runner._score_task(result, "profiling_fps")
+    assert score.overall > 0.3
+    assert "MILESTONE" not in score.notes

--- a/tests/integration/test_eval_milestones.py
+++ b/tests/integration/test_eval_milestones.py
@@ -36,7 +36,12 @@ def _result(task: str, steps: list[tuple[str, bool]]) -> LLMTaskResult:
 
 
 def test_milestones_defined_for_known_multistep_tasks() -> None:
-    assert TASK_MILESTONES["mutate_delete_with_confirm"] == ["create_node", "delete_node"]
+    # Mirrors the prompt: create_node AND delete_node AND get_scene_tree.
+    assert TASK_MILESTONES["mutate_delete_with_confirm"] == [
+        "create_node",
+        "delete_node",
+        "get_scene_tree",
+    ]
     assert "connect_signal" in TASK_MILESTONES["workflow_signal_and_test"]
 
 
@@ -53,7 +58,7 @@ def test_all_milestones_met_is_not_capped() -> None:
     runner = _runner()
     result = _result(
         "mutate_delete_with_confirm",
-        [("create_node", True), ("delete_node", True), ("done", True)],
+        [("create_node", True), ("delete_node", True), ("get_scene_tree", True), ("done", True)],
     )
     score = runner._score_task(result, "mutate_delete_with_confirm")
     assert score.overall > 0.3, f"completed task wrongly milestone-capped: {score.overall}"


### PR DESCRIPTION
## Summary

Closes #150.

Agents could complete half a task and call `done()` with a passing score because no error occurred — e.g. `mutate_delete_with_confirm` creates `MutTest` then calls `done()` without ever deleting it. This adds step-coverage enforcement to complement the #145 end-state validators.

## Changes (`evals/llm_eval_v2.py`)

- **`TASK_MILESTONES`** — the required tool calls each multi-step task must complete before `done()` counts (mutation, scripts, scene-session, signals, runtime, and end-to-end workflows). Names are the agent-facing bare tool names recorded in `result.steps`; a milestone is met only when that tool was called with `ok=True` (a failed call hasn't achieved the sub-goal). Single-tool tasks are omitted — `tool_choice` already covers those.
- **`_score_task` milestone cap** — when any milestone is unmet, every score component is capped to `0.3` (so `overall <= 0.3`), applied *before* the validator cap; the `notes` compose so both reasons surface.

## Acceptance criteria

- [x] Milestones defined for the multi-step tasks
- [x] `done()` before milestones = score cap (≤ 0.3)
- [x] Milestones checked against actual (successful) tool calls, not availability
- [x] Tasks with all milestones met are not capped; tasks without milestones unaffected

## Test plan

- New `tests/integration/test_eval_milestones.py`: done-before-milestone caps, all-met uncapped, a *failed* milestone call still caps, no-milestone task unaffected, and the table is populated.
- `uv run pytest -q tests/unit tests/contract tests/integration/test_eval_milestones.py` → 379 passed; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)