### PR TITLE
feat(evals): history compression to curb token bloat and timeouts

### DIFF
--- a/evals/cloud_client.py
+++ b/evals/cloud_client.py
@@ -24,6 +24,7 @@ from typing import Any
 import httpx
 
 from evals.correction import format_correction
+from evals.history import COMPRESSION_THRESHOLD, char_len, compress_history
 
 
 @dataclass
@@ -265,6 +266,22 @@ class CloudAgent:
         # correction in the next user message (issue #149).
         self._last_tool: str = ""
         self._last_params: dict[str, Any] = {}
+        # History compression (issue #148): keep raw history, send a summarized
+        # view past the threshold. _last_compression lets the runner record it.
+        self._compression_threshold: int = COMPRESSION_THRESHOLD
+        self._last_compression: dict[str, int] | None = None
+
+    def _history_view(self) -> list[dict]:
+        """Return the history to send: compressed past the step threshold."""
+        view = compress_history(self._history, self._compression_threshold)
+        if len(view) < len(self._history):
+            self._last_compression = {
+                "before_chars": char_len(self._history),
+                "after_chars": char_len(view),
+            }
+        else:
+            self._last_compression = None
+        return view
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""
@@ -305,7 +322,7 @@ class CloudAgent:
 
         cloud_call = call_fn(
             system=system,
-            messages=self._history,
+            messages=self._history_view(),
             model=self._model,
             api_key=self._api_key,
         )

--- a/evals/cloud_client.py
+++ b/evals/cloud_client.py
@@ -272,16 +272,20 @@ class CloudAgent:
         self._last_compression: dict[str, int] | None = None
 
     def _history_view(self) -> list[dict]:
-        """Return the history to send: compressed past the step threshold."""
+        """Return the history to send: compressed past the step threshold.
+
+        Compression is judged by character count, not message count — a shorter
+        message list can still be larger in chars. Only send (and record) the
+        compressed view when it actually shrinks the prompt.
+        """
         view = compress_history(self._history, self._compression_threshold)
-        if len(view) < len(self._history):
-            self._last_compression = {
-                "before_chars": char_len(self._history),
-                "after_chars": char_len(view),
-            }
-        else:
-            self._last_compression = None
-        return view
+        if view is not self._history:
+            before, after = char_len(self._history), char_len(view)
+            if after < before:
+                self._last_compression = {"before_chars": before, "after_chars": after}
+                return view
+        self._last_compression = None
+        return self._history
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""

