### PR TITLE
feat(safety): optional human-in-the-loop approval webhook for destructive tools

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -52,6 +52,34 @@ Every tool is tagged with exactly one:
 - `list_tools_by_safety_class()` is a `read_only` tool returning `{ class: [tool names] }`
   for agent introspection.
 
+### Human-in-the-loop approval (issue #153)
+
+An optional webhook gates `destructive` tools behind a human decision. It is **opt-in**:
+with no webhook configured the gate auto-approves, so evals and headless runs are never
+blocked. Configure via environment:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `GODOT_MCP_APPROVAL_WEBHOOK` | unset | Approval endpoint URL. Unset → auto-approve (current behavior). |
+| `GODOT_MCP_APPROVAL_TIMEOUT` | `30.0` | Per-request timeout, seconds. |
+| `GODOT_MCP_APPROVAL_FAIL_OPEN` | `true` | On an unreachable/slow webhook: `true` approves, `false` denies. |
+
+When a webhook is set, the server `POST`s an **`ApprovalRequest`** before the action runs
+and expects an **`ApprovalResponse`**:
+
+```jsonc
+// Request →
+{ "action": "delete_node", "safety_class": "destructive",
+  "params": { "node_path": "Enemy" }, "task_context": null, "timestamp": 1739000000.0 }
+// Response ←
+{ "approved": false, "reason": "blocked by reviewer" }   // approved defaults to false if absent
+```
+
+A denial (or a fail-closed unreachable webhook) raises the structured error
+`APPROVAL_DENIED` (`required: "human_approval"`) **before** any command reaches the addon.
+Every decision is logged. Gated tools today: `delete_node`, `reload_scene`,
+`scaffold_project`, `remove_input_action`, `clear_input_action_events`.
+
 #### Version gating (per-toolset)
 
 Some toolsets depend on Godot editor APIs that are only reliable from a specific

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -76,9 +76,12 @@ and expects an **`ApprovalResponse`**:
 ```
 
 A denial (or a fail-closed unreachable webhook) raises the structured error
-`APPROVAL_DENIED` (`required: "human_approval"`) **before** any command reaches the addon.
-Every decision is logged. Gated tools today: `delete_node`, `reload_scene`,
-`scaffold_project`, `remove_input_action`, `clear_input_action_events`.
+`APPROVAL_DENIED` (`required: "human_approval"`) **before the destructive command
+executes** — after `confirm` is checked but before the mutation is sent (a read-only
+existence precondition such as `require_node_exists` may run first). A malformed webhook
+reply fails safe to *denied*, never auto-approved. Every decision is logged. Gated tools
+today: `delete_node`, `reload_scene`, `scaffold_project`, `remove_input_action`,
+`clear_input_action_events`.
 
 #### Version gating (per-toolset)
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -66,6 +66,12 @@ class ServerConfig(BaseModel):
     # the connected editor's project.
     godot_bin: str | None = None
     godot_project_dir: str | None = None
+    # Human-in-the-loop approval (issue #14/#153). Opt-in: with no webhook,
+    # destructive tools run as before (so evals/headless are never blocked).
+    # ``fail_open`` decides whether an unreachable webhook approves or denies.
+    approval_webhook: str | None = None
+    approval_timeout: float = 30.0
+    approval_fail_open: bool = True
 
     @classmethod
     def from_env(cls) -> ServerConfig:
@@ -79,4 +85,8 @@ class ServerConfig(BaseModel):
             permission_mode=os.environ.get("GODOT_MCP_PERMISSION_MODE", "ask"),
             godot_bin=os.environ.get("GODOT_MCP_GODOT_BIN"),
             godot_project_dir=os.environ.get("GODOT_MCP_PROJECT_DIR"),
+            approval_webhook=os.environ.get("GODOT_MCP_APPROVAL_WEBHOOK"),
+            approval_timeout=float(os.environ.get("GODOT_MCP_APPROVAL_TIMEOUT", 30.0)),
+            approval_fail_open=os.environ.get("GODOT_MCP_APPROVAL_FAIL_OPEN", "true").lower()
+            != "false",
         )

--- a/mcp_server/models/approval.py
+++ b/mcp_server/models/approval.py
@@ -1,0 +1,31 @@
+"""Human-in-the-loop approval models (issue #153).
+
+The MCP server can POST an :class:`ApprovalRequest` to a configured webhook
+before running a destructive tool; the webhook replies with an
+:class:`ApprovalResponse`. Both are versioned JSON, like every other boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ApprovalRequest(BaseModel):
+    """Payload POSTed to the approval webhook before a gated action runs."""
+
+    action: str  # the tool name, e.g. "delete_node"
+    safety_class: str  # "destructive" | "mutating" | "runtime"
+    params: dict[str, Any] = Field(default_factory=dict)
+    task_context: str | None = None
+    timestamp: float = 0.0
+
+
+class ApprovalResponse(BaseModel):
+    """The webhook's verdict. Absent/invalid fields default to NOT approved, so a
+    malformed reply fails safe rather than silently allowing the action.
+    """
+
+    approved: bool = False
+    reason: str | None = None

--- a/mcp_server/models/envelope.py
+++ b/mcp_server/models/envelope.py
@@ -25,6 +25,7 @@ class ErrorCode(StrEnum):
     BRIDGE_DISCONNECTED = "BRIDGE_DISCONNECTED"
     TIMEOUT = "TIMEOUT"
     INTERNAL_ERROR = "INTERNAL_ERROR"
+    APPROVAL_DENIED = "APPROVAL_DENIED"  # human-in-the-loop gate (issue #153)
 
 
 class CommandEnvelope(BaseModel):

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -12,6 +12,7 @@ actionable message instead of a stack trace.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from pydantic import ValidationError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
@@ -133,14 +135,34 @@ def require_confirmation(confirm: bool, action: str) -> None:
 ApprovalPoster = Callable[[str, ApprovalRequest, float], Awaitable[ApprovalResponse]]
 
 
+def parse_approval_response(payload: Any) -> ApprovalResponse:
+    """Parse a webhook body into a verdict. A reply we cannot parse fails *safe*
+    (denied) rather than raising — a malformed response must never auto-approve a
+    destructive action, even with ``fail_open=True``.
+    """
+    try:
+        return ApprovalResponse.model_validate(payload)
+    except ValidationError:
+        return ApprovalResponse(approved=False, reason="malformed approval response")
+
+
 async def post_approval(
     url: str, request: ApprovalRequest, timeout: float
 ) -> ApprovalResponse:
-    """Default poster: POST the request as JSON and parse the verdict."""
+    """Default poster: POST the request as JSON and parse the verdict.
+
+    Only transport-level failures (timeout, connection) propagate — those are the
+    "webhook unreachable" case the gate's fail-open/closed policy handles. A reply
+    with an unparseable body is a *received* verdict that fails safe to denied.
+    """
     async with httpx.AsyncClient() as client:
         resp = await client.post(url, json=request.model_dump(), timeout=timeout)
         resp.raise_for_status()
-        return ApprovalResponse.model_validate(resp.json())
+        try:
+            payload = resp.json()
+        except ValueError:
+            return ApprovalResponse(approved=False, reason="non-JSON approval response")
+        return parse_approval_response(payload)
 
 
 @dataclass
@@ -189,6 +211,8 @@ class ApprovalGate:
         )
         try:
             response = await self.poster(self.webhook_url, request, self.timeout)
+        except asyncio.CancelledError:
+            raise  # never treat cancellation as a webhook failure
         except Exception:
             logger.warning(
                 "approval webhook unreachable; failing %s",

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -12,17 +12,27 @@ actionable message instead of a stack trace.
 
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import httpx
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
+from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
 from mcp_server.models.envelope import ErrorCode, ResponseEnvelope
+
+if TYPE_CHECKING:
+    from mcp_server.config import ServerConfig
+
+logger = logging.getLogger(__name__)
 
 
 class SafetyClass(StrEnum):
@@ -113,6 +123,97 @@ def require_confirmation(confirm: bool, action: str) -> None:
         raise PreconditionError(
             f"'{action}' is destructive and may be irreversible. Pass confirm=true to proceed.",
             required="confirm",
+        )
+
+
+# --- human-in-the-loop approval (issue #153) -------------------------------
+
+# A poster takes (url, request, timeout) and returns the webhook's verdict.
+# Injected so the gate is unit-testable without a network.
+ApprovalPoster = Callable[[str, ApprovalRequest, float], Awaitable[ApprovalResponse]]
+
+
+async def post_approval(
+    url: str, request: ApprovalRequest, timeout: float
+) -> ApprovalResponse:
+    """Default poster: POST the request as JSON and parse the verdict."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=request.model_dump(), timeout=timeout)
+        resp.raise_for_status()
+        return ApprovalResponse.model_validate(resp.json())
+
+
+@dataclass
+class ApprovalGate:
+    """Optional human approval for destructive (and, if wired, mutating/runtime)
+    tools (issue #153).
+
+    Opt-in: with ``webhook_url`` unset the gate auto-approves, so evals and
+    headless runs are never blocked. When set, :meth:`require` POSTs an
+    :class:`ApprovalRequest` and raises ``PreconditionError(APPROVAL_DENIED)`` on
+    a denial. An unreachable/slow webhook approves when ``fail_open`` (default)
+    or denies when not. Every decision is logged.
+    """
+
+    webhook_url: str | None = None
+    timeout: float = 30.0
+    fail_open: bool = True
+    poster: ApprovalPoster = field(default=post_approval)
+    clock: Callable[[], float] = field(default=time.time)
+
+    @classmethod
+    def from_config(cls, config: ServerConfig) -> ApprovalGate:
+        return cls(
+            webhook_url=config.approval_webhook,
+            timeout=config.approval_timeout,
+            fail_open=config.approval_fail_open,
+        )
+
+    async def require(
+        self,
+        action: str,
+        safety_class: str,
+        params: dict[str, Any],
+        task_context: str | None = None,
+    ) -> None:
+        """Block ``action`` unless the webhook approves it. No-op without a webhook."""
+        if not self.webhook_url:
+            return  # opt-in: no webhook configured → auto-approve
+
+        request = ApprovalRequest(
+            action=action,
+            safety_class=safety_class,
+            params=params,
+            task_context=task_context,
+            timestamp=self.clock(),
+        )
+        try:
+            response = await self.poster(self.webhook_url, request, self.timeout)
+        except Exception:
+            logger.warning(
+                "approval webhook unreachable; failing %s",
+                "open" if self.fail_open else "closed",
+                extra={"action": action, "safety_class": safety_class},
+                exc_info=True,
+            )
+            if self.fail_open:
+                return
+            raise PreconditionError(
+                f"Approval webhook is unreachable; failing closed for '{action}'.",
+                required="human_approval",
+                error=ErrorCode.APPROVAL_DENIED,
+            ) from None
+
+        if response.approved:
+            logger.info("approval granted", extra={"action": action})
+            return
+        logger.info(
+            "approval denied", extra={"action": action, "reason": response.reason}
+        )
+        raise PreconditionError(
+            response.reason or f"'{action}' was denied by the human approver.",
+            required="human_approval",
+            error=ErrorCode.APPROVAL_DENIED,
         )
 
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,7 +23,7 @@ from mcp_server.diagnostics import register_diagnostics
 from mcp_server.prompts import register_prompts
 from mcp_server.resources.context import register_resources
 from mcp_server.runtime import GodotRunner, Runner
-from mcp_server.safety import register_safety_tools
+from mcp_server.safety import ApprovalGate, register_safety_tools
 from mcp_server.tools.analysis import register_analysis
 from mcp_server.tools.animation import register_animation
 from mcp_server.tools.audio import register_audio
@@ -68,11 +68,14 @@ def create_server(
     config: ServerConfig | None = None,
     bridge: Bridge | None = None,
     runner: Runner | None = None,
+    approval: ApprovalGate | None = None,
 ) -> FastMCP:
     """Create the FastMCP server, wiring the bridge and registering tools."""
     config = config or ServerConfig()
     bridge = bridge or Bridge(config.bridge)
     runner = runner or GodotRunner(config)
+    # Human-in-the-loop approval gate (issue #153); no-op unless a webhook is set.
+    approval = approval or ApprovalGate.from_config(config)
 
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncIterator[None]:
@@ -179,8 +182,8 @@ def create_server(
     )
     register_health(mcp, bridge, config)
     register_inspection(mcp, bridge)
-    register_mutation(mcp, bridge)
-    register_scene_session(mcp, bridge)
+    register_mutation(mcp, bridge, approval)
+    register_scene_session(mcp, bridge, approval)
     register_node_ops(mcp, bridge)
     register_resource_files(mcp, bridge)
     register_project_fs(mcp, bridge)
@@ -201,7 +204,7 @@ def create_server(
     register_runtime_inspect(mcp, bridge)
     register_import_asset(mcp, bridge)
     register_input_sim(mcp, bridge)
-    register_input_map(mcp, bridge)
+    register_input_map(mcp, bridge, approval)
     register_testing(mcp, bridge)
     register_profiling(mcp, bridge)
     register_batch(mcp, bridge)
@@ -210,7 +213,7 @@ def create_server(
     register_export(mcp, bridge, config, runner)
     register_scripts(mcp, bridge, config, runner)
     register_debug_workflow(mcp, bridge, config, runner)
-    register_project_scaffold(mcp, bridge)
+    register_project_scaffold(mcp, bridge, approval)
     register_safety_tools(mcp)
 
     # Gate the tool surface by category, then apply the default exposure (core +

--- a/mcp_server/tools/input_map.py
+++ b/mcp_server/tools/input_map.py
@@ -24,6 +24,7 @@ from mcp_server.models.input_map import (
 from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
+    ApprovalGate,
     enforce_preconditions,
     require_bridge_connected,
     require_confirmation,
@@ -33,8 +34,11 @@ from mcp_server.tools._route import run_or_preview
 INPUT_MAP = {INPUT_MAP_TAG}
 
 
-def register_input_map(mcp: FastMCP, bridge: Bridge) -> None:
+def register_input_map(
+    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+) -> None:
     """Register the input map editing tools."""
+    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=INPUT_MAP)
     @enforce_preconditions
@@ -65,6 +69,7 @@ def register_input_map(mcp: FastMCP, bridge: Bridge) -> None:
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "remove_input_action")
+            await approval.require("remove_input_action", "destructive", {"name": name})
         params = {"name": name, "confirm": True}
         preview = {"name": name, "removed": False}
         return await run_or_preview(
@@ -133,6 +138,7 @@ def register_input_map(mcp: FastMCP, bridge: Bridge) -> None:
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "clear_input_action_events")
+            await approval.require("clear_input_action_events", "destructive", {"action": action})
         params = {"action": action, "confirm": True}
         preview = {"action": action, "cleared": False}
         return await run_or_preview(

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -36,6 +36,7 @@ from mcp_server.models.mutation import (
 from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
+    ApprovalGate,
     enforce_preconditions,
     require_active_scene,
     require_bridge_connected,
@@ -92,8 +93,11 @@ async def _try_set_with_suggestions(
         raise
 
 
-def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
+def register_mutation(
+    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+) -> None:
     """Register all eight mutation tools on the server."""
+    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
@@ -165,6 +169,7 @@ def register_mutation(mcp: FastMCP, bridge: Bridge) -> None:
         await require_node_exists(bridge, node_path)
         if not dry_run:
             require_confirmation(confirm, "delete_node")
+            await approval.require("delete_node", "destructive", {"node_path": node_path})
         params = {"node_path": node_path, "confirm": True}
         preview = {"node_path": node_path, "deleted": False}
         return await run_or_preview(

--- a/mcp_server/tools/project_scaffold.py
+++ b/mcp_server/tools/project_scaffold.py
@@ -16,7 +16,12 @@ from fastmcp import FastMCP
 from mcp_server.bridge import Bridge
 from mcp_server.categories import PROJECT_SCAFFOLD_TAG
 from mcp_server.models.project_scaffold import ScaffoldProjectResult
-from mcp_server.safety import DESTRUCTIVE, enforce_preconditions, require_confirmation
+from mcp_server.safety import (
+    DESTRUCTIVE,
+    ApprovalGate,
+    enforce_preconditions,
+    require_confirmation,
+)
 from mcp_server.tools._route import run_or_preview
 
 PROJECT_SCAFFOLD = {PROJECT_SCAFFOLD_TAG}
@@ -35,8 +40,11 @@ _SCAFFOLD_TYPES: set[str] = {
 # ---------------------------------------------------------------------------
 
 
-def register_project_scaffold(mcp: FastMCP, bridge: Bridge) -> None:
+def register_project_scaffold(
+    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+) -> None:
     """Register the project scaffold tool."""
+    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=DESTRUCTIVE, tags=PROJECT_SCAFFOLD)
     @enforce_preconditions
@@ -60,6 +68,7 @@ def register_project_scaffold(mcp: FastMCP, bridge: Bridge) -> None:
             )
         if not dry_run:
             require_confirmation(confirm, "scaffold_project")
+            await approval.require("scaffold_project", "destructive", {"type": type})
         params: dict[str, str] = {
             "type": type,
             "project_name": project_name or type,

--- a/mcp_server/tools/scene_session.py
+++ b/mcp_server/tools/scene_session.py
@@ -25,6 +25,7 @@ from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
     READ_ONLY,
+    ApprovalGate,
     enforce_preconditions,
     require_active_scene,
     require_bridge_connected,
@@ -36,8 +37,11 @@ from mcp_server.tools._route import route, run_or_preview
 SCENE_EDIT = {SCENE_EDIT_TAG}
 
 
-def register_scene_session(mcp: FastMCP, bridge: Bridge) -> None:
+def register_scene_session(
+    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+) -> None:
     """Register scene session tools in the scene_edit toolset."""
+    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
@@ -65,6 +69,7 @@ def register_scene_session(mcp: FastMCP, bridge: Bridge) -> None:
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "reload_scene")
+            await approval.require("reload_scene", "destructive", {"scene_path": scene_path})
         params: dict[str, Any] = {"scene_path": scene_path, "confirm": True}
         preview = {"scene_path": scene_path, "reloaded": False}
         return await run_or_preview(

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -13,7 +13,9 @@ from fastmcp import Client, FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
+from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
 from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.safety import ApprovalGate
 from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for
 
@@ -267,6 +269,42 @@ async def test_set_node_property_no_suggestions_when_list_empty() -> None:
     assert "has no property 'bad'" in text
     # No suggestions bracket when the list is empty.
     assert "suggestions=" not in text
+
+
+async def test_delete_node_blocked_when_approval_denied() -> None:
+    # With an approval webhook configured and the verdict "deny", a confirmed
+    # delete must be blocked BEFORE reaching the bridge (issue #153).
+    async def deny(url: str, request: ApprovalRequest, timeout: float) -> ApprovalResponse:
+        return ApprovalResponse(approved=False, reason="blocked by reviewer")
+
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    gate = ApprovalGate(webhook_url="http://hook", poster=deny)
+    server = create_server(ServerConfig(), bridge=bridge, approval=gate)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "delete_node", {"node_path": "Player", "confirm": True}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "APPROVAL_DENIED" in str(result.content)
+    assert "blocked by reviewer" in str(result.content)
+    assert "cmd_delete_node" not in _commands(conn)  # never reached the addon
+
+
+async def test_delete_node_proceeds_when_approval_granted() -> None:
+    async def approve(url: str, request: ApprovalRequest, timeout: float) -> ApprovalResponse:
+        return ApprovalResponse(approved=True)
+
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    gate = ApprovalGate(webhook_url="http://hook", poster=approve)
+    server = create_server(ServerConfig(), bridge=bridge, approval=gate)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool("delete_node", {"node_path": "Player", "confirm": True})
+    assert result.structured_content["deleted"] is True
+    assert "cmd_delete_node" in _commands(conn)
 
 
 async def test_delete_without_confirm_is_blocked() -> None:

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -12,7 +12,12 @@ import pytest
 
 from mcp_server.config import ServerConfig
 from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
-from mcp_server.safety import ApprovalGate, ApprovalPoster, PreconditionError
+from mcp_server.safety import (
+    ApprovalGate,
+    ApprovalPoster,
+    PreconditionError,
+    parse_approval_response,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -99,3 +104,27 @@ async def test_from_config_without_webhook_is_noop() -> None:
     gate = ApprovalGate.from_config(ServerConfig())
     assert gate.webhook_url is None
     await gate.require(action="delete_node", safety_class="destructive", params={})
+
+
+async def test_well_formed_response_parses() -> None:
+    assert parse_approval_response({"approved": True}).approved is True
+    # Missing field defaults to NOT approved (fail safe).
+    assert parse_approval_response({"reason": "x"}).approved is False
+
+
+async def test_malformed_response_fails_safe_to_denied() -> None:
+    # Non-dict / wrong-shape bodies must deny, not raise or approve.
+    for bad in ("approved", ["yes"], 42):
+        assert parse_approval_response(bad).approved is False
+
+
+async def test_malformed_response_denies_even_when_fail_open() -> None:
+    # A *received* but unparseable verdict must not auto-approve even with
+    # fail_open=True (that's only for unreachable webhooks).
+    async def malformed(url: str, request: ApprovalRequest, timeout: float) -> ApprovalResponse:
+        return parse_approval_response("garbage")
+
+    gate = ApprovalGate(webhook_url="http://hook", poster=malformed, fail_open=True)
+    with pytest.raises(PreconditionError) as exc:
+        await gate.require(action="delete_node", safety_class="destructive", params={})
+    assert exc.value.error == "APPROVAL_DENIED"

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -1,0 +1,101 @@
+"""Human-in-the-loop approval gate for destructive tools (issue #153).
+
+The gate is opt-in: with no webhook configured it auto-approves (so evals and
+headless runs are never blocked). When a webhook is set, destructive tools must
+be approved; unreachable webhooks fail open or closed per config. The HTTP
+poster is injected, so this is a pure unit test — no network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.config import ServerConfig
+from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
+from mcp_server.safety import ApprovalGate, ApprovalPoster, PreconditionError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _poster(
+    response: ApprovalResponse | None = None, *, raises: Exception | None = None
+) -> tuple[ApprovalPoster, list[ApprovalRequest]]:
+    """Return a fake poster and the list it records each request into."""
+    seen: list[ApprovalRequest] = []
+
+    async def poster(url: str, request: ApprovalRequest, timeout: float) -> ApprovalResponse:
+        seen.append(request)
+        if raises is not None:
+            raise raises
+        return response or ApprovalResponse(approved=True)
+
+    return poster, seen
+
+
+async def test_no_webhook_auto_approves() -> None:
+    gate = ApprovalGate()  # webhook_url is None
+    # Must not raise and must not attempt any POST.
+    await gate.require(action="delete_node", safety_class="destructive", params={"node_path": "X"})
+
+
+async def test_webhook_approval_passes() -> None:
+    poster, seen = _poster(ApprovalResponse(approved=True))
+    gate = ApprovalGate(webhook_url="http://hook", poster=poster)
+    await gate.require(action="delete_node", safety_class="destructive", params={"node_path": "X"})
+    assert len(seen) == 1
+
+
+async def test_webhook_denial_raises_precondition() -> None:
+    poster, _ = _poster(ApprovalResponse(approved=False, reason="nope"))
+    gate = ApprovalGate(webhook_url="http://hook", poster=poster)
+    with pytest.raises(PreconditionError) as exc:
+        await gate.require(action="delete_node", safety_class="destructive", params={})
+    assert exc.value.error == "APPROVAL_DENIED"
+    assert "nope" in exc.value.hint
+
+
+async def test_request_payload_carries_context() -> None:
+    poster, seen = _poster()
+    gate = ApprovalGate(webhook_url="http://hook", poster=poster, clock=lambda: 123.0)
+    await gate.require(
+        action="delete_node",
+        safety_class="destructive",
+        params={"node_path": "Enemy"},
+        task_context="cleanup",
+    )
+    req = seen[0]
+    assert req.action == "delete_node"
+    assert req.safety_class == "destructive"
+    assert req.params == {"node_path": "Enemy"}
+    assert req.task_context == "cleanup"
+    assert req.timestamp == 123.0
+
+
+async def test_unreachable_webhook_fails_open_by_default() -> None:
+    poster, _ = _poster(raises=TimeoutError("boom"))
+    gate = ApprovalGate(webhook_url="http://hook", poster=poster, fail_open=True)
+    await gate.require(action="delete_node", safety_class="destructive", params={})  # no raise
+
+
+async def test_unreachable_webhook_can_fail_closed() -> None:
+    poster, _ = _poster(raises=TimeoutError("boom"))
+    gate = ApprovalGate(webhook_url="http://hook", poster=poster, fail_open=False)
+    with pytest.raises(PreconditionError) as exc:
+        await gate.require(action="delete_node", safety_class="destructive", params={})
+    assert exc.value.error == "APPROVAL_DENIED"
+
+
+async def test_from_config_reads_fields() -> None:
+    config = ServerConfig(
+        approval_webhook="http://hook", approval_timeout=5.0, approval_fail_open=False
+    )
+    gate = ApprovalGate.from_config(config)
+    assert gate.webhook_url == "http://hook"
+    assert gate.timeout == 5.0
+    assert gate.fail_open is False
+
+
+async def test_from_config_without_webhook_is_noop() -> None:
+    gate = ApprovalGate.from_config(ServerConfig())
+    assert gate.webhook_url is None
+    await gate.require(action="delete_node", safety_class="destructive", params={})


### PR DESCRIPTION
## Summary

Closes #153.

A cloud model hallucinated non-existent tools when stuck; a more dangerous hallucination could be catastrophic. This adds an **opt-in** approval gate so a human (or policy service) can veto destructive tool calls before they reach Godot. With no webhook configured the gate auto-approves — evals and headless runs are never blocked.

## Changes

- **`mcp_server/safety.py`** — `ApprovalGate` (`from_config`). `require()` POSTs an `ApprovalRequest` and raises `PreconditionError(APPROVAL_DENIED)` on denial; an unreachable/slow webhook fails open (default) or closed per config. The HTTP poster is injected → unit-testable without a network. All decisions logged.
- **`mcp_server/models/approval.py`** — `ApprovalRequest` / `ApprovalResponse` (`approved` defaults to `false`, so a malformed reply fails safe).
- **`mcp_server/config.py`** — `approval_webhook` / `approval_timeout` / `approval_fail_open` + `GODOT_MCP_APPROVAL_*` env vars.
- **`ErrorCode.APPROVAL_DENIED`** added to the enumerated set.
- Wired into **all five destructive tools** (`delete_node`, `reload_scene`, `scaffold_project`, `remove_input_action`, `clear_input_action_events`) via a gate threaded through their registrars; `create_server` builds it from config (injectable for tests). A default no-op gate keeps existing callers/tests unchanged.
- **`docs/tool-contracts.md`** — webhook contract.

## Acceptance criteria

- [x] Webhook URL configurable via env var / config
- [x] Request includes tool name, params, task context, safety class (+ timestamp)
- [x] Timeout handling (default 30s, fail open or closed)
- [x] Logging of all approval decisions
- [x] Does NOT block evals / headless (opt-in; no webhook → auto-approve)

## Test plan

- `tests/unit/test_approval.py`: auto-approve (no webhook), approve, deny → `APPROVAL_DENIED`, payload contents, fail-open, fail-closed, `from_config`.
- `tests/contract/test_mutation.py`: end-to-end — a denied `delete_node` is blocked **before** the bridge; a granted one proceeds.
- `ruff` + `mypy` + zero-skip clean; 384 unit+contract pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)