### PR TITLE
Configure Qodo/PR-Agent as Automated Reviewer with Ollama Models

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -28,8 +28,8 @@ Each step gates the next.
 3. **Green code.** Minimum to pass. Refactor in a separate step once green is locked.
 4. **Preflight clean.** Server touched: `pytest` (contract + unit at least), type check, lint, zero-skip scan. Addon touched: load the plugin in Godot 4.4+ and confirm it enables/disables without errors.
 5. **PR opened.** Title `<type>(<scope>): <summary> (closes #N)`; body has a summary, the issue's acceptance criteria as a checklist, and a Test plan.
-6. **Comments addressed.** Every comment gets a code change or a written reply. A separate concern → a follow-up issue, linked.
-7. **Merge.** CI green, preflight green, comments resolved. Squash; delete branch.
+6. **Comments addressed.** The automated reviewer is the **Qodo / The-PR-Agent** bot (`k3s-qodo-pr-agent`, configured in `.pr_agent.toml`, running open-source models on Ollama Cloud). It auto-runs `/describe` + `/review` on open; `/improve` is manual. **Wait for its review to land before addressing anything** — don't pre-emptively self-review. Treat findings as **advisory**: fix real issues, reply to misreads. Every comment gets a code change or a written reply; a separate concern → a follow-up issue, linked.
+7. **Merge.** CI green, preflight green, Qodo review addressed. Squash; delete branch.
 
 ## Anti-patterns
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,12 +5,13 @@
 # /improve = manual-only toggle (pr_commands runs /describe + /review on open).
 
 [config]
-# Open-source models on Ollama Cloud only — no proprietary models. Cost-tiered
-# for high PR volume: a small/fast coder model as primary (code review benefits
-# from a code-tuned model), a larger one only on fallback failure.
-# ⚠ CONFIRM the exact Ollama Cloud tags against the account before relying on this.
+# Open-source models on Ollama Cloud only — no proprietary models.
+# Primary: qwen3-coder:30b — already the cluster's default code-review model
+# (a code-tuned model fits code review). Fallback: qwen3-coder-next (same family,
+# slightly lower performance), used only if the primary call fails.
+# The litellm "ollama/" prefix must match the cluster's working model string.
 model = "ollama/qwen3-coder:30b"
-fallback_models = ["ollama/minimax-m2"]
+fallback_models = ["ollama/qwen3-coder-next"]
 
 [pr_reviewer]
 # The diff-only "ticket compliance analysis" mis-fired (marked implemented

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -8,9 +8,9 @@
 # Open-source models on Ollama Cloud only — mirrors the cluster's default
 # hierarchy. Coder models fit code review. Tags must match the cluster's
 # working litellm "ollama/" strings.
-model = "ollama/qwen3-coder-next"             # primary
-fallback_models = ["ollama/qwen3-coder:30b"]  # used only if the primary fails
-model_reasoning = "ollama/qwen3-coder-next"   # self-reflection; same as primary
+model = "ollama/qwen3-coder:30b"              # primary (qwen3-coder-next was too slow / blocking)
+fallback_models = ["ollama/qwen3-coder-next"] # last-resort only (rare; ok if slow)
+model_reasoning = "ollama/qwen3-coder:30b"    # self-reflection; same as primary (kept fast)
 model_weak = "ollama/gemma4:12b"              # cheap model for easy subtasks
 
 [pr_reviewer]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,13 +5,13 @@
 # /improve = manual-only toggle (pr_commands runs /describe + /review on open).
 
 [config]
-# Open-source models on Ollama Cloud only — no proprietary models.
-# Primary: qwen3-coder:30b — already the cluster's default code-review model
-# (a code-tuned model fits code review). Fallback: qwen3-coder-next (same family,
-# slightly lower performance), used only if the primary call fails.
-# The litellm "ollama/" prefix must match the cluster's working model string.
-model = "ollama/qwen3-coder:30b"
-fallback_models = ["ollama/qwen3-coder-next"]
+# Open-source models on Ollama Cloud only — mirrors the cluster's default
+# hierarchy. Coder models fit code review. Tags must match the cluster's
+# working litellm "ollama/" strings.
+model = "ollama/qwen3-coder-next"             # primary
+fallback_models = ["ollama/qwen3-coder:30b"]  # used only if the primary fails
+model_reasoning = "ollama/qwen3-coder-next"   # self-reflection; same as primary
+model_weak = "ollama/gemma4:12b"              # cheap model for easy subtasks
 
 [pr_reviewer]
 # The diff-only "ticket compliance analysis" mis-fired (marked implemented

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -41,3 +41,11 @@ Focus on real correctness bugs, security, and missing regression tests.
 # /improve is manual-only (cluster-side). When invoked, keep it tight + high-confidence.
 suggestions_score_threshold = 7
 extra_instructions = "Only high-impact correctness/security fixes; skip style and CI-enforced nits."
