### PR TITLE
chore: add GDScript support to graphify + include the addon in the graph

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,10 +1,10 @@
 # .graphifyignore — focus the knowledge graph on the MCP *itself*:
-#   - mcp_server/   the Python FastMCP server (the AI-facing product)
-#   - docs/         its architecture/contract docs
+#   - mcp_server/                 the Python FastMCP server (the AI-facing product)
+#   - godot/addons/godot_mcp/     the Godot addon (the .gd half of the MCP)
+#   - docs/                       its architecture/contract docs
 #
-# NOTE: graphify has no GDScript parser, so the Godot addon
-# (godot/addons/godot_mcp/, the .gd half of the MCP) is invisible to it either
-# way — this graph is the Python server + docs, not the addon.
+# GDScript (.gd) support is added to the installed graphify by
+# scripts/graphify_gdscript_support.py (re-run after any `graphify install`).
 #
 # Everything below is a SEPARATE project, a harness/consumer, or a generated/
 # meta artifact that otherwise dominates the graph (e.g. FakeAddonConnection,
@@ -23,9 +23,14 @@ evals/
 # otherwise outrank the real abstractions in the god-node list.
 tests/
 
-# Godot project tree — nothing here is graphable (no .gd parser); excluded for
-# clarity so the corpus is unambiguously "the Python MCP + docs".
-godot/
+# Godot project tree: keep ONLY the addon (the MCP's .gd half). Exclude the
+# editor cache, the addon's own smoke tests, and the demo scene/scripts shell.
+godot/*
+!godot/addons/
+godot/addons/*
+!godot/addons/godot_mcp/
+godot/.godot/
+godot/tests/
 
 # Generated graph output + its extraction cache.
 graphify-out/

--- a/scripts/graphify_gdscript_support.py
+++ b/scripts/graphify_gdscript_support.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Add GDScript (.gd) support to the installed graphify package.
+
+graphify ships tree-sitter extractors for ~40 languages but not GDScript, so the
+Godot addon half of this MCP (godot/addons/godot_mcp/*.gd) is invisible to the
+knowledge graph. This patcher teaches the *installed* graphify to parse .gd:
+
+  1. installs `tree-sitter-language-pack` (bundles the gdscript grammar);
+  2. writes a `tree_sitter_gdscript` shim exposing the grammar as `language()`;
+  3. patches graphify/detect.py  — adds `.gd` to CODE_EXTENSIONS;
+  4. patches graphify/extract.py — a GDScript LanguageConfig + dispatch entry,
+     a positional-callee branch (GDScript calls have no named callee field), and
+     a one-line fix so a provider returning a Language (not a capsule) works.
+
+Idempotent: re-running is a no-op. site-packages edits are wiped by
+`graphify install`/upgrades — just re-run this script afterward (it's committed
+so the support is reproducible). Run with the SAME interpreter graphify uses,
+e.g.  `<graphify-python> scripts/graphify_gdscript_support.py`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _ensure_language_pack() -> None:
+    try:
+        import tree_sitter_language_pack  # noqa: F401
+        return
+    except ImportError:
+        pass
+    print("installing tree-sitter-language-pack …")
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-q", "tree-sitter-language-pack>=1.8"],
+        check=True,
+    )
+
+
+def _write_shim(site_dir: Path) -> None:
+    shim = site_dir / "tree_sitter_gdscript.py"
+    body = (
+        '"""Shim: expose the language-pack GDScript grammar as a standalone\n'
+        'tree_sitter_gdscript module so graphify\'s ts_module config can load it."""\n'
+        "from tree_sitter_language_pack import get_language\n\n\n"
+        "def language():\n"
+        '    """Return the GDScript tree_sitter.Language (graphify wraps it)."""\n'
+        '    return get_language("gdscript")\n'
+    )
+    if shim.exists() and shim.read_text() == body:
+        print(f"shim already current: {shim}")
+        return
+    shim.write_text(body)
+    print(f"wrote shim: {shim}")
+
+
+def _patch_detect(detect_py: Path) -> None:
+    src = detect_py.read_text()
+    if "'.gd'" in src.split("CODE_EXTENSIONS")[1].split("}")[0]:
+        print("detect.py: .gd already in CODE_EXTENSIONS")
+        return
+    anchor = "CODE_EXTENSIONS = {'.py',"
+    if anchor not in src:
+        raise SystemExit("detect.py: CODE_EXTENSIONS anchor not found — graphify layout changed")
+    detect_py.write_text(src.replace(anchor, "CODE_EXTENSIONS = {'.gd', '.py',", 1))
+    print("detect.py: added '.gd' to CODE_EXTENSIONS")
+
+
+_CONFIG_BLOCK = '''_GDSCRIPT_CONFIG = LanguageConfig(
+    ts_module="tree_sitter_gdscript",
+    ts_language_fn="language",
+    class_types=frozenset({"class_definition"}),
+    function_types=frozenset({"function_definition", "constructor_definition"}),
+    import_types=frozenset(),
+    call_types=frozenset({"call", "attribute_call"}),
+    call_function_field="",
+    name_field="name",
+    name_fallback_child_types=("name", "identifier"),
+    body_field="body",
+    body_fallback_child_types=("body",),
+    function_boundary_types=frozenset(
+        {"function_definition", "constructor_definition", "class_definition"}
+    ),
+)
+
+
+def extract_gdscript(path: Path) -> dict:
+    """Extract classes, functions, and calls from a .gd (GDScript) file."""
+    return _extract_generic(path, _GDSCRIPT_CONFIG)
+
+
+'''
+
+_CALL_BRANCH = '''            elif config.ts_module == "tree_sitter_gdscript":
+                # GDScript: callee is the first identifier child (positional, no
+                # named field) for both `call` and `attribute_call`.
+                _gd_first = node.children[0] if node.children else None
+                if _gd_first is not None and _gd_first.type == "identifier":
+                    callee_name = _read_text(_gd_first, source)
+'''
+
+
+def _patch_extract(extract_py: Path) -> None:
+    src = extract_py.read_text()
+
+    # 1. Config + wrapper, inserted before extract_lua.
+    if "_GDSCRIPT_CONFIG" not in src:
+        anchor = "def extract_lua(path: Path) -> dict:"
+        if anchor not in src:
+            raise SystemExit("extract.py: extract_lua anchor not found")
+        src = src.replace(anchor, _CONFIG_BLOCK + anchor, 1)
+        print("extract.py: added _GDSCRIPT_CONFIG + extract_gdscript")
+    else:
+        print("extract.py: _GDSCRIPT_CONFIG already present")
+
+    # 2. Dispatch entry.
+    if '".gd": extract_gdscript' not in src:
+        anchor = '    ".lua": extract_lua,\n'
+        if anchor not in src:
+            raise SystemExit("extract.py: _DISPATCH lua anchor not found")
+        src = src.replace(anchor, anchor + '    ".gd": extract_gdscript,\n', 1)
+        print("extract.py: registered .gd in _DISPATCH")
+    else:
+        print("extract.py: .gd already in _DISPATCH")
+
+    # 3. Language-wrap fix (accept a provider that already returns a Language).
+    if "_raw_lang = lang_fn()" not in src:
+        anchor = "        language = Language(lang_fn())\n"
+        if anchor not in src:
+            raise SystemExit("extract.py: Language(lang_fn()) anchor not found")
+        replacement = (
+            "        _raw_lang = lang_fn()\n"
+            "        language = _raw_lang if isinstance(_raw_lang, Language) "
+            "else Language(_raw_lang)\n"
+        )
+        src = src.replace(anchor, replacement, 1)
+        print("extract.py: made Language() robust to Language-returning providers")
+    else:
+        print("extract.py: Language-wrap fix already present")
+
+    # 4. Positional-callee branch in the generic call handler.
+    if "# GDScript: callee is the first identifier child" not in src:
+        anchor = (
+            "            else:\n"
+            "                # Generic: get callee from call_function_field\n"
+        )
+        if anchor not in src:
+            raise SystemExit("extract.py: generic call-handler anchor not found")
+        src = src.replace(anchor, _CALL_BRANCH + anchor, 1)
+        print("extract.py: added GDScript positional-callee branch")
+    else:
+        print("extract.py: GDScript call branch already present")
+
+    extract_py.write_text(src)
+
+
+def main() -> None:
+    import graphify
+
+    gdir = Path(graphify.__file__).parent
+    site_dir = gdir.parent
+    print(f"graphify: {gdir}")
+    _ensure_language_pack()
+    _write_shim(site_dir)
+    _patch_detect(gdir / "detect.py")
+    _patch_extract(gdir / "extract.py")
+    print("\nDone. Verify with: python -c \"from graphify.extract import _DISPATCH; print('.gd' in _DISPATCH)\"")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/graphify_gdscript_support.py
+++ b/scripts/graphify_gdscript_support.py
@@ -165,7 +165,10 @@ def main() -> None:
     _write_shim(site_dir)
     _patch_detect(gdir / "detect.py")
     _patch_extract(gdir / "extract.py")
-    print("\nDone. Verify with: python -c \"from graphify.extract import _DISPATCH; print('.gd' in _DISPATCH)\"")
+    print(
+        "\nDone. Verify with:\n"
+        "  python -c \"from graphify.extract import _DISPATCH; print('.gd' in _DISPATCH)\""
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
graphify ships ~40 tree-sitter language extractors but **not GDScript**, so the Godot addon half of the MCP (`godot/addons/godot_mcp/*.gd`) was invisible to the knowledge graph. This adds `.gd` support and brings the addon into the focused graph.

- **`scripts/graphify_gdscript_support.py`** — an **idempotent patcher** for the installed graphify:
  - installs `tree-sitter-language-pack` (bundles the gdscript grammar, ABI-compatible with tree-sitter 0.25);
  - writes a `tree_sitter_gdscript` shim exposing it as `language()`;
  - patches `detect.py` (`+.gd`) and `extract.py` (a GDScript `LanguageConfig` + dispatch entry, a **positional-callee branch** since GDScript `call`/`attribute_call` have no named callee field, and a one-line fix so a provider returning a `Language` rather than a capsule works).
  - site-packages edits are wiped by `graphify install`; re-run the script after — it's committed so the support is reproducible.
- **`.graphifyignore`** — un-ignore `godot/addons/godot_mcp/` now that `.gd` parses (still excludes the editor cache, addon smoke tests, and demo shell).

## Result
The graph now spans **both halves of the MCP** — **1279 nodes (370 GDScript), 59 communities** (was 902 / 41, Python-only). The addon's `command_router` `_ok()` / `_fail()` — the GDScript envelope builders every `cmd_*` handler calls — surface as god nodes (138 / 125 edges) alongside the Python `Bridge` (192), `ServerConfig`, `route()`, `ApprovalGate`.

Verified: Python extraction unaffected; `mutation.gd` yields 11 functions + intra-file call edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)