### PR TITLE
chore: add .graphifyignore to focus the knowledge graph on the MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ examples/**/.godot/
 # OS / editor
 .DS_Store
 .env
+
+# graphify generated knowledge graph (regenerable output + cache)
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,38 @@
+# .graphifyignore — focus the knowledge graph on the MCP *itself*:
+#   - mcp_server/   the Python FastMCP server (the AI-facing product)
+#   - docs/         its architecture/contract docs
+#
+# NOTE: graphify has no GDScript parser, so the Godot addon
+# (godot/addons/godot_mcp/, the .gd half of the MCP) is invisible to it either
+# way — this graph is the Python server + docs, not the addon.
+#
+# Everything below is a SEPARATE project, a harness/consumer, or a generated/
+# meta artifact that otherwise dominates the graph (e.g. FakeAddonConnection,
+# EvalTracker, OllamaAgent, and the whole vampire demo game ranked as hubs).
+# gitignore syntax; last match wins. Flip a line to a leading "!" to re-include.
+
+# The demo game — a SEPARATE project (godot-mcp is deliberately game-agnostic),
+# not the MCP. Biggest source of unrelated nodes (Player, Enemy, weapons, …).
+examples/
+
+# Eval harness — a CONSUMER of the MCP over the bridge, not the MCP. Pulls in
+# OllamaAgent / CloudAgent / EvalTracker / variant + history machinery.
+evals/
+
+# Test scaffolding — fakes and fixtures (FakeAddonConnection, connector_for, …)
+# otherwise outrank the real abstractions in the god-node list.
+tests/
+
+# Godot project tree — nothing here is graphable (no .gd parser); excluded for
+# clarity so the corpus is unambiguously "the Python MCP + docs".
+godot/
+
+# Generated graph output + its extraction cache.
+graphify-out/
+
+# CI / harness / agent meta — not the product.
+.github/
+.claude/
+
+# Generated dependency lock (huge, not architecturally meaningful).
+uv.lock


### PR DESCRIPTION
## Summary
The graphify knowledge graph was dominated by non-MCP artifacts — the vampire demo game (a separate project), the eval harness, and test fakes all ranked as god nodes (`FakeAddonConnection`, `EvalTracker`, `OllamaAgent`). This scopes graphify to the MCP itself.

- **`.graphifyignore`** — keep `mcp_server/` (the Python FastMCP server) + `docs/`; exclude `examples/` (demo game), `evals/` (harness/consumer), `tests/`, `godot/` (graphify has no GDScript parser, so the addon was never graphable), `.github/`, `.claude/`, `graphify-out/`, `uv.lock`.
- **`.gitignore`** — ignore `graphify-out/` (regenerable graph output + extraction cache; it was 4 MB of untracked artifacts).

## Result
Graph drops from **2571 nodes / 226 communities → 902 / 41**, and the god nodes are now the real architecture: `Bridge`, `ServerConfig`, `PreconditionError`, `route()`, `create_server()`, `run_or_preview()`, `ApprovalGate`, `require_node_exists()`, `ResponseEnvelope`, `ErrorCode`.

Note: graphify (0.4.29 installed) has no GDScript parser, so the graph covers the **Python server + docs**, not the `.gd` addon half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)