+
+[ignore]
+# Drop lock/generated/data files from the diff before review — cuts noise + token
+# cost, and keeps lockfile churn from pushing a PR over Qodo's size limit
+# (this is what was silently skipping the mlflow-SDK PR). Matched via re.match
+# (anchored at path start); globs translate to regex.
+glob = ["*.lock", "*.uid", "*.import"]
+regex = ['graphify-out/.*']

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,42 @@
+# Repo config for the self-hosted PR reviewer (The-PR-Agent / k3s-qodo-pr-agent).
+# https://github.com/The-PR-Agent/pr-agent
+#
+# Cluster-side (NOT here): OLLAMA_API_BASE / OLLAMA_API_KEY secrets, and the
+# /improve = manual-only toggle (pr_commands runs /describe + /review on open).
+
+[config]
+# Open-source models on Ollama Cloud only — no proprietary models. Cost-tiered
+# for high PR volume: a small/fast coder model as primary (code review benefits
+# from a code-tuned model), a larger one only on fallback failure.
+# ⚠ CONFIRM the exact Ollama Cloud tags against the account before relying on this.
+model = "ollama/qwen3-coder:30b"
+fallback_models = ["ollama/minimax-m2"]
+
+[pr_reviewer]
+# The diff-only "ticket compliance analysis" mis-fired (marked implemented
+# criteria non-compliant), so disable just that section.
+require_ticket_analysis_review = false
+num_max_findings = 3
+extra_instructions = """
+godot-mcp is a game-agnostic Godot MCP server.
+
+Do NOT raise these (intentional, or already enforced elsewhere — they only add noise/cost):
+- Anything CI already gates: ruff lint+format, mypy (strict on mcp_server + tests), pytest,
+  the zero-skip test gate, coverage. Don't restyle or duplicate CI-enforced findings.
+- CI / tooling / generated files: .github/**, *.lock, *.uid, *.import, graphify-out/**.
+- evals/ is dev tooling, not shipped server code; fail-fast there is intentional.
+
+Conventions to respect:
+- TDD: a behavior change should come with a test; failures return the {ok,error,hint}
+  envelope, never raw traces; safety classes + dry_run/confirm live in the MCP layer,
+  not the addon.
+- Server-side MLflow registration (datasets/scorers) happens out-of-band, so code that
+  only *defines* such objects is complete — don't flag it as missing wiring.
+
+Focus on real correctness bugs, security, and missing regression tests.
+"""
+
+[pr_code_suggestions]
+# /improve is manual-only (cluster-side). When invoked, keep it tight + high-confidence.
+suggestions_score_threshold = 7
+extra_instructions = "Only high-impact correctness/security fixes; skip style and CI-enforced nits."


### PR DESCRIPTION
### **User description**
## Summary
Configures the self-hosted **The-PR-Agent** reviewer (`k3s-qodo-pr-agent`) for this repo via `.pr_agent.toml`, and documents the review gate in `workflow.md`.

## `.pr_agent.toml`
- **OSS models on Ollama Cloud only** — `model = ollama/qwen3-coder:30b` (a code-tuned model fits code review), `fallback_models = [ollama/minimax-m2]`. Cost-tiered for high PR volume.
- `require_ticket_analysis_review = false` — the diff-only ticket-compliance section mis-fired (flagged implemented criteria as non-compliant).
- `extra_instructions` — tells the reviewer to **ignore CI-enforced concerns** (ruff/mypy/coverage/zero-skip) and CI/generated files, and encodes repo conventions (TDD, `{ok,error,hint}` envelope, MCP-layer safety, out-of-band MLflow registration) so it stops flagging intentional patterns. Focus on correctness/security/missing tests.
- `/improve` stays **manual** (cluster-side); high `suggestions_score_threshold` when invoked.

## Docs
`workflow.md` step 6 now names Qodo as the reviewer, marks findings **advisory**, and codifies **wait-for-review-before-addressing**.

## Maintainer action (cluster-side, not in this PR)
- Set `OLLAMA_API_BASE` / `OLLAMA_API_KEY` for Ollama Cloud.
- **Confirm the exact Ollama Cloud tags** (`qwen3-coder:30b`, `minimax-m2`) — adjust if your account uses different tags. A wrong tag would fail all reviews on this repo, so validate with one throwaway PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces Qodo/PR-Agent as the automated reviewer for PRs

- Configures open-source Ollama models for code review

- Updates workflow to require Qodo review before addressing comments

- Documents review gate and advisory findings policy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR opened"] -- "Auto-run /describe + /review" --> B["Qodo/PR-Agent reviews"]
  B -- "Wait for review before addressing" --> C["Comments addressed"]
  C -- "Merge after Qodo review" --> D["Squash and delete branch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflow.md</strong><dd><code>Update workflow for automated reviewer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/rules/workflow.md

<ul><li>Replaces manual review step with automated Qodo/PR-Agent bot<br> <li> Specifies that findings are advisory and should be addressed after <br>review<br> <li> Updates merge criteria to include Qodo review approval<br> <li> Clarifies that /improve command is manual only</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/186/files#diff-38a6b340cf48743a42499b37abaa68e3443d08a395082364af57e508d5d1a359">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Configure PR agent with Ollama models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Adds PR agent configuration file with Ollama model settings<br> <li> Configures qwen3-coder:30b as primary model and minimax-m2 as fallback<br> <li> Disables ticket analysis review to prevent false positives<br> <li> Sets extra instructions to ignore CI-enforced concerns and focus on <br>correctness/security</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/186/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

