### PR TITLE
feat(evals): dynamic corrective prompts after tool failures

### DIFF
--- a/evals/cloud_client.py
+++ b/evals/cloud_client.py
@@ -23,6 +23,8 @@ from typing import Any
 
 import httpx
 
+from evals.correction import format_correction
+
 
 @dataclass
 class CloudCall:
@@ -259,6 +261,10 @@ class CloudAgent:
         self._model = model or self.DEFAULT_MODELS[provider]
         self._api_key = api_key
         self._history: list[dict] = []
+        # Track the most recent call so a failure can be quoted back as a
+        # correction in the next user message (issue #149).
+        self._last_tool: str = ""
+        self._last_params: dict[str, Any] = {}
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""
@@ -309,6 +315,8 @@ class CloudAgent:
             "params": cloud_call.params,
             "reasoning": cloud_call.reasoning,
         })})
+        self._last_tool = cloud_call.tool
+        self._last_params = cloud_call.params
         return cloud_call
 
     async def _execute(self, call: CloudCall) -> dict:
@@ -333,14 +341,23 @@ class CloudAgent:
             return {"ok": False, "error": str(e), "hint": "Bridge execution failed", "done": False}
 
     def _add_result(self, result: dict) -> None:
-        """Add the tool result to history for the LLM."""
+        """Add the tool result to history for the LLM.
+
+        On failure, append a dynamic correction (issue #149) that quotes the
+        failed call and its hint, so the model adapts instead of repeating it.
+        """
         summary = json.dumps({
             "ok": result["ok"],
             "error": result.get("error"),
             "hint": result.get("hint"),
             "result_keys": list(result.get("result", {}).keys()),
         })
