### PR TITLE
feat(evals): scene setup, play-session safety, and premature-done recovery

### DIFF
--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -1235,27 +1235,9 @@ class LLMTaskRunner:
         except Exception:
             pass
 
-        # Cleanup: delete created test nodes
-        for node_path in created_nodes:
-            try:
-                await self._bridge.call(
-                    "cmd_delete_node",
-                    {"node_path": node_path, "confirm": True},
-                )
-            except Exception:
-                pass  # Node may already be deleted or renamed
-
-        # Cleanup: revert renames (in reverse order)
-        for renamed_path, original_name in reversed(rename_stack):
-            try:
-                await self._bridge.call(
-                    "cmd_rename_node",
-                    {"node_path": renamed_path, "new_name": original_name},
-                )
-            except Exception:
-                pass  # Node may no longer exist
-
-        # Run task completion validator BEFORE cleanup (cleanup removes artifacts)
+        # Run the task completion validator on the REAL post-task state, BEFORE
+        # any node cleanup — cleanup deletes created nodes and reverts renames,
+        # which would make e.g. _validate_rename see RenamedNode already gone.
         validator = TASK_VALIDATORS.get(task_name)
         validation_passed: bool | None = None
         if validator:

--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -689,6 +689,29 @@ def _unmet_milestones(result: LLMTaskResult, task_name: str) -> list[str]:
     return [tool for tool in required if tool not in succeeded]
 
 