--- a/evals/history.py
+++ b/evals/history.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""History compression for eval agents (issue #148).
+
+After ~8 steps the prompt grows past 5k tokens; quality degrades and the
+480b-cloud model hit the 120s HTTP timeout. We keep the raw history internally
+but send a compact, template-built summary of the older steps (no extra LLM
+call) plus the most recent steps verbatim.
+
+Shared by OllamaAgent and CloudAgent so the format can't drift.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Compress once the agent has taken more than this many steps (assistant turns).
+COMPRESSION_THRESHOLD = 6
+# Steps kept verbatim after the summary so the model still sees recent detail.
+KEEP_RECENT_STEPS = 2
+
+
+def char_len(messages: list[dict[str, Any]]) -> int:
+    """Total character length of message contents — a cheap token proxy."""
+    return sum(len(str(m.get("content", ""))) for m in messages)
+
+
+def _parse_call(content: str) -> str | None:
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    tool = data.get("tool")
+    if not tool:
+        return None
+    params = data.get("params", {})
+    params_str = json.dumps(params, separators=(",", ":")) if params else "{}"
+    if len(params_str) > 60:
+        params_str = params_str[:57] + "..."
+    return f"{tool}({params_str})"
+
+
+def _parse_result(content: str) -> tuple[bool, str]:
+    # User result messages look like ``Tool result: {json}`` (optionally with a
+    # trailing correction line). Pull the JSON object out and read ok/error/hint.
+    start, end = content.find("{"), content.rfind("}")
+    if start < 0 or end <= start:
+        return True, ""
+    try:
+        data = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        return True, ""
+    ok = bool(data.get("ok", True))
+    if ok:
+        return True, ""
+    err = (data.get("error") or "ERROR").strip()
+    hint = (data.get("hint") or "").strip()
+    return False, f"{err}: {hint}".strip().rstrip(":").strip()
+
+
+def summarize_history(messages: list[dict[str, Any]]) -> str:
+    """Template summary (no LLM): one line per completed step, ✓/✗ + hint."""
+    lines = ["Progress summary (older steps compressed):"]
+    pending: str | None = None
+    for m in messages:
+        role = m.get("role")
+        if role == "assistant":
+            pending = _parse_call(str(m.get("content", "")))
+        elif role == "user" and pending is not None:
+            ok, detail = _parse_result(str(m.get("content", "")))
+            mark = "✓" if ok else "✗"
+            line = f"- {mark} {pending}"
+            if not ok and detail:
+                line += f" FAILED: {detail}"
+            lines.append(line)
+            pending = None
+    return "\n".join(lines)
+
+
+def compress_history(
+    history: list[dict[str, Any]],
+    threshold: int = COMPRESSION_THRESHOLD,
+    keep_recent_steps: int = KEEP_RECENT_STEPS,
+) -> list[dict[str, Any]]:
+    """Return a sendable view: summary of older steps + the recent steps verbatim.
+
+    Returns ``history`` unchanged when there are ``threshold`` steps or fewer.
+    Never mutates the input — the caller keeps the raw history.
+    """
+    assistant_idx = [i for i, m in enumerate(history) if m.get("role") == "assistant"]
+    if len(assistant_idx) <= threshold:
+        return history
+    cut = assistant_idx[len(assistant_idx) - keep_recent_steps]
+    older, recent = history[:cut], history[cut:]
+    summary = {"role": "user", "content": summarize_history(older)}
+    return [summary, *recent]

--- a/evals/history.py
+++ b/evals/history.py
@@ -90,7 +90,10 @@ def compress_history(
     assistant_idx = [i for i, m in enumerate(history) if m.get("role") == "assistant"]
     if len(assistant_idx) <= threshold:
         return history
-    cut = assistant_idx[len(assistant_idx) - keep_recent_steps]
+    # Keep at least one recent step and always leave something to summarize,
+    # so the slice index is valid regardless of how keep_recent_steps is set.
+    keep = max(1, min(keep_recent_steps, len(assistant_idx) - 1))
+    cut = assistant_idx[len(assistant_idx) - keep]
     older, recent = history[:cut], history[cut:]
     summary = {"role": "user", "content": summarize_history(older)}
     return [summary, *recent]

--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -1109,6 +1109,11 @@ class LLMTaskRunner:
                 result.error_categories.append("infrastructure")
                 break
 
+            # Record any history compression the agent applied this step (#148).
+            comp = getattr(self._agent, "_last_compression", None)
+            if comp:
+                self._profiler.record_compression(comp["before_chars"], comp["after_chars"])
+
             result.token_usage.prompt_tokens += call.prompt_tokens
             result.token_usage.completion_tokens += call.completion_tokens
             result.token_usage.total_tokens += call.prompt_tokens + call.completion_tokens

--- a/evals/ollama_agent.py
+++ b/evals/ollama_agent.py
@@ -25,6 +25,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))
 
 from evals.correction import format_correction  # noqa: E402
+from evals.history import COMPRESSION_THRESHOLD, char_len, compress_history  # noqa: E402
 from mcp_server.bridge import Bridge  # noqa: E402
 from mcp_server.config import BridgeConfig  # noqa: E402
 
@@ -64,6 +65,22 @@ class OllamaAgent:
         # correction in the next user message (issue #149).
         self._last_tool: str = ""
         self._last_params: dict[str, Any] = {}
+        # History compression (issue #148): keep raw history, send a summarized
+        # view past the threshold. _last_compression lets the runner record it.
+        self._compression_threshold: int = COMPRESSION_THRESHOLD
+        self._last_compression: dict[str, int] | None = None
+
+    def _history_view(self) -> list[dict]:
+        """Return the history to send: compressed past the step threshold."""
+        view = compress_history(self._history, self._compression_threshold)
+        if len(view) < len(self._history):
+            self._last_compression = {
+                "before_chars": char_len(self._history),
+                "after_chars": char_len(view),
+            }
+        else:
+            self._last_compression = None
+        return view
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""
@@ -101,7 +118,7 @@ class OllamaAgent:
         """Ask the LLM to choose the next tool."""
         system = self._system_prompt(task, available_tools)
         # qwen3-coder:30b on Ollama ignores system role; prepend to first user message
-        messages = self._history.copy()
+        messages = self._history_view().copy()
         if not messages:
             messages = [{"role": "user", "content": system}]
         else:

--- a/evals/ollama_agent.py
+++ b/evals/ollama_agent.py
@@ -71,16 +71,20 @@ class OllamaAgent:
         self._last_compression: dict[str, int] | None = None
 
     def _history_view(self) -> list[dict]:
