### PR TITLE
Optimize pre-flight by removing redundant round-trips and cache

### DIFF
--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -26,25 +26,14 @@ T = TypeVar("T", bound=BaseModel)
 # ---------------------------------------------------------------------------
 # Pre-flight validation
 # ---------------------------------------------------------------------------
-
-# Cache: {command_signature -> is_valid}
-_preflight_cache: dict[str, bool] = {}
-
-MUTATION_COMMANDS: set[str] = {
-    "cmd_create_node",
-    "cmd_set_node_property",
-    "cmd_delete_node",
-    "cmd_rename_node",
-    "cmd_attach_script",
-    "cmd_connect_signal",
-    "cmd_write_script",
-    "cmd_patch_script",
-    "cmd_batch_set_property",
-    # Composite/macro mutations (issue #154) must also invalidate the cache.
-    "cmd_compose_node",
-    "cmd_batch_create_nodes",
-    "cmd_apply_node_edits",
-}
+#
+# Pre-flight does **pure-string** parameter checks only. It deliberately does NOT
+# round-trip the bridge to confirm a node/parent exists (#166): every mutating MCP
+# tool already enforces that via require_node_exists / require_active_scene
+# (mcp_server/safety.py), and the LLM eval bypasses route() entirely — so a
+# preflight existence probe was a wasted ~70ms round-trip per mutation with no
+# unique value. Likewise there is no module-level cache (the old one was global
+# mutable state that bled across sessions and self-cleared on every mutation).
 
 # Script-writing mutations; read-only cmd_read_script is excluded so it reaches
 # the addon for its own envelope.
@@ -53,52 +42,6 @@ _SCRIPT_MUTATIONS: set[str] = {
     "cmd_write_script",
     "cmd_patch_script",
 }
