### PR TITLE
chore(evals): register tool-desc eval tasks as a GenAI dataset in Godot AI (closes #183)

### DIFF
--- a/evals/dataset_sync.py
+++ b/evals/dataset_sync.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Register tool-desc eval tasks as an MLflow GenAI dataset in "Godot AI" (#183).
+
+`evals/llm_eval_v2.py` defines the tool-description eval tasks declaratively
+(``TASK_PROMPTS`` + ``EXPECTED_FIRST_TOOLS``). This maps them into MLflow GenAI
+dataset records and registers them under the unified "Godot AI" experiment so
+the tool-desc data lives alongside godot-agents' datasets and judges.
+
+Opt-in: a no-op (returns ``None``) when no tracking URI is configured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+
+DEFAULT_EXPERIMENT = "Godot AI"
+
+
+def to_records(
+    task_prompts: dict[str, str],
+    expected_first_tools: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Map tool-desc tasks to GenAI records. Pure and unit-testable.
+
+    Each task -> ``{inputs: {prompt}, expectations: {expected_first_tool}, tags}``.
+    """
+    records: list[dict[str, Any]] = []
+    for task_name, prompt in task_prompts.items():
+        records.append(
+            {
+                "inputs": {"prompt": prompt},
+                "expectations": {"expected_first_tool": expected_first_tools.get(task_name)},
+                "tags": {"task_name": task_name},
+            }
+        )
+    return records
+
+
+def sync_dataset(
+    name: str,
+    *,
+    experiment: str = DEFAULT_EXPERIMENT,
+    tracking_uri: str | None = None,
+    task_prompts: dict[str, str] | None = None,
+    expected_first_tools: dict[str, str] | None = None,
+) -> Any | None:
+    """Register the tool-desc tasks as a GenAI dataset under ``experiment``.
+
+    Idempotent: reuses an existing dataset of the same ``name`` in the experiment.
+    Falls back to ``llm_eval_v2``'s task tables when the dicts aren't supplied.
+    Returns the dataset, or ``None`` when tracking is not configured.
+    """
+    uri = tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
+    if not uri:
+        return None
+
+    if task_prompts is None or expected_first_tools is None:
+        from evals.llm_eval_v2 import EXPECTED_FIRST_TOOLS, TASK_PROMPTS
+
+        task_prompts = task_prompts or TASK_PROMPTS
+        expected_first_tools = expected_first_tools or EXPECTED_FIRST_TOOLS
+
+    import mlflow
+    from mlflow.genai.datasets import create_dataset, search_datasets
+
+    mlflow.set_tracking_uri(uri)
+    exp = mlflow.set_experiment(experiment)
+    records = to_records(task_prompts, expected_first_tools)
+
+    existing = [
+        d
+        for d in search_datasets(experiment_ids=[exp.experiment_id])
+        if getattr(d, "name", "") == name
+    ]
+    dataset = (
+        existing[0] if existing else create_dataset(name=name, experiment_id=[exp.experiment_id])
+    )
+    dataset.merge_records(records)
+    return dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sync tool-desc eval tasks into MLflow (Godot AI)."
+    )
+    parser.add_argument("--name", default="godot-mcp-tool-desc", help="GenAI dataset name")
+    parser.add_argument("--experiment", default=DEFAULT_EXPERIMENT, help="MLflow experiment")
+    parser.add_argument("--tracking-uri", default=None, help="MLflow tracking URI (or use env)")
+    args = parser.parse_args()
+
+    dataset = sync_dataset(args.name, experiment=args.experiment, tracking_uri=args.tracking_uri)
+    if dataset is None:
+        print("No MLFLOW_TRACKING_URI configured; nothing synced.")
+    else:
+        print(f"Synced dataset '{args.name}' into experiment '{args.experiment}'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_eval_dataset_sync.py
+++ b/tests/unit/test_eval_dataset_sync.py
@@ -6,6 +6,7 @@ sqlite-backed and fully offline — no calls to the live MLflow server.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import mlflow
 import pytest
@@ -53,6 +54,38 @@ def test_sync_registers_dataset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
         expected_first_tools=_EXPECTED,
     )
     assert ds is not None
+
+    from mlflow.genai.datasets import search_datasets
+
+    mlflow.set_tracking_uri(uri)
+    exp = mlflow.get_experiment_by_name("td-exp")
+    assert exp is not None
+    found = [
+        d
+        for d in search_datasets(experiment_ids=[exp.experiment_id])
+        if getattr(d, "name", "") == "godot-mcp-tool-desc"
+    ]
+    assert len(found) == 1
+
+
+def test_sync_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-running sync reuses the existing dataset rather than creating a duplicate."""
+    uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+
+    def _sync() -> Any:
+        return sync_dataset(
+            "godot-mcp-tool-desc",
+            experiment="td-exp",
+            tracking_uri=uri,
+            task_prompts=_PROMPTS,
+            expected_first_tools=_EXPECTED,
+        )
+
+    first = _sync()
+    second = _sync()
+    assert first is not None and second is not None
+    # The second run resolved the existing dataset, not a freshly created one.
+    assert second.dataset_id == first.dataset_id
 
     from mlflow.genai.datasets import search_datasets
 

--- a/tests/unit/test_eval_dataset_sync.py
+++ b/tests/unit/test_eval_dataset_sync.py
@@ -1,0 +1,67 @@
+"""Unit tests for syncing tool-desc eval tasks into a GenAI dataset (#183).
+
+sqlite-backed and fully offline — no calls to the live MLflow server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlflow
+import pytest
+
+from evals.dataset_sync import sync_dataset, to_records
+
+_PROMPTS = {
+    "inspect_scene_tree": "Get the full scene tree and report Sprite2D count.",
+    "create_player": "Create a CharacterBody2D named Player.",
+}
+_EXPECTED = {
+    "inspect_scene_tree": "get_scene_tree",
+    "create_player": "create_node",
+}
+
+
+def test_to_records_maps_prompt_and_expected_tool() -> None:
+    records = to_records(_PROMPTS, _EXPECTED)
+    assert len(records) == 2
+    by_task = {r["tags"]["task_name"]: r for r in records}
+
+    r = by_task["inspect_scene_tree"]
+    assert r["inputs"] == {"prompt": "Get the full scene tree and report Sprite2D count."}
+    assert r["expectations"] == {"expected_first_tool": "get_scene_tree"}
+
+    # A task with no expected tool still produces a valid record.
+    extra = to_records({"x": "do x"}, {})
+    assert extra[0]["expectations"]["expected_first_tool"] is None
+
+
+def test_sync_noop_without_tracking_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    assert (
+        sync_dataset("x", task_prompts=_PROMPTS, expected_first_tools=_EXPECTED) is None
+    )
+
+
+def test_sync_registers_dataset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    ds = sync_dataset(
+        "godot-mcp-tool-desc",
+        experiment="td-exp",
+        tracking_uri=uri,
+        task_prompts=_PROMPTS,
+        expected_first_tools=_EXPECTED,
+    )
+    assert ds is not None
+
+    from mlflow.genai.datasets import search_datasets
+
+    mlflow.set_tracking_uri(uri)
+    exp = mlflow.get_experiment_by_name("td-exp")
+    assert exp is not None
+    found = [
+        d
+        for d in search_datasets(experiment_ids=[exp.experiment_id])
+        if getattr(d, "name", "") == "godot-mcp-tool-desc"
+    ]
+    assert len(found) == 1


### PR DESCRIPTION
Rebased successor to #184 (its base `chore/181-evals-mlflow-sdk` was merged via #182 and deleted, which auto-closed #184). Replays only the dataset-sync commit onto `main`.

Qodo reviewed the content on #184 (commit 066ac99); both focus areas were addressed there (fail-fast by design; search scoped to the single target experiment). CI passed on the identical tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)