### PR TITLE
docs: godot-mcp is a standalone, harness-agnostic MCP server (closes #178)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Entry point for OpenCode and other agentic clients working in **godot-mcp**.
 
+## Independent & harness-agnostic
+
+godot-mcp is a **standalone MCP server** — generic Godot editor control over the Model Context Protocol. It is usable by **any** AI agent harness (Claude Code, OpenCode, or any stdio/HTTP MCP client) and is **game-agnostic** (no built-in game vocabulary; see [`CLAUDE.md`](./CLAUDE.md)).
+
+It has **no dependency on any specific consumer.** Other projects depend on godot-mcp, never the reverse — e.g. the `godot-agents` orchestrator is coded specifically against this server's tool surface, but godot-mcp must **never** couple back to it (no agent-harness-specific tools, prompts, assumptions, or imports). Keep the surface generic; let consumers adapt to it.
+
 The full project context and the grounding-rule index are in [`CLAUDE.md`](./CLAUDE.md) — read it first. The constitutional rules themselves live in [`.claude/rules/`](./.claude/rules/) and are the source of truth for how to build here:
 
 - `architecture.md` — library-first; the addon/server boundary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Entry point for OpenCode and other agentic clients working in **godot-mcp**.
 
 ## Independent & harness-agnostic
 
-godot-mcp is a **standalone MCP server** — generic Godot editor control over the Model Context Protocol. It is usable by **any** AI agent harness (Claude Code, OpenCode, or any stdio/HTTP MCP client) and is **game-agnostic** (no built-in game vocabulary; see [`CLAUDE.md`](./CLAUDE.md)).
+godot-mcp is a **standalone MCP server** — generic Godot editor control over the Model Context Protocol. It is usable by **any** AI agent harness (Claude Code, OpenCode, or any MCP client over stdio or Streamable HTTP) and is **game-agnostic** (no built-in game vocabulary; see [`CLAUDE.md`](./CLAUDE.md)).
 
 It has **no dependency on any specific consumer.** Other projects depend on godot-mcp, never the reverse — e.g. the `godot-agents` orchestrator is coded specifically against this server's tool surface, but godot-mcp must **never** couple back to it (no agent-harness-specific tools, prompts, assumptions, or imports). Keep the surface generic; let consumers adapt to it.
 


### PR DESCRIPTION
## Summary
Makes godot-mcp's **independence** explicit in `AGENTS.md`:
- a **standalone** MCP server, usable by **any** AI agent harness (Claude Code, OpenCode, any stdio/HTTP MCP client), game-agnostic;
- **no dependency on any specific consumer** — consumers (e.g. the `godot-agents` orchestrator, which is coded specifically against this server's surface) depend on godot-mcp, never the reverse. No agent-harness-specific tools/prompts/assumptions.

## Acceptance criteria (#178)
- [x] States standalone / harness-agnostic
- [x] States no dependency on any specific consumer
- [x] Docs-only, no behavior change

## Test plan
Docs-only — workflow step 2 (failing test) is N/A. No code paths touched.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)