-
-# Returned on a cache hit for a previously-failed signature.
-_CACHED_FAILURE: dict[str, Any] = {
-    "ok": False,
-    "error": "PARAM_ERROR",
-    "hint": "Parameter validation failed (cached).",
-}
-
-
-def _invalidate_preflight_cache() -> None:
-    """Clear the pre-flight cache after any mutation."""
-    _preflight_cache.clear()
-
-
-async def _validate_node_path(
-    bridge: Bridge, command: str, params: dict[str, Any]
-) -> dict[str, Any] | None:
-    """Fail a *mutation* targeting a node that doesn't exist.
-
-    Read-only inspection commands (e.g. cmd_get_node_properties) and runtime
-    commands (e.g. cmd_monitor, cmd_assert_node_state) are skipped so the addon
-    returns its own RESOURCE_NOT_FOUND/assertion envelope — pre-empting them here
-    both masks those structured errors and (for get_node_properties) recurses on
-    itself. cmd_create_node is skipped too (the target doesn't exist yet).
-    """
-    node_path = params.get("node_path", "")
-    if not (node_path and command in MUTATION_COMMANDS and command != "cmd_create_node"):
-        return None
-    try:
-        resp = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
-    except Exception:
-        return None  # Bridge error; fall through to addon validation
-    # Only a genuine "missing node" fails preflight. Other errors (e.g.
-    # PRECONDITION_FAILED for no active scene) pass through so the addon returns
-    # its own structured envelope instead of a misleading "node not found".
-    if not resp.ok and resp.error == "RESOURCE_NOT_FOUND":
-        return {
-            "ok": False,
-            "error": "PARAM_ERROR",
-            "hint": (
-                f"Node '{node_path}' not found in scene. "
-                "Use get_scene_tree to discover valid paths."
-            ),
-            "required": "node_path",
-        }
-    return None
 
 
 async def _validate_script_path(
@@ -120,30 +63,9 @@ async def _validate_script_path(
     return None
 
 
-async def _validate_parent_path(
-    bridge: Bridge, command: str, params: dict[str, Any]
-) -> dict[str, Any] | None:
-    """Fail cmd_create_node when its parent node doesn't exist."""
-    parent_path = params.get("parent_path", "")
-    if not (parent_path and command == "cmd_create_node" and parent_path not in {".", "/", ""}):
-        return None
-    try:
-        resp = await bridge.send("cmd_get_node_properties", {"node_path": parent_path})
-    except Exception:
-        return None
-    if not resp.ok:
-        return {
-            "ok": False,
-            "error": "PARAM_ERROR",
-            "hint": f"Parent '{parent_path}' not found. Use '.' for scene root.",
-            "required": "parent_path",
-        }
-    return None
-
-
 # Each validator returns a PARAM_ERROR dict on failure, else None. Property
 # names are deliberately not validated server-side — the addon has better context.
-_VALIDATORS = (_validate_node_path, _validate_script_path, _validate_parent_path)
+_VALIDATORS = (_validate_script_path,)
 
 
 async def _preflight_validate(
@@ -153,20 +75,12 @@ async def _preflight_validate(
 
     Returns {"ok": True} if validation passes or no rules apply.
     Returns {"ok": False, "error": "...", "hint": "...", "required": "..."} on the
-    first failure. Results are cached by command + sorted params.
+    first failure. Pure-string checks only — no bridge round-trips, no cache (#166).
     """
-    cache_key = f"{command}:{sorted(params.items())}"
-    cached = _preflight_cache.get(cache_key)
-    if cached is not None:
-        return {"ok": True} if cached else dict(_CACHED_FAILURE)
-
     for validate in _VALIDATORS:
         failure = await validate(bridge, command, params)
         if failure is not None:
-            _preflight_cache[cache_key] = False
             return failure
-
-    _preflight_cache[cache_key] = True
     return {"ok": True}
 
 
@@ -209,10 +123,6 @@ async def route(
         raise ToolError(detail)
 
     response = await bridge.send(command, params or {})
-
-    # Invalidate cache on mutations (scene state may have changed)
-    if command in MUTATION_COMMANDS:
-        _invalidate_preflight_cache()
 
     if not response.ok:
         detail = f"{response.error}: {response.hint}" if response.hint else str(response.error)

--- a/tests/unit/test_preflight_validate.py
+++ b/tests/unit/test_preflight_validate.py
@@ -1,55 +1,38 @@
-"""Unit tests for the split pre-flight validators (issue #176).
+"""Unit tests for pre-flight validation (issues #176, #166).
 
-`_preflight_validate` was a 93-line linear wall; it's now an orchestrator over
-per-rule validators. These pin each rule plus the orchestrator's caching and
-short-circuit behavior.
+Pre-flight is now **pure-string checks only**: node/parent existence is enforced
+by ``require_*`` preconditions in the tool layer (``mcp_server/safety.py``), not
+round-tripped here. Removing that round-trip — and the module-level cache that
+backed it — is #166. These pin the surviving script-path rule and assert
+preflight neither calls the bridge for existence nor keeps global state.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
-from typing import Any
-
-import pytest
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import BridgeConfig
 from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
-from mcp_server.tools._route import (
-    _invalidate_preflight_cache,
-    _preflight_cache,
-    _preflight_validate,
-    _validate_node_path,
-    _validate_parent_path,
-    _validate_script_path,
-)
+from mcp_server.tools._route import _preflight_validate, _validate_script_path
 from tests.fakes import FakeAddonConnection, Responder, connector_for, ping_responder
 
 
-def _node_responder(*, exists: bool) -> Responder:
+def _counting_responder() -> tuple[Responder, list[str]]:
+    """A responder that records every command it sees (for round-trip assertions)."""
+    seen: list[str] = []
+
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
-        if cmd.command == "cmd_get_node_properties":
-            if exists:
-                return ResponseEnvelope.success(cmd.id, {"node_path": "X"})
-            return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "no node")
+        seen.append(cmd.command)
         return ping_responder(cmd)
-    return responder
+
+    return responder, seen
 
 
 async def _bridge(responder: Responder = ping_responder) -> Bridge:
     bridge = Bridge(BridgeConfig(), connector=connector_for(FakeAddonConnection(responder)))
     await bridge.connect()
     return bridge
-
-
-@pytest.fixture(autouse=True)
-def _clear_cache() -> Iterator[None]:
-    # Clear before AND after: _preflight_cache is global, so leftover entries
-    # would make other test modules order-dependent (cache hits skip validation).
-    _invalidate_preflight_cache()
-    yield
-    _invalidate_preflight_cache()
 
 
 def test_script_path_rejects_non_res_path() -> None:
@@ -63,47 +46,44 @@ def test_script_path_rejects_non_res_path() -> None:
         skip = await _validate_script_path(bridge, "cmd_read_script", {"script_path": "x.gd"})
         assert skip is None
         await bridge.close()
+
     asyncio.run(go())
 
 
-def test_node_path_missing_node_fails_only_for_mutations() -> None:
+def test_preflight_rejects_bad_script_path() -> None:
     async def go() -> None:
-        miss = await _bridge(_node_responder(exists=False))
-        fail = await _validate_node_path(miss, "cmd_set_node_property", {"node_path": "Ghost"})
-        assert fail is not None and fail["required"] == "node_path"
-        # read-only command skips (addon returns its own envelope)
-        skip = await _validate_node_path(miss, "cmd_get_node_properties", {"node_path": "Ghost"})
-        assert skip is None
-        await miss.close()
-        present = await _bridge(_node_responder(exists=True))
-        ok = await _validate_node_path(present, "cmd_set_node_property", {"node_path": "Player"})
-        assert ok is None
-        await present.close()
-    asyncio.run(go())
-
-
-def test_parent_path_missing_fails_dot_skips() -> None:
-    async def go() -> None:
-        miss = await _bridge(_node_responder(exists=False))
-        fail = await _validate_parent_path(miss, "cmd_create_node", {"parent_path": "Ghost"})
-        assert fail is not None and fail["required"] == "parent_path"
-        ok = await _validate_parent_path(miss, "cmd_create_node", {"parent_path": "."})
-        assert ok is None
-        await miss.close()
-    asyncio.run(go())
-
-
-def test_preflight_caches_and_short_circuits() -> None:
-    async def go() -> None:
-        bridge = await _bridge(_node_responder(exists=False))
-        params: dict[str, Any] = {"script_path": "bad.gd"}
-        result = await _preflight_validate(bridge, "cmd_write_script", params)
+        bridge = await _bridge()
+        result = await _preflight_validate(bridge, "cmd_write_script", {"script_path": "bad.gd"})
         assert result["ok"] is False and result["required"] == "script_path"
-        # failure cached
-        assert _preflight_cache[f"cmd_write_script:{sorted(params.items())}"] is False
-        # a clean command caches True
-        ok = await _preflight_validate(bridge, "cmd_ping", {})
-        assert ok == {"ok": True}
-        assert _preflight_cache["cmd_ping:[]"] is True
         await bridge.close()
+
     asyncio.run(go())
+
+
+def test_preflight_does_not_round_trip_node_existence() -> None:
+    """#166: a mutation targeting a node must NOT round-trip cmd_get_node_properties
+    in preflight — require_node_exists in the tool layer owns existence checks."""
+
+    async def go() -> None:
+        responder, seen = _counting_responder()
+        bridge = await _bridge(responder)
+        seen.clear()  # ignore the connect/ping handshake
+        result = await _preflight_validate(bridge, "cmd_set_node_property", {"node_path": "Ghost"})
+        assert result == {"ok": True}
+        assert "cmd_get_node_properties" not in seen
+        # cmd_create_node with a parent must likewise not probe the parent.
+        result = await _preflight_validate(bridge, "cmd_create_node", {"parent_path": "Ghost"})
+        assert result == {"ok": True}
+        assert "cmd_get_node_properties" not in seen
+        await bridge.close()
+
+    asyncio.run(go())
+
+
+def test_no_module_level_preflight_cache() -> None:
+    """#166: the module-level mutable cache (an architecture violation) is removed."""
+    import mcp_server.tools._route as route_mod
+
+    assert not hasattr(route_mod, "_preflight_cache")
+    assert not hasattr(route_mod, "_invalidate_preflight_cache")
+    assert not hasattr(route_mod, "MUTATION_COMMANDS")


### PR DESCRIPTION
### **User description**
## Summary
Removes the redundant preflight node-existence round-trip and the module-level cache that backed it (#166).

Every mutating MCP tool already enforces node/parent existence via `require_node_exists` / `require_active_scene` (`mcp_server/safety.py`), and the LLM eval bypasses `route()` entirely — so the preflight `cmd_get_node_properties` round-trip in `_validate_node_path` / `_validate_parent_path` was a wasted ~70ms per mutation with no unique value. Pre-flight is now pure-string checks only (the `res://` `script_path` rule).

`_preflight_cache` is also removed: module-level mutable state (an architecture-rule violation that bleeds across sessions) that self-cleared on every mutation.

## Acceptance criteria
- [x] Drop round-tripping `node_path`/`parent_path` existence checks; keep cheap pure-string checks
- [x] Remove `_preflight_cache` (and now-unused `MUTATION_COMMANDS`)
- [x] Contract/precondition tests assert missing-node errors still surface (via `require_*`)

## Test plan
- `test_preflight_validate.py`: script-path still rejected; preflight makes **no** existence round-trip; `_preflight_cache`/`_invalidate_preflight_cache`/`MUTATION_COMMANDS` globals are gone.
- Full suite: ruff ✓, mypy ✓ (199 files), 484 passed, zero-skip ✓. (4 live-editor e2e tests TIMEOUT locally with no bridge up; pre-existing, skip in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Remove redundant pre-flight node existence round-trips.

- Eliminate module-level mutable state and cache.

- Simplify validation to pure-string checks only.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request"] --> B["Pre-flight (String Check)"]
  B --> C["Bridge Execution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_route.py</strong><dd><code>Simplify pre-flight validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/_route.py

<ul><li>Remove <code>_validate_node_path</code> and <code>_validate_parent_path</code>.<br> <li> Remove <code>_preflight_cache</code> and <code>MUTATION_COMMANDS</code>.<br> <li> Simplify <code>_preflight_validate</code> to use string checks only.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/190/files#diff-01da951849455fe4b33f27e100cc270a20348263d7d674dbab63428dd369baf4">+10/-100</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_preflight_validate.py</strong><dd><code>Update pre-flight validation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_preflight_validate.py

<ul><li>Update tests for removed features.<br> <li> Verify no round-trips in pre-flight.<br> <li> Assert removal of global state.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/190/files#diff-4c1a6d49102ddcc10872903ca8e20d871fe94b34a08e05148d0b1290a1258255">+44/-64</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