+# Reject a premature done() at most this many times before accepting it, so a
+# stuck model can't burn the whole step budget bouncing off the gate.
+MAX_DONE_REJECTIONS = 2
+
+
+def _should_reject_done(
+    result: LLMTaskResult,
+    task_name: str,
+    rejections: int,
+    step_num: int,
+    max_steps: int,
+) -> bool:
+    """True when the agent called done() but a milestone is still unmet and we can
+    still nudge it (rejection budget left, steps remaining). The dominant 30b
+    failure mode is calling done() early; a corrective nudge recovers many tasks.
+    """
+    if rejections >= MAX_DONE_REJECTIONS:
+        return False
+    if step_num >= max_steps - 1:
+        return False
+    return bool(_unmet_milestones(result, task_name))
+
+
 TASK_PROMPTS: dict[str, str] = {
     # === INSPECTION (4 tasks) ===
     "inspect_scene_tree": (
@@ -1098,6 +1121,7 @@ class LLMTaskRunner:
         # Track mutations for cleanup
         created_nodes: list[str] = []
         rename_stack: list[tuple[str, str]] = []  # (old_name, new_name)
+        done_rejections = 0
 
         for step_num in range(max_steps):
             step_prompt = (
@@ -1182,11 +1206,34 @@ class LLMTaskRunner:
                 result.error_categories.append(category)
 
             if call.tool == "done" or exec_result.get("done"):
+                # Reject a premature done(): nudge the agent with the unmet
+                # milestones and keep going instead of accepting a half-done task.
+                if _should_reject_done(result, task_name, done_rejections, step_num, max_steps):
+                    done_rejections += 1
+                    unmet = _unmet_milestones(result, task_name)
+                    self._agent._history.append({
+                        "role": "user",
+                        "content": (
+                            "You called done() but the task is INCOMPLETE. You still "
+                            f"must successfully call: {', '.join(unmet)}. "
+                            "Do NOT call done() again until you have. Continue now."
+                        ),
+                    })
+                    continue
                 break
 
             if result.errors >= 4:
                 result.notes = "Stopped: too many errors"
                 break
+
+        # Always stop any play session the task started. A runtime task that
+        # forgets stop_scene leaves an orphaned game that blocks the editor
+        # bridge for every later task (and can crash the editor) — this keeps the
+        # suite robust regardless of how the agent finished.
+        try:
+            await self._bridge.call("cmd_stop_scene", {})
+        except Exception:
+            pass
 
         # Cleanup: delete created test nodes
         for node_path in created_nodes:
@@ -1306,6 +1353,9 @@ class LLMTaskRunner:
 
 ALL_TASK_NAMES: list[str] = list(TASK_PROMPTS.keys())
 
+# The demo scene the tasks are written against (vampire example project).
+DEMO_SCENE = "res://scenes/main.tscn"
+
 
 async def run_llm_suite(
     tasks: list[str] | None = None,
@@ -1319,6 +1369,14 @@ async def run_llm_suite(
     if not await bridge.connect():
         print("❌ Could not connect to Godot addon bridge. Is Godot running?")
         return []
+
+    # The tasks assume the vampire demo nodes (Background, Player, Sprite2D, …).
+    # Open it explicitly so the suite never runs against whatever stale scene the
+    # editor happened to have open (a leftover temp scene fails every node task).
+    open_resp = await bridge.call("cmd_open_scene", {"scene_path": DEMO_SCENE})
+    if not open_resp.get("ok"):
+        print(f"⚠️  Could not open {DEMO_SCENE}: {open_resp.get('error')}. "
+              "Node-dependent tasks may fail.")
 
     runner = LLMTaskRunner(bridge, model=model, provider=provider, variant=variant)
     task_list = tasks or ALL_TASK_NAMES

--- a/tests/integration/test_eval_milestones.py
+++ b/tests/integration/test_eval_milestones.py
@@ -17,9 +17,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from evals.llm_eval_v2 import (  # noqa: E402
+    MAX_DONE_REJECTIONS,
     TASK_MILESTONES,
     LLMTaskResult,
     LLMTaskRunner,
+    _should_reject_done,
 )
 
 
@@ -81,3 +83,29 @@ def test_task_without_milestones_is_unaffected() -> None:
     score = runner._score_task(result, "profiling_fps")
     assert score.overall > 0.3
     assert "MILESTONE" not in score.notes
+
+
+def test_premature_done_is_rejected_when_milestone_unmet() -> None:
+    # Created MutTest, calling done() early — delete_node/get_scene_tree unmet.
+    result = _result("mutate_delete_with_confirm", [("create_node", True)])
+    assert _should_reject_done(result, "mutate_delete_with_confirm", 0, 1, 12) is True
+
+
+def test_done_accepted_once_milestones_met() -> None:
+    result = _result(
+        "mutate_delete_with_confirm",
+        [("create_node", True), ("delete_node", True), ("get_scene_tree", True)],
+    )
+    assert _should_reject_done(result, "mutate_delete_with_confirm", 0, 3, 12) is False
+
+
+def test_done_accepted_after_rejection_budget_spent() -> None:
+    result = _result("mutate_delete_with_confirm", [("create_node", True)])
+    spent = MAX_DONE_REJECTIONS
+    assert _should_reject_done(result, "mutate_delete_with_confirm", spent, 3, 12) is False
+
+
+def test_done_accepted_on_last_step() -> None:
+    result = _result("mutate_delete_with_confirm", [("create_node", True)])
+    # step_num == max_steps - 1: no room to continue, so accept done().
+    assert _should_reject_done(result, "mutate_delete_with_confirm", 0, 11, 12) is False


### PR DESCRIPTION
## Summary

Improvements discovered by running the real `qwen3-coder` eval against a live editor. The run surfaced two reliability bugs and the dominant model failure mode:

- The suite ran against a **stale temp scene** (no `Background`/`Player` nodes) → every node task failed with `RESOURCE_NOT_FOUND`, confounding scores.
- A runtime task **forgot `stop_scene`**, leaving an orphaned play session that blocked the bridge for all later tasks and **crashed the editor** mid-run.
- On the valid tasks, every fail was the model calling **`done()` early** (missing `delete_node`/`read_script`/`save`/`stop_scene`). Tool *discovery* was good (~0.78 first-tool-correct); *completion* was the gap.

## Changes (`evals/llm_eval_v2.py`)

- **Scene setup** — `run_llm_suite` opens `res://scenes/main.tscn` on startup so the suite always runs against the demo nodes the tasks assume.
- **Play-session safety** — `run_task` always calls `cmd_stop_scene` in cleanup, so a forgotten `stop_scene` can't orphan a game and block/crash the editor.
- **Premature-`done()` recovery** — when `done()` is called with a milestone still unmet, the agent is nudged with the missing tools and continues (up to `MAX_DONE_REJECTIONS`) instead of being scored as a half-done fail.

## Test plan

- `tests/integration/test_eval_milestones.py`: `_should_reject_done` across unmet / met / budget-spent / last-step.
- `ruff` + `mypy` clean; eval unit tests pass.

⚠️ **Not yet validated live** — the editor crashed during the discovery run; will re-run the full suite (and the 30b-vs-79b model comparison) against a restarted editor before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)