-        self._history.append({"role": "user", "content": f"Tool result: {summary}"})
+        content = f"Tool result: {summary}"
+        if not result.get("ok", True):
+            content += "\n" + format_correction(
+                self._last_tool, self._last_params, result.get("error"), result.get("hint")
+            )
+        self._history.append({"role": "user", "content": content})
 
     async def run_task(
         self,

--- a/evals/correction.py
+++ b/evals/correction.py
@@ -31,12 +31,15 @@ def format_correction(
     Names the failed ``tool(params)`` plus the ``error``/``hint`` and instructs
     the model not to repeat the same parameters.
     """
-    params_str = json.dumps(params, separators=(",", ":")) if params else "{}"
     err = (error or "ERROR").strip()
     hint_str = (hint or "").strip()
-    detail = f"{err}: {hint_str}" if hint_str else err
-    msg = (
-        f"CORRECTION: last call {tool}({params_str}) FAILED — {detail}. "
-        "Do NOT repeat the same parameters; apply the hint."
-    )
-    return msg[:limit]
+    # Keep the call signature from crowding out the instruction: a large
+    # payload (e.g. write_script `content`) is reduced to a short snippet.
+    params_str = json.dumps(params, separators=(",", ":")) if params else "{}"
+    if len(params_str) > 60:
+        params_str = params_str[:57] + "..."
+    # Lead with the error+hint (the actual fix) so it survives the cap even
+    # when the call signature that follows is long.
+    lead = f"CORRECTION ({err}): {hint_str}".rstrip()
+    tail = f" Your last call was {tool}({params_str}); do NOT repeat the same parameters."
+    return (lead + tail)[:limit]

--- a/evals/correction.py
+++ b/evals/correction.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Dynamic corrective-prompt formatting for eval agents (issue #149).
+
+Static system prompts get ignored after a few steps, so models repeat the same
+failing call 2–3× before recovering. After a failure we append a compact, high
+-attention correction to the *next user message* (not the system prompt) naming
+the exact call that failed and telling the model to apply the hint instead of
+repeating itself. Kept short to avoid token bloat.
+
+Shared by OllamaAgent and CloudAgent so the wording can't drift between them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Cap so the correction stays high-signal and cheap (issue #149 acceptance).
+CORRECTION_LIMIT = 200
+
+
+def format_correction(
+    tool: str,
+    params: dict[str, Any],
+    error: str | None,
+    hint: str | None,
+    limit: int = CORRECTION_LIMIT,
+) -> str:
+    """Return a one-line correction (<= ``limit`` chars) for a failed call.
+
+    Names the failed ``tool(params)`` plus the ``error``/``hint`` and instructs
+    the model not to repeat the same parameters.
+    """
+    params_str = json.dumps(params, separators=(",", ":")) if params else "{}"
+    err = (error or "ERROR").strip()
+    hint_str = (hint or "").strip()
+    detail = f"{err}: {hint_str}" if hint_str else err
+    msg = (
+        f"CORRECTION: last call {tool}({params_str}) FAILED — {detail}. "
+        "Do NOT repeat the same parameters; apply the hint."
+    )
+    return msg[:limit]

--- a/evals/ollama_agent.py
+++ b/evals/ollama_agent.py
@@ -24,6 +24,7 @@ import httpx
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))
 
+from evals.correction import format_correction  # noqa: E402
 from mcp_server.bridge import Bridge  # noqa: E402
 from mcp_server.config import BridgeConfig  # noqa: E402
 
@@ -59,6 +60,10 @@ class OllamaAgent:
         self._bridge = bridge
         self._model = model
         self._history: list[dict] = []
+        # Track the most recent call so a failure can be quoted back as a
+        # correction in the next user message (issue #149).
+        self._last_tool: str = ""
+        self._last_params: dict[str, Any] = {}
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""
@@ -149,9 +154,11 @@ class OllamaAgent:
                 }
 
         self._history.append({"role": "assistant", "content": json.dumps(parsed)})
+        self._last_tool = parsed.get("tool", "done")
+        self._last_params = parsed.get("params", {})
         return LLMCall(
-            tool=parsed.get("tool", "done"),
-            params=parsed.get("params", {}),
+            tool=self._last_tool,
+            params=self._last_params,
             reasoning=parsed.get("reasoning", ""),
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
@@ -179,14 +186,23 @@ class OllamaAgent:
             return {"ok": False, "error": str(e), "hint": "Bridge execution failed", "done": False}
 
     def _add_result(self, result: dict) -> None:
-        """Add the tool result to history for the LLM."""
+        """Add the tool result to history for the LLM.
+
+        On failure, append a dynamic correction (issue #149) that quotes the
+        failed call and its hint, so the model adapts instead of repeating it.
+        """
         summary = json.dumps({
             "ok": result["ok"],
             "error": result.get("error"),
             "hint": result.get("hint"),
             "result_keys": list(result.get("result", {}).keys()),
         })
-        self._history.append({"role": "user", "content": f"Tool result: {summary}"})
+        content = f"Tool result: {summary}"
+        if not result.get("ok", True):
+            content += "\n" + format_correction(
+                self._last_tool, self._last_params, result.get("error"), result.get("hint")
+            )
+        self._history.append({"role": "user", "content": content})
 
     async def run_task(
         self,

--- a/tests/integration/test_eval_corrections.py
+++ b/tests/integration/test_eval_corrections.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Dynamic corrective-prompt tests (issue #149).
+
+After a failed tool call, the agent injects a compact, high-attention
+correction into the next user message so it stops repeating the same mistake.
+The formatter and the injection are unit-testable without a live LLM/bridge.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evals.cloud_client import CloudAgent  # noqa: E402
+from evals.correction import CORRECTION_LIMIT, format_correction  # noqa: E402
+from evals.ollama_agent import OllamaAgent  # noqa: E402
+
+
+def test_format_correction_includes_call_error_and_hint() -> None:
+    msg = format_correction(
+        "attach_script",
+        {"node_path": "Background", "script_path": "res://background.gd"},
+        "RESOURCE_NOT_FOUND",
+        "The exact path is res://scripts/debugger_demo.gd.",
+    )
+    assert "attach_script" in msg
+    assert "RESOURCE_NOT_FOUND" in msg
+    assert "debugger_demo.gd" in msg
+    assert "CORRECTION" in msg
+
+
+def test_format_correction_capped() -> None:
+    msg = format_correction("t", {"x": "y" * 500}, "ERR", "h" * 500)
+    assert len(msg) <= CORRECTION_LIMIT
+
+
+def test_format_correction_handles_missing_hint() -> None:
+    msg = format_correction("play_scene", {}, "PRECONDITION_FAILED", None)
+    assert "play_scene" in msg and "PRECONDITION_FAILED" in msg
+
+
+def _failed() -> dict[str, object]:
+    return {
+        "ok": False,
+        "error": "RESOURCE_NOT_FOUND",
+        "hint": "Use res://scripts/debugger_demo.gd exactly.",
+        "result": {},
+    }
+
+
+def test_ollama_injects_correction_on_failure() -> None:
+    agent = OllamaAgent(bridge=None)  # type: ignore[arg-type]
+    agent._last_tool = "attach_script"
+    agent._last_params = {"script_path": "res://background.gd"}
+    agent._add_result(_failed())
+    content = agent._history[-1]["content"]
+    assert "CORRECTION" in content and "attach_script" in content
+
+
+def test_ollama_no_correction_on_success() -> None:
+    agent = OllamaAgent(bridge=None)  # type: ignore[arg-type]
+    agent._last_tool = "create_node"
+    agent._last_params = {"name": "X"}
+    agent._add_result({"ok": True, "result": {"node_path": "X"}})
+    assert "CORRECTION" not in agent._history[-1]["content"]
+
+
+def test_cloud_injects_correction_on_failure() -> None:
+    agent = CloudAgent(bridge=None, provider="anthropic", api_key="test")
+    agent._last_tool = "connect_signal"
+    agent._last_params = {"signal_name": "ready"}
+    agent._add_result(_failed())
+    content = agent._history[-1]["content"]
+    assert "CORRECTION" in content and "connect_signal" in content


### PR DESCRIPTION
## Summary

Closes #149.

Static system prompts get ignored after a few steps, so both models repeated the same failing call 2–3× before recovering (or not) — e.g. `attach_script` with `Background.gd` despite the prompt saying not to. This injects a dynamic correction after each failure.

## Changes

- **`evals/correction.py`** (new) — `format_correction()` builds a one-line, high-attention correction (≤200 chars) naming the failed `tool(params)` plus its `error`/`hint` and instructing the model not to repeat the same parameters. Shared by both agents so the wording can't drift.
- **`OllamaAgent` + `CloudAgent`** — track the last call in `_ask`, and in `_add_result` append the correction to the **next user message** (higher attention than the system prompt) whenever a call failed.

## Acceptance criteria

- [x] `_add_result()` extracts and formats the last error as a correction hint (both agents)
- [x] Correction limited to 200 chars
- [ ] Eval shows reduced repeated-identical-error rate — observational; requires a live LLM run (not CI-testable)

## Test plan

- New `tests/integration/test_eval_corrections.py`: formatter content + 200-char cap + missing-hint handling; both agents inject on failure and not on success.
- `uv run pytest -q tests/unit tests/contract tests/integration/test_eval_corrections.py` → 385 passed; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)