### PR TITLE
refactor(readability): extract debug_workflow service + split _preflight_validate (closes #176)

### DIFF
--- a/mcp_server/debug_workflow.py
+++ b/mcp_server/debug_workflow.py
@@ -1,0 +1,192 @@
+"""Debug-workflow service: aggregate read-only diagnostics into one report.
+
+The ``debug_workflow`` tool is a thin delegator (per
+.claude/rules/architecture.md — tool bodies hold no domain logic); all the work
+lives here as small, independently testable pieces:
+
+- ``collect_parse_errors`` / ``collect_scene_tree`` / ``collect_run`` /
+  ``collect_bridge_info`` gather one diagnostic each,
+- ``build_report`` is a pure function turning those into findings/suggestions,
+- ``run_debug_workflow`` orchestrates them and assembles the result model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.debug_workflow import DebugWorkflowResult
+from mcp_server.models.runtime import RunCaptureResult
+from mcp_server.models.scripts import ParseError
+from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
+from mcp_server.tools._route import route
+from mcp_server.tools.scripts import parse_check_errors
+
+
+async def collect_parse_errors(
+    bridge: Bridge, config: ServerConfig, runner: Runner
+) -> tuple[list[ParseError], str | None]:
+    """Parse-check every GDScript file. Returns (errors, skipped_reason)."""
+    if runner.binary is None:
+        return [], "Godot binary not found — cannot parse-check scripts."
+    parse_errors: list[ParseError] = []
+    try:
+        project_dir = await resolve_project_dir(bridge, config)
+        scripts_response = await bridge.send("cmd_list_scripts", {"directory": "res://"})
+        if scripts_response.ok and scripts_response.result:
+            for script_path in scripts_response.result.get("scripts", []):
+                try:
+                    output = await runner.check_script(project_dir, script_path, timeout=15.0)
+                    parse_errors.extend(parse_check_errors(output.stdout + "\n" + output.stderr))
+                except Exception:
+                    pass  # Skip individual scripts that fail to check
+    except Exception as exc:
+        return parse_errors, str(exc)
+    return parse_errors, None
+
+
+async def collect_scene_tree(bridge: Bridge) -> dict[str, Any] | None:
+    """Fetch the active scene tree, or None if unavailable."""
+    try:
+        tree_response = await route(bridge, "cmd_get_scene_tree", {"max_depth": -1})
+        if tree_response:
+            return tree_response
+    except Exception:
+        pass
+    return None
+
+
+async def collect_run(
+    bridge: Bridge, config: ServerConfig, runner: Runner, scene: str, timeout_seconds: float
+) -> tuple[RunCaptureResult | None, str | None]:
+    """Headless-run the project/scene. Returns (summary, skipped_reason)."""
+    if runner.binary is None:
+        return None, None
+    try:
+        project_dir = await resolve_project_dir(bridge, config)
+        output = await runner.run(project_dir, scene or None, float(timeout_seconds))
+        return summarize_run(output), None
+    except Exception as exc:
+        # Can't resolve project dir (no editor, no env var) — report it as a finding.
+        return None, str(exc)
+
+
+async def collect_bridge_info(bridge: Bridge) -> dict[str, Any]:
+    """Bridge connectivity plus project/version info when reachable."""
+    bridge_info: dict[str, Any] = {"connected": bridge.connected}
+    try:
+        info_response = await route(bridge, "cmd_get_project_info")
+        if info_response:
+            bridge_info = {
+                "connected": True,
+                "godot_version": info_response.get("godot_version"),
+                "project_name": info_response.get("name"),
+                "main_scene": info_response.get("main_scene"),
+                "autoloads": info_response.get("autoloads"),
+            }
+    except Exception:
+        pass
+    return bridge_info
+
+
+def build_report(
+    *,
+    bridge_connected: bool,
+    tree_result: dict[str, Any] | None,
+    run_result: RunCaptureResult | None,
+    run_skipped: str | None,
+    parse_errors: list[ParseError],
+    parse_skipped: str | None,
+) -> tuple[list[str], list[str]]:
+    """Turn the collected diagnostics into (findings, suggestions). Pure."""
+    findings: list[str] = []
+    suggestions: list[str] = []
+
+    if run_skipped:
+        findings.append(f"HEADLESS RUN SKIPPED: {run_skipped}")
+
+    if not bridge_connected:
+        findings.append("BRIDGE DISCONNECTED: Godot editor is not reachable.")
+        suggestions.append(
+            "Open Godot with the addon enabled\n"
+            "(Project Settings → Plugins → godot_mcp → Enable)."
+        )
+
+    if tree_result is None or not tree_result.get("tree"):
+        findings.append("NO ACTIVE SCENE: No .tscn scene is currently open in the editor.")
+        suggestions.append("Open a scene in Godot or call create_scene() to make one.")
+
+    if run_result:
+        if run_result.errors:
+            findings.append(
+                f"RUNTIME ERRORS: {len(run_result.errors)} error(s) captured "
+                "during headless run."
+            )
+            for err in run_result.errors[:3]:
+                suggestions.append(
+                    f"  [{err.type.upper()}] {err.message}"
+                    + (f" at {err.source}:{err.line}" if err.source else "")
+                )
+        if run_result.warnings:
+            findings.append(
+                f"RUNTIME WARNINGS: {len(run_result.warnings)} warning(s) captured."
+            )
+        if run_result.timed_out:
+            findings.append("RUN TIMED OUT: The game did not exit within the timeout.")
+            suggestions.append(
+                "Check for infinite loops in _process/_physics_process or missing quit() calls."
+            )
+        if run_result.exit_code != 0:
+            findings.append(
+                f"NON-ZERO EXIT: headless run exited with code {run_result.exit_code}."
+            )
+
+    if parse_errors:
+        findings.append(f"PARSE ERRORS: {len(parse_errors)} script(s) failed parse check.")
+        for pe in parse_errors[:3]:
+            suggestions.append(
+                f"  [PARSE] {pe.message}"
+                + (f" at {pe.source}:{pe.line}" if pe.source else "")
+            )
+    elif parse_skipped:
+        findings.append(f"PARSE CHECK SKIPPED: {parse_skipped}")
+
+    if not findings:
+        findings.append("No obvious issues detected. The project appears healthy.")
+    if not suggestions:
+        suggestions.append("Consider running run_test_scenario() for deeper play-testing.")
+
+    return findings, suggestions
+
+
+async def run_debug_workflow(
+    bridge: Bridge, config: ServerConfig, runner: Runner, scene: str, timeout_seconds: float
+) -> DebugWorkflowResult:
+    """Run all diagnostics and assemble the unified report model."""
+    parse_errors, parse_skipped = await collect_parse_errors(bridge, config, runner)
+    tree_result = await collect_scene_tree(bridge)
+    run_result, run_skipped = await collect_run(bridge, config, runner, scene, timeout_seconds)
+    bridge_info = await collect_bridge_info(bridge)
+
+    findings, suggestions = build_report(
+        bridge_connected=bridge.connected,
+        tree_result=tree_result,
+        run_result=run_result,
+        run_skipped=run_skipped,
+        parse_errors=parse_errors,
+        parse_skipped=parse_skipped,
+    )
+
+    return DebugWorkflowResult(
+        bridge=bridge_info,
+        scene_tree=tree_result.get("tree") if tree_result else None,
+        run=run_result.model_dump() if run_result else None,
+        parse={
+            "ok": not parse_errors,
+            "errors": [e.model_dump() for e in parse_errors],
+            "skipped_reason": parse_skipped,
+        },
+        findings=findings,
+        suggestions=suggestions,
+    )

--- a/mcp_server/debug_workflow.py
+++ b/mcp_server/debug_workflow.py
@@ -20,8 +20,8 @@ from mcp_server.models.debug_workflow import DebugWorkflowResult
 from mcp_server.models.runtime import RunCaptureResult
 from mcp_server.models.scripts import ParseError
 from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
+from mcp_server.scripts_parse import parse_check_errors
 from mcp_server.tools._route import route
-from mcp_server.tools.scripts import parse_check_errors
 
 
 async def collect_parse_errors(

--- a/mcp_server/scripts_parse.py
+++ b/mcp_server/scripts_parse.py
@@ -1,0 +1,39 @@
+"""Tool-independent parsing of Godot ``--check-only`` output.
+
+Kept free of FastMCP / tool-layer imports so both the scripts tool and the
+debug-workflow service can use it without pulling in tool-registration code.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcp_server.models.scripts import ParseError
+
+# "(res://path.gd:42)" as printed on a parse error's "at:" line.
+_CHECK_SOURCE_RE = re.compile(r"\((res://[^):]+):(\d+)\)")
+
+
+def parse_check_errors(text: str) -> list[ParseError]:
+    """Extract structured parse errors from ``--check-only`` output.
+
+    Godot prints ``SCRIPT ERROR: Parse Error: <message>`` followed by an
+    ``at: … (res://file.gd:LINE)`` line; pair them up.
+    """
+    lines = text.splitlines()
+    errors: list[ParseError] = []
+    for i, line in enumerate(lines):
+        # Only genuine parse errors — not other SCRIPT ERROR shapes (e.g. load
+        # failures) that --check-only may also print.
+        if "Parse Error:" not in line:
+            continue
+        message = line.split("Parse Error:", 1)[-1].strip()
+        source: str | None = None
+        line_no: int | None = None
+        for look in lines[i : i + 3]:
+            match = _CHECK_SOURCE_RE.search(look)
+            if match:
+                source, line_no = match.group(1), int(match.group(2))
+                break
+        errors.append(ParseError(message=message, source=source, line=line_no))
+    return errors

--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -46,102 +46,125 @@ MUTATION_COMMANDS: set[str] = {
     "cmd_apply_node_edits",
 }
 
+# Script-writing mutations; read-only cmd_read_script is excluded so it reaches
+# the addon for its own envelope.
+_SCRIPT_MUTATIONS: set[str] = {
+    "cmd_attach_script",
+    "cmd_write_script",
+    "cmd_patch_script",
+}
+
+# Returned on a cache hit for a previously-failed signature.
+_CACHED_FAILURE: dict[str, Any] = {
+    "ok": False,
+    "error": "PARAM_ERROR",
+    "hint": "Parameter validation failed (cached).",
+}
+
 
 def _invalidate_preflight_cache() -> None:
     """Clear the pre-flight cache after any mutation."""
     _preflight_cache.clear()
 
 
+async def _validate_node_path(
+    bridge: Bridge, command: str, params: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Fail a *mutation* targeting a node that doesn't exist.
+
+    Read-only inspection commands (e.g. cmd_get_node_properties) and runtime
+    commands (e.g. cmd_monitor, cmd_assert_node_state) are skipped so the addon
+    returns its own RESOURCE_NOT_FOUND/assertion envelope — pre-empting them here
+    both masks those structured errors and (for get_node_properties) recurses on
+    itself. cmd_create_node is skipped too (the target doesn't exist yet).
+    """
+    node_path = params.get("node_path", "")
+    if not (node_path and command in MUTATION_COMMANDS and command != "cmd_create_node"):
+        return None
+    try:
+        resp = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
+    except Exception:
+        return None  # Bridge error; fall through to addon validation
+    # Only a genuine "missing node" fails preflight. Other errors (e.g.
+    # PRECONDITION_FAILED for no active scene) pass through so the addon returns
+    # its own structured envelope instead of a misleading "node not found".
+    if not resp.ok and resp.error == "RESOURCE_NOT_FOUND":
+        return {
+            "ok": False,
+            "error": "PARAM_ERROR",
+            "hint": (
+                f"Node '{node_path}' not found in scene. "
+                "Use get_scene_tree to discover valid paths."
+            ),
+            "required": "node_path",
+        }
+    return None
+
+
+async def _validate_script_path(
+    bridge: Bridge, command: str, params: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Fail a script mutation whose path isn't a ``res://`` path.
+
+    File existence isn't reliably checkable server-side (project root may differ);
+    the addon returns its own RESOURCE_NOT_FOUND if the file is missing.
+    """
+    script_path = params.get("script_path", "")
+    if script_path and command in _SCRIPT_MUTATIONS and not script_path.startswith("res://"):
+        return {
+            "ok": False,
+            "error": "PARAM_ERROR",
+            "hint": f"script_path must start with 'res://'. Got: '{script_path}'",
+            "required": "script_path",
+        }
+    return None
+
+
+async def _validate_parent_path(
+    bridge: Bridge, command: str, params: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Fail cmd_create_node when its parent node doesn't exist."""
+    parent_path = params.get("parent_path", "")
+    if not (parent_path and command == "cmd_create_node" and parent_path not in {".", "/", ""}):
+        return None
+    try:
+        resp = await bridge.send("cmd_get_node_properties", {"node_path": parent_path})
+    except Exception:
+        return None
+    if not resp.ok:
+        return {
+            "ok": False,
+            "error": "PARAM_ERROR",
+            "hint": f"Parent '{parent_path}' not found. Use '.' for scene root.",
+            "required": "parent_path",
+        }
+    return None
+
+
+# Each validator returns a PARAM_ERROR dict on failure, else None. Property
+# names are deliberately not validated server-side — the addon has better context.
+_VALIDATORS = (_validate_node_path, _validate_script_path, _validate_parent_path)
+
+
 async def _preflight_validate(
     bridge: Bridge, command: str, params: dict[str, Any]
 ) -> dict[str, Any]:
-    """Validate parameters before sending to Godot.
+    """Validate parameters before sending to Godot, running each rule in turn.
 
     Returns {"ok": True} if validation passes or no rules apply.
-    Returns {"ok": False, "error": "...", "hint": "...", "required": "..."} on failure.
+    Returns {"ok": False, "error": "...", "hint": "...", "required": "..."} on the
+    first failure. Results are cached by command + sorted params.
     """
-    # Build a cache key from command + sorted params
     cache_key = f"{command}:{sorted(params.items())}"
-    if cache_key in _preflight_cache:
-        if not _preflight_cache[cache_key]:
-            return {
-                "ok": False,
-                "error": "PARAM_ERROR",
-                "hint": "Parameter validation failed (cached).",
-            }
-        return {"ok": True}
+    cached = _preflight_cache.get(cache_key)
+    if cached is not None:
+        return {"ok": True} if cached else dict(_CACHED_FAILURE)
 
-    # --- node_path validation ---
-    # Only pre-validate existence for *mutations*. Read-only inspection commands
-    # (e.g. cmd_get_node_properties) and runtime commands (e.g. cmd_monitor,
-    # cmd_assert_node_state) must reach the addon so it can return its own
-    # RESOURCE_NOT_FOUND/assertion envelope — pre-empting them here both masks
-    # those structured errors and (for get_node_properties) recurses on itself.
-    node_path = params.get("node_path", "")
-    if node_path and command in MUTATION_COMMANDS and command != "cmd_create_node":
-        # Skip create_node (target node doesn't exist yet — that's the point).
-        try:
-            resp = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
-            # Only a genuine "missing node" should fail preflight. Other errors
-            # (e.g. PRECONDITION_FAILED for no active scene) must pass through so
-            # the addon returns its own structured envelope instead of a
-            # misleading "node not found".
-            if not resp.ok and resp.error == "RESOURCE_NOT_FOUND":
-                _preflight_cache[cache_key] = False
-                return {
-                    "ok": False,
-                    "error": "PARAM_ERROR",
-                    "hint": (
-                        f"Node '{node_path}' not found in scene. "
-                        "Use get_scene_tree to discover valid paths."
-                    ),
-                    "required": "node_path",
-                }
-        except Exception:
-            pass  # Bridge error; fall through to addon validation
-
-    # --- script_path validation (mutations only; cmd_read_script is read-only
-    # and must reach the addon for its own envelope) ---
-    _SCRIPT_MUTATIONS = {
-        "cmd_attach_script",
-        "cmd_write_script",
-        "cmd_patch_script",
-    }
-    script_path = params.get("script_path", "")
-    if script_path and command in _SCRIPT_MUTATIONS:
-        if not script_path.startswith("res://"):
+    for validate in _VALIDATORS:
+        failure = await validate(bridge, command, params)
+        if failure is not None:
             _preflight_cache[cache_key] = False
-            return {
-                "ok": False,
-                "error": "PARAM_ERROR",
-                "hint": f"script_path must start with 'res://'. Got: '{script_path}'",
-                "required": "script_path",
-            }
-        # File existence isn't reliably checkable server-side (project root may
-        # differ); let the addon return its own RESOURCE_NOT_FOUND if missing.
-
-    # --- parent_path validation ---
-    parent_path = params.get("parent_path", "")
-    if parent_path and command == "cmd_create_node":
-        if parent_path not in {".", "/", ""}:
-            try:
-                resp = await bridge.send("cmd_get_node_properties", {"node_path": parent_path})
-                if not resp.ok:
-                    _preflight_cache[cache_key] = False
-                    return {
-                        "ok": False,
-                        "error": "PARAM_ERROR",
-                        "hint": f"Parent '{parent_path}' not found. Use '.' for scene root.",
-                        "required": "parent_path",
-                    }
-            except Exception:
-                pass
-
-    # --- property validation (lightweight) ---
-    prop = params.get("property", "")
-    if prop and command in {"cmd_set_node_property", "cmd_batch_set_property"}:
-        # We skip expensive property list checks; addon has better context
-        pass
+            return failure
 
     _preflight_cache[cache_key] = True
     return {"ok": True}

--- a/mcp_server/tools/debug_workflow.py
+++ b/mcp_server/tools/debug_workflow.py
@@ -37,8 +37,7 @@ def register_debug_workflow(
         1. Parse errors across all GDScript files
         2. Active scene tree structure (nodes, scripts, properties)
         3. Headless run of the project (or a specific scene) capturing errors/warnings
-        4. Signal connections in the active scene
-        5. Bridge connection state and Godot version
+        4. Bridge connection state and Godot version
 
         ``scene`` — optional res:// path to focus the headless run on a specific scene.
         """

--- a/mcp_server/tools/debug_workflow.py
+++ b/mcp_server/tools/debug_workflow.py
@@ -1,25 +1,21 @@
-"""Debug workflow: aggregate diagnostics to help the LLM/user find errors.
+"""Debug workflow tool: thin delegator to the debug-workflow service.
 
-Runs a sequence of read-only checks — parse errors, scene tree inspection,
-headless run capture, project stats, and signal flow analysis — then returns
-a unified report with actionable findings. This is the "call one tool, get
-everything" debug primitive.
+Aggregates several read-only diagnostics into one call. All logic lives in
+``mcp_server.debug_workflow`` (per .claude/rules/architecture.md — tool bodies
+are delegation only); this module just registers and wires the tool.
 """
 
 from __future__ import annotations
-
-from typing import Any
 
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
 from mcp_server.config import ServerConfig
+from mcp_server.debug_workflow import run_debug_workflow
 from mcp_server.models.debug_workflow import DebugWorkflowResult
-from mcp_server.models.scripts import ParseError
-from mcp_server.runtime import Runner, summarize_run
+from mcp_server.runtime import Runner
 from mcp_server.safety import READ_ONLY
-from mcp_server.tools._route import route
 
 
 def register_debug_workflow(
@@ -46,145 +42,4 @@ def register_debug_workflow(
 
         ``scene`` — optional res:// path to focus the headless run on a specific scene.
         """
-        # 1. Parse errors — scan every .gd file in the project
-        parse_errors: list[ParseError] = []
-        parse_skipped: str | None = None
-        if runner.binary is not None:
-            try:
-                from mcp_server.runtime import resolve_project_dir
-                from mcp_server.tools.scripts import parse_check_errors
-                project_dir = await resolve_project_dir(bridge, config)
-                # List scripts via bridge
-                scripts_response = await bridge.send(
-                    "cmd_list_scripts", {"directory": "res://"}
-                )
-                if scripts_response.ok and scripts_response.result:
-                    for script_path in scripts_response.result.get("scripts", []):
-                        try:
-                            output = await runner.check_script(
-                                project_dir, script_path, timeout=15.0,
-                            )
-                            errs = parse_check_errors(
-                                output.stdout + "\n" + output.stderr
-                            )
-                            parse_errors.extend(errs)
-                        except Exception:
-                            # Skip individual scripts that fail to check
-                            pass
-            except Exception as exc:
-                parse_skipped = str(exc)
-        else:
-            parse_skipped = "Godot binary not found — cannot parse-check scripts."
-
-        # 2. Scene tree
-        tree_result = None
-        try:
-            tree_response = await route(bridge, "cmd_get_scene_tree", {"max_depth": -1})
-            if tree_response:
-                tree_result = tree_response
-        except Exception:
-            pass
-
-        # Build the unified report (initialize early so exception handlers can append)
-        findings: list[str] = []
-        suggestions: list[str] = []
-
-        # 3. Headless run
-        run_result = None
-        if runner.binary is not None:
-            try:
-                from mcp_server.runtime import resolve_project_dir
-                project_dir = await resolve_project_dir(bridge, config)
-                output = await runner.run(
-                    project_dir, scene or None, float(timeout_seconds),
-                )
-                run_result = summarize_run(output)
-            except Exception as exc:
-                # If we can't resolve project dir (no editor, no env var), report it.
-                run_result = None
-                findings.append(f"HEADLESS RUN SKIPPED: {exc}")
-
-        # 4. Bridge / project info
-        bridge_info: dict[str, Any] = {"connected": bridge.connected}
-        try:
-            info_response = await route(bridge, "cmd_get_project_info")
-            if info_response:
-                bridge_info = {
-                    "connected": True,
-                    "godot_version": info_response.get("godot_version"),
-                    "project_name": info_response.get("name"),
-                    "main_scene": info_response.get("main_scene"),
-                    "autoloads": info_response.get("autoloads"),
-                }
-        except Exception:
-            pass
-
-        if not bridge.connected:
-            findings.append("BRIDGE DISCONNECTED: Godot editor is not reachable.")
-            suggestions.append(
-                "Open Godot with the addon enabled\n"
-                "(Project Settings → Plugins → godot_mcp → Enable)."
-            )
-
-        if tree_result is None or not tree_result.get("tree"):
-            findings.append("NO ACTIVE SCENE: No .tscn scene is currently open in the editor.")
-            suggestions.append("Open a scene in Godot or call create_scene() to make one.")
-
-        if run_result:
-            if run_result.errors:
-                findings.append(
-                    "RUNTIME ERRORS: "
-                    f"{len(run_result.errors)} error(s) captured "
-                    "during headless run."
-                )
-                for err in run_result.errors[:3]:
-                    suggestions.append(
-                        f"  [{err.type.upper()}] {err.message}"
-                        + (f" at {err.source}:{err.line}" if err.source else "")
-                    )
-            if run_result.warnings:
-                findings.append(
-                    f"RUNTIME WARNINGS: {len(run_result.warnings)} warning(s) captured."
-                )
-            if run_result.timed_out:
-                findings.append("RUN TIMED OUT: The game did not exit within the timeout.")
-                suggestions.append(
-                    "Check for infinite loops in _process/_physics_process or missing quit() calls."
-                )
-            if run_result.exit_code != 0:
-                findings.append(
-                    "NON-ZERO EXIT: headless run exited with "
-                    f"code {run_result.exit_code}."
-                )
-
-        if parse_errors:
-            findings.append(
-                f"PARSE ERRORS: {len(parse_errors)} script(s) failed parse check."
-            )
-            for pe in parse_errors[:3]:
-                suggestions.append(
-                    f"  [PARSE] {pe.message}"
-                    + (f" at {pe.source}:{pe.line}" if pe.source else "")
-                )
-        elif parse_skipped:
-            findings.append(f"PARSE CHECK SKIPPED: {parse_skipped}")
-
-        if not findings:
-            findings.append("No obvious issues detected. The project appears healthy.")
-
-        if not suggestions:
-            suggestions.append("Consider running run_test_scenario() for deeper play-testing.")
-
-        return DebugWorkflowResult(
-            bridge=bridge_info,
-            scene_tree=tree_result.get("tree") if tree_result else None,
-            run=run_result.model_dump() if run_result else None,
-            parse={
-                "ok": not parse_errors,
-                "errors": [e.model_dump() for e in parse_errors],
-                "skipped_reason": parse_skipped,
-            },
-            findings=findings,
-            suggestions=suggestions,
-        )
-
+        return await run_debug_workflow(bridge, config, runner, scene, timeout_seconds)

--- a/mcp_server/tools/scripts.py
+++ b/mcp_server/tools/scripts.py
@@ -10,8 +10,6 @@ errors. All in the gated ``scripts`` toolset.
 
 from __future__ import annotations
 
-import re
-
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
@@ -20,7 +18,6 @@ from mcp_server.config import ServerConfig
 from mcp_server.models.scripts import (
     NodeScript,
     ParseCheckResult,
-    ParseError,
     PatchScriptResult,
     ScriptContent,
     ScriptList,
@@ -28,37 +25,10 @@ from mcp_server.models.scripts import (
 )
 from mcp_server.runtime import Runner, resolve_project_dir
 from mcp_server.safety import MUTATING, READ_ONLY, PreconditionError, enforce_preconditions
+from mcp_server.scripts_parse import parse_check_errors
 from mcp_server.tools._route import route, run_or_preview
 
 SCRIPTS = {SCRIPTS_TAG}
-
-# "(res://path.gd:42)" as printed on a parse error's "at:" line.
-_CHECK_SOURCE_RE = re.compile(r"\((res://[^):]+):(\d+)\)")
-
-
-def parse_check_errors(text: str) -> list[ParseError]:
-    """Extract structured parse errors from ``--check-only`` output.
-
-    Godot prints ``SCRIPT ERROR: Parse Error: <message>`` followed by an
-    ``at: … (res://file.gd:LINE)`` line; pair them up.
-    """
-    lines = text.splitlines()
-    errors: list[ParseError] = []
-    for i, line in enumerate(lines):
-        # Only genuine parse errors — not other SCRIPT ERROR shapes (e.g. load
-        # failures) that --check-only may also print.
-        if "Parse Error:" not in line:
-            continue
-        message = line.split("Parse Error:", 1)[-1].strip()
-        source: str | None = None
-        line_no: int | None = None
-        for look in lines[i : i + 3]:
-            match = _CHECK_SOURCE_RE.search(look)
-            if match:
-                source, line_no = match.group(1), int(match.group(2))
-                break
-        errors.append(ParseError(message=message, source=source, line=line_no))
-    return errors
 
 
 def register_scripts(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: Runner) -> None:

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -11,8 +11,8 @@ from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
 from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
 from mcp_server.runtime import RunOutput
+from mcp_server.scripts_parse import parse_check_errors
 from mcp_server.server import create_server
-from mcp_server.tools.scripts import parse_check_errors
 from tests.fakes import FakeAddonConnection, connector_for
 
 # asyncio_mode=auto runs the async tests; no module-wide mark (it would warn on the

--- a/tests/integration/test_scripts_e2e.py
+++ b/tests/integration/test_scripts_e2e.py
@@ -16,7 +16,7 @@ import pytest
 from mcp_server.bridge import Bridge
 from mcp_server.config import BridgeConfig, ServerConfig
 from mcp_server.runtime import GodotRunner
-from mcp_server.tools.scripts import parse_check_errors
+from mcp_server.scripts_parse import parse_check_errors
 from tests.integration._godot import GODOT_BIN, GODOT_PROJECT
 
 pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")

--- a/tests/unit/test_debug_report.py
+++ b/tests/unit/test_debug_report.py
@@ -1,0 +1,102 @@
+"""Unit tests for the extracted debug-workflow service (issue #176).
+
+`build_report` is the pure report-assembly function pulled out of the old
+159-line `debug_workflow` tool body; `run_debug_workflow` is the orchestrator.
+These pin the report wording/ordering so the refactor preserves behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig, ServerConfig
+from mcp_server.debug_workflow import build_report, run_debug_workflow
+from mcp_server.models.runtime import LogEntry, RunCaptureResult
+from mcp_server.models.scripts import ParseError
+from mcp_server.runtime import GodotRunner
+from tests.fakes import FakeAddonConnection, connector_for
+
+HEALTHY = "No obvious issues detected. The project appears healthy."
+
+
+def _run(errors: list[LogEntry] | None = None, **kw: object) -> RunCaptureResult:
+    base: dict[str, object] = dict(
+        ran=True, exit_code=0, timed_out=False, duration_seconds=0.1,
+        errors=errors or [], warnings=[], output=[], command=["fake"],
+    )
+    base.update(kw)
+    return RunCaptureResult(**base)  # type: ignore[arg-type]
+
+
+def test_build_report_healthy_project() -> None:
+    findings, suggestions = build_report(
+        bridge_connected=True, tree_result={"tree": {"name": "Root"}},
+        run_result=_run(), run_skipped=None, parse_errors=[], parse_skipped=None,
+    )
+    assert findings == [HEALTHY]
+    assert suggestions == ["Consider running run_test_scenario() for deeper play-testing."]
+
+
+def test_build_report_disconnected_no_scene_parse_skipped() -> None:
+    findings, _ = build_report(
+        bridge_connected=False, tree_result=None, run_result=None,
+        run_skipped=None, parse_errors=[], parse_skipped="no binary",
+    )
+    assert any(f.startswith("BRIDGE DISCONNECTED") for f in findings)
+    assert any(f.startswith("NO ACTIVE SCENE") for f in findings)
+    assert "PARSE CHECK SKIPPED: no binary" in findings
+    assert HEALTHY not in findings
+
+
+def test_build_report_run_errors_warnings_timeout() -> None:
+    run = _run(
+        errors=[LogEntry(type="error", message="boom", source="res://x.gd", line=5)],
+        warnings=[LogEntry(type="warning", message="meh", source=None, line=None)],
+        timed_out=True, exit_code=None,
+    )
+    findings, suggestions = build_report(
+        bridge_connected=True, tree_result={"tree": {}}, run_result=run,
+        run_skipped=None, parse_errors=[], parse_skipped=None,
+    )
+    assert any(f.startswith("RUNTIME ERRORS") for f in findings)
+    assert any(f.startswith("RUNTIME WARNINGS") for f in findings)
+    assert any(f.startswith("RUN TIMED OUT") for f in findings)
+    assert any(f.startswith("NON-ZERO EXIT") for f in findings)  # exit_code None != 0
+    assert "  [ERROR] boom at res://x.gd:5" in suggestions
+
+
+def test_build_report_run_skipped_is_first_finding() -> None:
+    findings, _ = build_report(
+        bridge_connected=False, tree_result={"tree": {}}, run_result=None,
+        run_skipped="cannot resolve project dir", parse_errors=[], parse_skipped=None,
+    )
+    assert findings[0] == "HEADLESS RUN SKIPPED: cannot resolve project dir"
+
+
+def test_build_report_parse_errors_take_precedence_over_skipped() -> None:
+    findings, _ = build_report(
+        bridge_connected=True, tree_result={"tree": {}}, run_result=_run(),
+        run_skipped=None,
+        parse_errors=[ParseError(message="bad", source="res://a.gd", line=1)],
+        parse_skipped="should be ignored",
+    )
+    assert any(f.startswith("PARSE ERRORS") for f in findings)
+    assert not any("PARSE CHECK SKIPPED" in f for f in findings)
+
+
+def test_run_debug_workflow_orchestrates_to_model() -> None:
+    async def go() -> None:
+        bridge = Bridge(BridgeConfig(), connector=connector_for(FakeAddonConnection()))
+        await bridge.connect()
+        runner = GodotRunner(ServerConfig())
+        runner.binary = None  # force "no Godot" path → parse/run skipped, deterministic
+        result = await run_debug_workflow(bridge, ServerConfig(), runner, "", 5.0)
+        assert result.bridge["connected"] is True
+        assert result.scene_tree is None
+        assert result.run is None
+        assert result.parse["skipped_reason"] is not None
+        assert any(f.startswith("NO ACTIVE SCENE") for f in result.findings)
+        await bridge.close()
+
+    asyncio.run(go())

--- a/tests/unit/test_preflight_validate.py
+++ b/tests/unit/test_preflight_validate.py
@@ -8,6 +8,7 @@ short-circuit behavior.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -43,7 +44,11 @@ async def _bridge(responder: Responder = ping_responder) -> Bridge:
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache() -> None:
+def _clear_cache() -> Iterator[None]:
+    # Clear before AND after: _preflight_cache is global, so leftover entries
+    # would make other test modules order-dependent (cache hits skip validation).
+    _invalidate_preflight_cache()
+    yield
     _invalidate_preflight_cache()
 
 

--- a/tests/unit/test_preflight_validate.py
+++ b/tests/unit/test_preflight_validate.py
@@ -1,0 +1,104 @@
+"""Unit tests for the split pre-flight validators (issue #176).
+
+`_preflight_validate` was a 93-line linear wall; it's now an orchestrator over
+per-rule validators. These pin each rule plus the orchestrator's caching and
+short-circuit behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.tools._route import (
+    _invalidate_preflight_cache,
+    _preflight_cache,
+    _preflight_validate,
+    _validate_node_path,
+    _validate_parent_path,
+    _validate_script_path,
+)
+from tests.fakes import FakeAddonConnection, Responder, connector_for, ping_responder
+
+
+def _node_responder(*, exists: bool) -> Responder:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_get_node_properties":
+            if exists:
+                return ResponseEnvelope.success(cmd.id, {"node_path": "X"})
+            return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "no node")
+        return ping_responder(cmd)
+    return responder
+
+
+async def _bridge(responder: Responder = ping_responder) -> Bridge:
+    bridge = Bridge(BridgeConfig(), connector=connector_for(FakeAddonConnection(responder)))
+    await bridge.connect()
+    return bridge
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    _invalidate_preflight_cache()
+
+
+def test_script_path_rejects_non_res_path() -> None:
+    async def go() -> None:
+        bridge = await _bridge()
+        fail = await _validate_script_path(bridge, "cmd_write_script", {"script_path": "x.gd"})
+        assert fail is not None and fail["required"] == "script_path"
+        ok = await _validate_script_path(bridge, "cmd_write_script", {"script_path": "res://x.gd"})
+        assert ok is None
+        # read-only cmd_read_script is not a mutation → no validation
+        skip = await _validate_script_path(bridge, "cmd_read_script", {"script_path": "x.gd"})
+        assert skip is None
+        await bridge.close()
+    asyncio.run(go())
+
+
+def test_node_path_missing_node_fails_only_for_mutations() -> None:
+    async def go() -> None:
+        miss = await _bridge(_node_responder(exists=False))
+        fail = await _validate_node_path(miss, "cmd_set_node_property", {"node_path": "Ghost"})
+        assert fail is not None and fail["required"] == "node_path"
+        # read-only command skips (addon returns its own envelope)
+        skip = await _validate_node_path(miss, "cmd_get_node_properties", {"node_path": "Ghost"})
+        assert skip is None
+        await miss.close()
+        present = await _bridge(_node_responder(exists=True))
+        ok = await _validate_node_path(present, "cmd_set_node_property", {"node_path": "Player"})
+        assert ok is None
+        await present.close()
+    asyncio.run(go())
+
+
+def test_parent_path_missing_fails_dot_skips() -> None:
+    async def go() -> None:
+        miss = await _bridge(_node_responder(exists=False))
+        fail = await _validate_parent_path(miss, "cmd_create_node", {"parent_path": "Ghost"})
+        assert fail is not None and fail["required"] == "parent_path"
+        ok = await _validate_parent_path(miss, "cmd_create_node", {"parent_path": "."})
+        assert ok is None
+        await miss.close()
+    asyncio.run(go())
+
+
+def test_preflight_caches_and_short_circuits() -> None:
+    async def go() -> None:
+        bridge = await _bridge(_node_responder(exists=False))
+        params: dict[str, Any] = {"script_path": "bad.gd"}
+        result = await _preflight_validate(bridge, "cmd_write_script", params)
+        assert result["ok"] is False and result["required"] == "script_path"
+        # failure cached
+        assert _preflight_cache[f"cmd_write_script:{sorted(params.items())}"] is False
+        # a clean command caches True
+        ok = await _preflight_validate(bridge, "cmd_ping", {})
+        assert ok == {"ok": True}
+        assert _preflight_cache["cmd_ping:[]"] is True
+        await bridge.close()
+    asyncio.run(go())


### PR DESCRIPTION
## Summary
Readability pass for public contributions, targeting the two genuine Python "god functions" found in the audit (no extremely long files exist — max 482L — and no GDScript god functions — max 73L).

- **`debug_workflow`**: the 159L / ~32-branch logic packed into the `@mcp.tool` body is extracted into a new service module `mcp_server/debug_workflow.py` (`collect_parse_errors` / `collect_scene_tree` / `collect_run` / `collect_bridge_info`, a **pure** `build_report`, and a `run_debug_workflow` orchestrator). The tool body is now **19L of pure delegation** — satisfying the architecture rule "tool bodies are delegation only, zero domain logic."
- **`_preflight_validate`**: the 93L / ~19-branch linear wall is split into per-rule validators (`_validate_node_path` / `_validate_script_path` / `_validate_parent_path`) behind a thin orchestrator that owns caching + short-circuit. `_SCRIPT_MUTATIONS` hoisted to module level.

Behavior is unchanged — same report wording/ordering, same validation rules, caching, and short-circuit semantics.

## Function size before → after
| Function | Before | After |
|---|---|---|
| `debug_workflow()` (tool body) | 159L / 32 br | 19L / 0 br |
| `_preflight_validate()` | 93L / 19 br | 22L / 3 br |
| largest new unit (`build_report`) | — | 68L (pure, linear, tested) |

## Acceptance criteria (#176)
- [x] `debug_workflow` tool body is delegation-only; logic in `mcp_server/debug_workflow.py`
- [x] `build_report` is a pure, unit-tested function; wording/ordering unchanged
- [x] `_preflight_validate` split into named per-rule validators; behavior unchanged
- [x] New unit tests for the extracted seams (red before, green after); existing contract tests stay green
- [x] Preflight clean: pytest, mypy (strict), ruff, zero-skip

## Test plan
- New: `tests/unit/test_debug_report.py` (build_report cases + orchestration) and `tests/unit/test_preflight_validate.py` (each rule + caching/short-circuit). Red before implementation, green after.
- Existing `tests/contract/test_debug_contract.py` stays green (end-to-end tool behavior).
- Full preflight: **404 unit+contract tests pass**, `mypy` clean (195 files), `ruff` clean, zero-skip clean.

## Non-goals
The long-but-flat `register_*()` functions are intentionally left as-is (idiomatic FastMCP wiring, low complexity).