-        """Return the history to send: compressed past the step threshold."""
+        """Return the history to send: compressed past the step threshold.
+
+        Compression is judged by character count, not message count — a shorter
+        message list can still be larger in chars. Only send (and record) the
+        compressed view when it actually shrinks the prompt.
+        """
         view = compress_history(self._history, self._compression_threshold)
-        if len(view) < len(self._history):
-            self._last_compression = {
-                "before_chars": char_len(self._history),
-                "after_chars": char_len(view),
-            }
-        else:
-            self._last_compression = None
-        return view
+        if view is not self._history:
+            before, after = char_len(self._history), char_len(view)
+            if after < before:
+                self._last_compression = {"before_chars": before, "after_chars": after}
+                return view
+        self._last_compression = None
+        return self._history
 
     def _system_prompt(self, task: str, available_tools: list[dict]) -> str:
         """Build the system prompt with structured tool descriptions."""

--- a/evals/profiler.py
+++ b/evals/profiler.py
@@ -24,10 +24,24 @@ class ToolProfiler:
     """Aggregate timing and outcome stats per tool."""
 
     _calls: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    _compressions: list[dict[str, int]] = field(default_factory=list)
 
     def record(self, tool: str, latency_ms: float, ok: bool = True) -> None:
         """Log a single tool invocation."""
         self._calls.setdefault(tool, []).append({"latency_ms": latency_ms, "ok": ok})
+
+    def record_compression(self, before_chars: int, after_chars: int) -> None:
+        """Log a history-compression event (issue #148)."""
+        self._compressions.append({"before_chars": before_chars, "after_chars": after_chars})
+
+    def compression_savings(self) -> dict[str, int]:
+        """Chars saved by history compression (≈4 chars/token estimate)."""
+        saved = sum(c["before_chars"] - c["after_chars"] for c in self._compressions)
+        return {
+            "compressions": len(self._compressions),
+            "chars_saved": saved,
+            "est_tokens_saved": saved // 4,
+        }
 
     def summary(self) -> dict[str, dict[str, float | int]]:
         """Return per-tool summary: count, mean, median, p95, min, max, error_rate."""
@@ -76,3 +90,4 @@ class ToolProfiler:
     def reset(self) -> None:
         """Clear all recorded data."""
         self._calls.clear()
+        self._compressions.clear()

--- a/evals/profiler.py
+++ b/evals/profiler.py
@@ -36,7 +36,7 @@ class ToolProfiler:
 
     def compression_savings(self) -> dict[str, int]:
         """Chars saved by history compression (≈4 chars/token estimate)."""
