### PR TITLE
Update reviewer models for A/B trial of kimi-k2.7-coder

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,13 +5,15 @@
 # /improve = manual-only toggle (pr_commands runs /describe + /review on open).
 
 [config]
-# Open-source models on Ollama Cloud only — mirrors the cluster's default
-# hierarchy. Coder models fit code review. Tags must match the cluster's
-# working litellm "ollama/" strings.
-model = "ollama/qwen3-coder:30b"              # primary (qwen3-coder-next was too slow / blocking)
-fallback_models = ["ollama/qwen3-coder-next"] # last-resort only (rare; ok if slow)
-model_reasoning = "ollama/qwen3-coder:30b"    # self-reflection; same as primary (kept fast)
-model_weak = "ollama/gemma4:12b"              # cheap model for easy subtasks
+# Open-source models on Ollama Cloud only. A/B: trial a larger cloud model as
+# primary (fewer false-positives + better instruction-following) while keeping
+# the fast/cheap qwen3-coder:30b as fallback — if the kimi tag is wrong the
+# primary just fails over to :30b, so reviews never hard-break.
+# Tags must match the cluster/cloud's working litellm "ollama/" strings.
+model = "ollama/kimi-k2.7-coder"             # primary (A/B trial — larger, coding-focused)
+fallback_models = ["ollama/qwen3-coder:30b"] # fast/cheap fallback (also the safety net)
+model_reasoning = "ollama/qwen3-coder:30b"   # self-reflection kept on the fast model (cost/latency)
+model_weak = "ollama/gemma4:12b"             # cheap model for easy subtasks
 
 [pr_reviewer]
 # The diff-only "ticket compliance analysis" mis-fired (marked implemented


### PR DESCRIPTION
### **User description**
A/B trial: switch the PR-Agent **primary** model to a larger coding-focused cloud model, `ollama/kimi-k2.7-coder`, to reduce false-positives and improve `extra_instructions` adherence. `qwen3-coder:30b` becomes the fast/cheap **fallback** (also a safety net — a wrong kimi tag just fails over to it, so reviews never hard-break). `model_reasoning` stays on `:30b` to keep the self-reflection pass cheap/fast.

Takes effect on PRs branched off `main` after this merges (`use_repo_settings_file=true` reads `.pr_agent.toml` from the PR's head tree).

**Confirm the exact Ollama tag** (`kimi-k2.7-coder` vs `kimi-k2.7-code`) — fallback protects against a miss, but the A/B won't engage if it's wrong.


___

### **PR Type**
Enhancement


___

### **Description**
- Update primary model to `kimi-k2.7-coder`.

- Set `qwen3-coder:30b` as fallback.

- Improve instruction following and reduce false positives.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request"] -- "Primary" --> B["kimi-k2.7-coder"]
  B -- "Fallback" --> C["qwen3-coder:30b"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Update reviewer models for A/B trial</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Update primary model to <code>ollama/kimi-k2.7-coder</code>.<br> <li> Set <code>ollama/qwen3-coder:30b</code> as the fallback.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/187/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

