### PR TITLE
Correct Kimi primary model tag in configuration

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -10,7 +10,7 @@
 # the fast/cheap qwen3-coder:30b as fallback — if the kimi tag is wrong the
 # primary just fails over to :30b, so reviews never hard-break.
 # Tags must match the cluster/cloud's working litellm "ollama/" strings.
-model = "ollama/kimi-k2.7-coder"             # primary (A/B trial — larger, coding-focused)
+model = "ollama/kimi-k27-code:cloud"         # primary (A/B trial — larger, coding-focused)
 fallback_models = ["ollama/qwen3-coder:30b"] # fast/cheap fallback (also the safety net)
 model_reasoning = "ollama/qwen3-coder:30b"   # self-reflection kept on the fast model (cost/latency)
 model_weak = "ollama/gemma4:12b"             # cheap model for easy subtasks


### PR DESCRIPTION
### **User description**
The A/B kimi tag was wrong (`kimi-k2.7-coder`), so the primary silently failed over to `qwen3-coder:30b`. Correct tag per the cluster: `ollama/kimi-k27-code:cloud`. Now the A/B will actually engage on new PRs.


___

### **PR Type**
Bug fix


___

### **Description**
- Update primary model tag for Kimi.

- Fix incorrect identifier to ensure A/B testing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request"] --> B["Primary Model (Kimi)"]
  B -- "Success" --> C["Process Result"]
  B -- "Failure" --> D["Fallback Model (Qwen)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Correct Kimi model identifier in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

- Update primary model tag to `ollama/kimi-k27-code:cloud`.


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/188/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