-        saved = sum(c["before_chars"] - c["after_chars"] for c in self._compressions)
+        saved = sum(max(0, c["before_chars"] - c["after_chars"]) for c in self._compressions)
         return {
             "compressions": len(self._compressions),
             "chars_saved": saved,

--- a/tests/integration/test_eval_history.py
+++ b/tests/integration/test_eval_history.py
@@ -95,3 +95,18 @@ def test_agent_history_view_noop_when_short() -> None:
     view = agent._history_view()
     assert view == agent._history
     assert agent._last_compression is None
+
+
+def test_compress_history_handles_zero_keep_recent() -> None:
+    # keep_recent_steps=0 must not IndexError (it can become configurable).
+    h = _history(COMPRESSION_THRESHOLD + 3)
+    out = compress_history(h, COMPRESSION_THRESHOLD, keep_recent_steps=0)
+    assert "Progress summary" in out[0]["content"]
+    assert len(out) >= 1
+
+
+def test_profiler_never_reports_negative_savings() -> None:
+    p = ToolProfiler()
+    # A "compression" that grew the prompt must not produce negative savings.
+    p.record_compression(before_chars=100, after_chars=180)
+    assert p.compression_savings()["chars_saved"] == 0

--- a/tests/integration/test_eval_history.py
+++ b/tests/integration/test_eval_history.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""History-compression tests (issue #148).
+
+After a configurable number of steps the agent sends a compact summary of the
+older history instead of every full tool result, to curb token bloat and the
+480b HTTP timeouts. The summary is template-built (no LLM call) and the raw
+history is kept internally. Pure functions + the agent view are unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from evals.history import (  # noqa: E402
+    COMPRESSION_THRESHOLD,
+    compress_history,
+    summarize_history,
+)
+from evals.ollama_agent import OllamaAgent  # noqa: E402
+from evals.profiler import ToolProfiler  # noqa: E402
+
+
+def _call(tool: str, **params: object) -> dict[str, str]:
+    return {"role": "assistant", "content": json.dumps({"tool": tool, "params": params})}
+
+
+def _result(ok: bool, error: str | None = None, hint: str | None = None) -> dict[str, str]:
+    body: dict[str, object] = {"ok": ok, "error": error, "hint": hint, "result_keys": []}
+    return {"role": "user", "content": "Tool result: " + json.dumps(body)}
+
+
+def _history(n: int) -> list[dict[str, str]]:
+    h: list[dict[str, str]] = []
+    for i in range(n):
+        h.append(_call("create_node", name=f"N{i}"))
+        h.append(_result(True))
+    return h
+
+
+def test_short_history_is_unchanged() -> None:
+    h = _history(COMPRESSION_THRESHOLD)
+    assert compress_history(h, COMPRESSION_THRESHOLD) == h
+
+
+def test_long_history_is_compressed() -> None:
+    h = _history(COMPRESSION_THRESHOLD + 3)
+    out = compress_history(h, COMPRESSION_THRESHOLD)
+    assert len(out) < len(h)
+    assert out[0]["role"] == "user"
+    assert "Progress summary" in out[0]["content"]
+    # The most recent step's call survives verbatim.
+    assert out[-2:] == h[-2:]
+
+
+def test_summary_marks_success_and_failure_with_hint() -> None:
+    msgs = [
+        _call("create_node", name="MutTest"),
+        _result(True),
+        _call("attach_script", script_path="res://background.gd"),
+        _result(False, "RESOURCE_NOT_FOUND", "Use res://scripts/debugger_demo.gd."),
+    ]
+    summary = summarize_history(msgs)
+    assert "create_node" in summary
+    assert "attach_script" in summary and "RESOURCE_NOT_FOUND" in summary
+    assert "debugger_demo.gd" in summary
+
+
+def test_profiler_tracks_compression_savings() -> None:
+    p = ToolProfiler()
+    assert p.compression_savings()["compressions"] == 0
+    p.record_compression(before_chars=1000, after_chars=400)
+    s = p.compression_savings()
+    assert s["compressions"] == 1
+    assert s["chars_saved"] == 600
+    p.reset()
+    assert p.compression_savings()["compressions"] == 0
+
+
+def test_agent_history_view_compresses_and_records() -> None:
+    agent = OllamaAgent(bridge=None)  # type: ignore[arg-type]
+    agent._history = _history(COMPRESSION_THRESHOLD + 2)
+    view = agent._history_view()
+    assert len(view) < len(agent._history)  # raw history untouched
+    assert agent._last_compression is not None
+    assert agent._last_compression["after_chars"] < agent._last_compression["before_chars"]
+
+
+def test_agent_history_view_noop_when_short() -> None:
+    agent = OllamaAgent(bridge=None)  # type: ignore[arg-type]
+    agent._history = _history(2)
+    view = agent._history_view()
+    assert view == agent._history
+    assert agent._last_compression is None


### PR DESCRIPTION
## Summary

Closes #148.

After ~8 steps the prompt grew past 5k tokens — quality degraded and the 480b-cloud model hit the 120s HTTP timeout. Agents now send a compact, template-built summary of older steps instead of every full tool result.

## Changes

- **`evals/history.py`** (new) — `compress_history()` keeps the most recent steps verbatim and replaces older ones with `summarize_history()`, a no-LLM template (one ✓/✗ line per step, error+hint on failures). Raw history is kept internally; only the sent view is compressed. Threshold configurable (default 6 steps), shared by both agents.
- **`OllamaAgent` + `CloudAgent`** — `_history_view()` builds the compressed view in `_ask` and records before/after sizes in `_last_compression`.
- **`ToolProfiler.record_compression()` / `compression_savings()`** — track chars saved (≈4 chars/token) per task; cleared on `reset()`.
- **Runner** — records each compression event after `_ask`.

## Acceptance criteria

- [x] Compression threshold configurable (default 6 steps)
- [x] Summary includes successful actions, failed actions + error hints
- [x] Token count tracked before/after compression (profiler, char-based estimate)
- [ ] No timeout failures on 480b — observational; requires a live cloud run

## Test plan

- New `tests/integration/test_eval_history.py`: short history unchanged, long history compressed with recent steps intact, summary marks success/failure + hint, profiler savings, agent view compresses (raw untouched) / no-ops when short.
- `uv run pytest -q tests/unit tests/contract tests/integration/test_eval_*.py` → 391 passed; `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)