### PR TITLE
chore(graphify): auto-refresh graph structure via git hook (closes #174)

### DIFF
--- a/.claude/rules/graphify.md
+++ b/.claude/rules/graphify.md
@@ -1,0 +1,79 @@
+---
+paths:
+  - ".env"
+  - ".graphifyignore"
+  - "graphify-out/**"
+  - "scripts/graphify*"
+---
+
+# Graphify (LLM extraction policy)
+
+The project's knowledge graph (`graphify-out/`) is built with the **graphify** CLI
+running against a **local ollama** backend. The backend, model, and tuning are
+configured in the repo-root `.env` (gitignored), not on the command line:
+
+```
+OLLAMA_BASE_URL=http://localhost:11434/v1   # presence → ollama is auto-detected
+OLLAMA_MODEL=...                            # overrides graphify's default model
+OLLAMA_API_KEY=ollama
+GRAPHIFY_OLLAMA_KEEP_ALIVE=30m
+GRAPHIFY_API_TIMEOUT=600
+```
+
+## The rule: always observe `.env` when running graphify
+
+**Never invoke `graphify` (or `python -m graphify`) directly. Run it through
+`scripts/graphify.sh`**, which sources `.env` and uses the pinned interpreter
+(`graphify-out/.graphify_python`):
+
+```bash
+scripts/graphify.sh label . --update
+scripts/graphify.sh query "How does the bridge work?"
+```
+
+If you must call graphify by hand, source `.env` into the environment first:
+
+```bash
+set -a; . ./.env; set +a
+$(cat graphify-out/.graphify_python) -m graphify <args>
+```
+
+## Why this matters
+
+graphify reads `os.environ` but **does not load `.env` itself**, and shells
+spawned by tooling don't auto-source it. Without these vars:
+
+- `detect_backend()` returns `None` (no API key resolves) — no LLM backend, so
+  community labeling falls back to `Community N` placeholders.
+- the ollama default model is `qwen2.5-coder:7b`, which is **not installed** here
+  — any LLM step errors out.
+
+Sourcing `.env` makes auto-detect resolve to `ollama` with `OLLAMA_MODEL`, so no
+`--backend`/`--model` flags are needed. The `/graphify` *skill* flow is separate:
+it dispatches Claude subagents (or Gemini), not ollama — ollama applies only to
+the `graphify` CLI covered by this rule.
+
+## Auto-refresh on commit (git hooks)
+
+Tracked git hooks keep the graph **structure** in sync with the code. After a
+commit or merge that touches `mcp_server/**/*.py` or `godot/addons/godot_mcp/**/*.gd`,
+`scripts/hooks/{post-commit,post-merge}` run `scripts/graphify.sh update .` —
+AST-only, **LLM-free** (~1-2s), and `graphify-out/` is gitignored so there's no
+commit churn. They no-op when no graph-relevant source changed.
+
+Activate once per clone (sets the per-checkout `core.hooksPath`):
+
+```bash
+scripts/hooks/install.sh
+```
+
+`update` re-clusters, which resets community **labels** to `Community N`
+placeholders. Names are cosmetic for `query`/`explain` (which traverse nodes/edges);
+refresh them on demand — or on a cadence — with `scripts/graphify.sh label .`.
+
+## Maintenance
+
+- After any `graphify` upgrade/reinstall, re-run `scripts/graphify_gdscript_support.py`
+  with the pinned interpreter — the site-packages `.gd` patch is wiped on reinstall.
+- `.graphifyignore` keeps the graph focused on the MCP itself (server + addon + docs);
+  flip a line to `!` to re-include an excluded tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ The constitutional rules live in `.claude/rules/` and are the source of truth fo
 | `testing.md` | III | TDD; contract→integration→unit; suite health (zero skips) |
 | `workflow.md` | — | Issue → red test → green → preflight → PR → merge pipeline |
 | `enforcement.md` | IX | Gates, PR checklist, CalVer |
+| `graphify.md` | — | Graphify LLM-extraction policy: always run graphify via `scripts/graphify.sh` so the repo `.env` (local ollama backend/model) is observed |
 
 Adapted from the [hybridindie/instructions-and-rules](https://github.com/hybridindie/instructions-and-rules) harness, pared to this project: no frontend/database/Copilot-mirror rules (none apply), with an addon rule added for the GDScript half.
 

--- a/scripts/graphify.sh
+++ b/scripts/graphify.sh
@@ -21,12 +21,16 @@ if [ -f "$ROOT/.env" ]; then
 fi
 
 # 2. Use the interpreter graphify was installed into (pinned by the skill),
-#    falling back to python3 on PATH.
+#    falling back to python3 on PATH. Read it into an argv array so a pin like
+#    "/usr/bin/env python3" (interpreter + arg) execs correctly — a single quoted
+#    "$PYTHON" would be treated as one command name and fail.
 PIN="$ROOT/graphify-out/.graphify_python"
-if [ -f "$PIN" ] && "$(cat "$PIN")" -c "import graphify" 2>/dev/null; then
-    PYTHON="$(cat "$PIN")"
-else
-    PYTHON="python3"
+py_cmd=(python3)
+if [ -f "$PIN" ]; then
+    read -r -a _pinned < "$PIN" || true
+    if [ "${#_pinned[@]}" -gt 0 ] && "${_pinned[@]}" -c "import graphify" 2>/dev/null; then
+        py_cmd=("${_pinned[@]}")
+    fi
 fi
 
-exec "$PYTHON" -m graphify "$@"
+exec "${py_cmd[@]}" -m graphify "$@"

--- a/scripts/graphify.sh
+++ b/scripts/graphify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# graphify wrapper — ALWAYS run graphify through this so the project .env is
+# observed. graphify reads os.environ but never loads .env itself, and shells
+# spawned by tooling don't auto-source it; without these vars graphify's
+# backend auto-detect returns None and it falls back to the uninstalled default
+# model (qwen2.5-coder:7b). See .claude/rules/graphify.md.
+#
+# Usage:  scripts/graphify.sh <graphify-args...>
+#   e.g.  scripts/graphify.sh label . --update
+#         scripts/graphify.sh query "How does the bridge work?"
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# 1. Source the project .env (export every assignment) if present.
+if [ -f "$ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$ROOT/.env"
+    set +a
+fi
+
+# 2. Use the interpreter graphify was installed into (pinned by the skill),
+#    falling back to python3 on PATH.
+PIN="$ROOT/graphify-out/.graphify_python"
+if [ -f "$PIN" ] && "$(cat "$PIN")" -c "import graphify" 2>/dev/null; then
+    PYTHON="$(cat "$PIN")"
+else
+    PYTHON="python3"
+fi
+
+exec "$PYTHON" -m graphify "$@"

--- a/scripts/hooks/_graphify_refresh.sh
+++ b/scripts/hooks/_graphify_refresh.sh
@@ -2,6 +2,8 @@
 # Shared by the post-commit and post-merge hooks (issue #174). Refreshes the
 # graphify graph STRUCTURE when the latest commit/merge touched MCP source.
 #
+# Arg 1 is the invoking mode ("post-commit" | "post-merge", default post-commit).
+#
 # AST-only + LLM-free (~1-2s); output (graphify-out/) is gitignored, so this
 # creates no commit churn. Re-clustering resets community labels to placeholders
 # — run `scripts/graphify.sh label .` to refresh names. See .claude/rules/graphify.md.
@@ -10,6 +12,8 @@
 # invokes it as post-commit, post-merge, or directly.
 set -uo pipefail
 
+mode="${1:-post-commit}"
+
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 cd "$ROOT" || exit 0
 
@@ -17,9 +21,15 @@ cd "$ROOT" || exit 0
 [ -x scripts/graphify.sh ] || exit 0
 [ -f graphify-out/.graphify_python ] || exit 0
 
-# Files changed by the most recent commit (HEAD). For a merge HEAD is the merge
-# commit; that's fine — we only need to know whether graph-relevant source moved.
-changed="$(git diff-tree --root --no-commit-id --name-only -r HEAD 2>/dev/null || true)"
+# Determine which files moved. A fast-forward pull integrates several commits at
+# once and the *tip* may be irrelevant, so on post-merge diff the whole merged
+# range (ORIG_HEAD..HEAD, which merge/pull set). For post-commit — or if ORIG_HEAD
+# is absent — inspect just the new commit.
+if [ "$mode" = "post-merge" ] && git rev-parse --verify --quiet ORIG_HEAD >/dev/null; then
+    changed="$(git diff --name-only ORIG_HEAD HEAD 2>/dev/null || true)"
+else
+    changed="$(git diff-tree --root --no-commit-id --name-only -r HEAD 2>/dev/null || true)"
+fi
 printf '%s\n' "$changed" | grep -qE '^(mcp_server/.*\.py|godot/addons/godot_mcp/.*\.gd)$' || exit 0
 
 # Structure-only refresh; tolerate any failure so git is never blocked.

--- a/scripts/hooks/_graphify_refresh.sh
+++ b/scripts/hooks/_graphify_refresh.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared by the post-commit and post-merge hooks (issue #174). Refreshes the
+# graphify graph STRUCTURE when the latest commit/merge touched MCP source.
+#
+# AST-only + LLM-free (~1-2s); output (graphify-out/) is gitignored, so this
+# creates no commit churn. Re-clustering resets community labels to placeholders
+# — run `scripts/graphify.sh label .` to refresh names. See .claude/rules/graphify.md.
+#
+# Best-effort: never fails a commit. Self-contained so it works whether git
+# invokes it as post-commit, post-merge, or directly.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$ROOT" || exit 0
+
+# Only act when graphify is actually set up in this checkout.
+[ -x scripts/graphify.sh ] || exit 0
+[ -f graphify-out/.graphify_python ] || exit 0
+
+# Files changed by the most recent commit (HEAD). For a merge HEAD is the merge
+# commit; that's fine — we only need to know whether graph-relevant source moved.
+changed="$(git diff-tree --root --no-commit-id --name-only -r HEAD 2>/dev/null || true)"
+printf '%s\n' "$changed" | grep -qE '^(mcp_server/.*\.py|godot/addons/godot_mcp/.*\.gd)$' || exit 0
+
+# Structure-only refresh; tolerate any failure so git is never blocked.
+scripts/graphify.sh update . >/dev/null 2>&1 || true
+exit 0

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Activate the tracked graphify git hooks for this checkout (issue #174).
+# core.hooksPath is a local, per-clone setting — run this once after cloning.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+chmod +x scripts/hooks/post-commit scripts/hooks/post-merge scripts/hooks/_graphify_refresh.sh
+git config core.hooksPath scripts/hooks
+echo "core.hooksPath -> scripts/hooks (graphify post-commit/post-merge active)"

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# graphify graph auto-refresh on commit (issue #174). See _graphify_refresh.sh.
+exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh"

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # graphify graph auto-refresh on commit (issue #174). See _graphify_refresh.sh.
-exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh"
+exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh" post-commit

--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# graphify graph auto-refresh on merge/pull (issue #174). See _graphify_refresh.sh.
+exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh"

--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # graphify graph auto-refresh on merge/pull (issue #174). See _graphify_refresh.sh.
-exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh"
+exec "$(git rev-parse --show-toplevel)/scripts/hooks/_graphify_refresh.sh" post-merge

--- a/tests/unit/test_graphify_hook.py
+++ b/tests/unit/test_graphify_hook.py
@@ -1,0 +1,86 @@
+"""Unit test for the graphify git-hook refresh predicate (issue #174).
+
+The hook (`scripts/hooks/_graphify_refresh.sh`, shared by post-commit/post-merge)
+must run `scripts/graphify.sh update .` after a commit ONLY when graph-relevant
+MCP source changed (`mcp_server/**/*.py` or `godot/addons/godot_mcp/**/*.gd`),
+and no-op otherwise. The test is hermetic: it stubs `scripts/graphify.sh` so no
+real graphify install is required.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFRESH = REPO_ROOT / "scripts" / "hooks" / "_graphify_refresh.sh"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "t")
+    # Stub graphify.sh: record its args to ran.log instead of running graphify.
+    hooks = repo / "scripts" / "hooks"
+    hooks.mkdir(parents=True)
+    (REFRESH).read_text()  # ensure the real script exists (red until created)
+    stub = repo / "scripts" / "graphify.sh"
+    stub.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "$@" >> "$(git rev-parse --show-toplevel)/ran.log"\n'
+    )
+    stub.chmod(0o755)
+    # Guard precondition: pretend graphify is set up in this checkout.
+    (repo / "graphify-out").mkdir()
+    (repo / "graphify-out" / ".graphify_python").write_text("/usr/bin/env python3\n")
+    return repo
+
+
+def _run_hook(repo: Path) -> None:
+    subprocess.run([str(REFRESH)], cwd=repo, check=False, capture_output=True, env={**os.environ})
+
+
+def _commit(repo: Path, rel: str) -> None:
+    target = repo / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", f"touch {rel}")
+
+
+@pytest.mark.parametrize(
+    "rel",
+    ["mcp_server/tools/health.py", "godot/addons/godot_mcp/handlers/mutation.gd"],
+)
+def test_hook_runs_update_on_relevant_change(tmp_path: Path, rel: str) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, rel)
+    _run_hook(repo)
+    log = repo / "ran.log"
+    assert log.exists(), f"hook did not invoke graphify.sh for {rel}"
+    assert "update ." in log.read_text()
+
+
+@pytest.mark.parametrize("rel", ["README.md", "docs/architecture.md", "evals/foo.py"])
+def test_hook_noops_on_irrelevant_change(tmp_path: Path, rel: str) -> None:
+    repo = _init_repo(tmp_path)
+    _commit(repo, rel)
+    _run_hook(repo)
+    assert not (repo / "ran.log").exists(), f"hook should have no-opped for {rel}"
+
+
+def test_hook_noops_when_graphify_not_setup(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "graphify-out" / ".graphify_python").unlink()  # not set up
+    _commit(repo, "mcp_server/tools/health.py")
+    _run_hook(repo)
+    assert not (repo / "ran.log").exists()

--- a/tests/unit/test_graphify_hook.py
+++ b/tests/unit/test_graphify_hook.py
@@ -45,8 +45,10 @@ def _init_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _run_hook(repo: Path) -> None:
-    subprocess.run([str(REFRESH)], cwd=repo, check=False, capture_output=True, env={**os.environ})
+def _run_hook(repo: Path, mode: str = "post-commit") -> None:
+    subprocess.run(
+        [str(REFRESH), mode], cwd=repo, check=False, capture_output=True, env={**os.environ}
+    )
 
 
 def _commit(repo: Path, rel: str) -> None:
@@ -55,6 +57,13 @@ def _commit(repo: Path, rel: str) -> None:
     target.write_text("x\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", f"touch {rel}")
+
+
+def _head(repo: Path) -> str:
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
 
 
 @pytest.mark.parametrize(
@@ -84,3 +93,25 @@ def test_hook_noops_when_graphify_not_setup(tmp_path: Path) -> None:
     _commit(repo, "mcp_server/tools/health.py")
     _run_hook(repo)
     assert not (repo / "ran.log").exists()
+
+
+def test_post_merge_detects_relevant_change_in_non_tip_commit(tmp_path: Path) -> None:
+    """Fast-forward pulls integrate many commits at once; a relevant change in a
+    non-tip commit must still trigger a refresh in post-merge mode (the tip-only
+    post-commit view would miss it)."""
+    repo = _init_repo(tmp_path)
+    _commit(repo, "README.md")            # base, pre-merge HEAD
+    base = _head(repo)
+    _commit(repo, "mcp_server/core.py")   # relevant change — NOT the tip
+    _commit(repo, "docs/guide.md")        # irrelevant tip commit
+    _git(repo, "update-ref", "ORIG_HEAD", base)  # what a fast-forward merge sets
+
+    # tip-only (post-commit) view sees only the irrelevant tip → no refresh
+    _run_hook(repo, "post-commit")
+    assert not (repo / "ran.log").exists()
+
+    # merged-range (post-merge) view spans ORIG_HEAD..HEAD → catches the change
+    _run_hook(repo, "post-merge")
+    log = repo / "ran.log"
+    assert log.exists()
+    assert "update ." in log.read_text()


### PR DESCRIPTION
## Summary
Keeps the graphify knowledge graph (`graphify-out/`, gitignored) in sync with the code automatically. Tracked git hooks run the **LLM-free** `scripts/graphify.sh update .` (~1-2s, AST only) after a commit/merge that touches MCP source, so `graphify query`/`explain` traverse current nodes/edges without manual rebuilds.

Also lands the `.env`-driven ollama wrapper + rule the hook depends on (graphify reads `os.environ` but never loads `.env`; the wrapper sources it and pins the interpreter).

## Acceptance criteria (#174)
- [x] `scripts/hooks/post-commit` + `post-merge` (tracked, executable) refresh structure on relevant changes
- [x] No-op when no `mcp_server/**/*.py` or `godot/addons/godot_mcp/**/*.gd` changed in the commit/merge
- [x] LLM-free (`update` only); community **labels** refreshed on demand via `scripts/graphify.sh label .` (documented tradeoff — `update` re-clusters and resets names to placeholders)
- [x] Reproducible install: `scripts/hooks/install.sh` → `git config core.hooksPath scripts/hooks`
- [x] `.claude/rules/graphify.md` documents the hook, install, and label cadence; `CLAUDE.md` rules table updated
- [x] Hermetic unit test for the trigger predicate (stubs `graphify.sh`, no real graphify dependency)

## Test plan
- `uv run pytest tests/unit/test_graphify_hook.py` — 6 cases: runs `update` for `.py`/`.gd` changes; no-ops for docs/README/evals and when graphify isn't set up. Red before the hook existed, green after.
- Live: real commit touching only `scripts/`+`tests/` → hook no-opped; scratch commit to `mcp_server/__init__.py` → hook ran `update`, `graph.json` rebuilt (scratch reset).
- Preflight: `ruff` clean, `mypy` clean (193 files), zero-skip gate clean, full unit suite 147 passed.

## Notes
- `graphify-out/` is gitignored → zero commit churn from refreshes.
- Root-commit edge case handled (`git diff-tree --root`).
- The `/graphify` skill flow is separate (Claude subagents/Gemini); this covers the ollama CLI only.