### PR TITLE
Implement batch command execution to improve throughput

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -585,6 +585,7 @@ support `dry_run`; `save=True` also saves the scene (a file write after the undo
 | `compose_node` | `parent_path, node_type, node_name, properties?, script_path?, children?, save=False, dry_run=False` | `ComposeNodeResult { node_path, created, children[], script_attached, properties_set[], saved }` | `mutating` |
 | `batch_create_nodes` | `parent_path, node_type, names[], properties?, save=False, dry_run=False` | `BatchCreateNodesResult { created[], count, saved }` | `mutating` |
 | `apply_node_edits` | `edits[] ({node_path, properties}), save=False, dry_run=False` | `ApplyNodeEditsResult { edited[], skipped[], count, saved }` | `mutating` |
+| `run_commands` | `commands[] ({command, params}), stop_on_error=True, dry_run=False` | `RunCommandsResult { results[] ({command, ok, result?, error?, hint?}), ok_all, count, planned[], dry_run }` | `mutating` |
 
 Every result model also carries `dry_run` (true on a preview), as for all `dry_run`-aware tools.
 
@@ -594,6 +595,14 @@ Every result model also carries `dry_run` (true on a preview), as for all `dry_r
 - `batch_create_nodes` creates many same-typed nodes (each with the same `properties`).
 - `apply_node_edits` sets many properties across many existing nodes; a node missing a
   property is reported under `skipped` (the rest still apply).
+- `run_commands` (issue #167) is a **generic** batch envelope: it runs an arbitrary
+  sequence of bridge commands in **one** round-trip (the addon executes them in a single
+  `_process` frame), the main throughput lever for scripted harnesses since the editor
+  drains commands serially. `command` may be the bare tool name (`set_node_property`) or
+  the addon form (`cmd_set_node_property`). Each sub-mutation still wraps its own
+  `UndoRedo` action; order is preserved. `ok_all` is true only if every sub-command
+  succeeded — the batch envelope itself is a success (it ran); inspect `results[].ok`.
+  `stop_on_error=True` (default) halts at the first failure; `False` runs them all.
 - These are game-agnostic, generic Godot operations — no game vocabulary (see the
   game-agnostic scope rule in `CLAUDE.md`).
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -95,6 +95,9 @@ func _init() -> void:
 	# tool drops the cmd_ prefix); see docs/architecture.md.
 	_handlers["cmd_ping"] = _cmd_ping
 	_handlers["cmd_get_project_info"] = _cmd_get_project_info
+	# Meta-command: execute a batch of sub-commands in one frame (issue #167).
+	# Lives on the router (not a domain handler) because it re-dispatches via _route.
+	_handlers["cmd_run_commands"] = _cmd_run_commands
 	# Instances are promoted to member variables so RefCounted objects survive
 	# beyond _init(); see discussion in git history.
 	_scene_inspect = MCPSceneInspectHandlers.new(self)
@@ -187,6 +190,36 @@ func _route(envelope: Dictionary) -> Dictionary:
 
 func _cmd_ping(_params: Dictionary) -> Dictionary:
 	return _ok({"pong": true})
+
+
+## Execute a batch of sub-commands in a single frame and return one response body
+## per command (issue #167). The editor drains commands serially (~one frame each),
+## so collapsing N round-trips into one is the main throughput lever for scripted
+## harnesses. Each sub-command re-enters _route, so its own handler still registers
+## UndoRedo. With stop_on_error (default true) the batch halts at the first failure.
+## The outer envelope is always ok:true (the batch ran); inspect per-command "ok".
+func _cmd_run_commands(params: Dictionary) -> Dictionary:
+	var raw: Variant = params.get("commands", [])
+	if typeof(raw) != TYPE_ARRAY:
+		return _fail("VALIDATION_ERROR", "'commands' must be an array of {command, params}.")
+	var stop_on_error := bool(params.get("stop_on_error", true))
+	var results: Array = []
+	var ok_all := true
+	for entry in (raw as Array):
+		if typeof(entry) != TYPE_DICTIONARY:
+			results.append(_fail("VALIDATION_ERROR", "Each command must be a {command, params} object."))
+			ok_all = false
+			if stop_on_error:
+				break
+			continue
+		var sub: Dictionary = _route(entry as Dictionary)
+		sub["command"] = str((entry as Dictionary).get("command", ""))
+		results.append(sub)
+		if not bool(sub.get("ok", false)):
+			ok_all = false
+			if stop_on_error:
+				break
+	return _ok({"results": results, "ok_all": ok_all, "count": results.size()})
 
 
 func _cmd_get_project_info(_params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -207,13 +207,25 @@ func _cmd_run_commands(params: Dictionary) -> Dictionary:
 	var ok_all := true
 	for entry in (raw as Array):
 		if typeof(entry) != TYPE_DICTIONARY:
-			results.append(_fail("VALIDATION_ERROR", "Each command must be a {command, params} object."))
+			# Every sub-result carries a "command" key so the server's SubCommandResult
+			# (which requires it) validates even for a malformed entry.
+			var bad := _fail("VALIDATION_ERROR", "Each command must be a {command, params} object.")
+			bad["command"] = ""
+			results.append(bad)
 			ok_all = false
 			if stop_on_error:
 				break
 			continue
-		var sub: Dictionary = _route(entry as Dictionary)
-		sub["command"] = str((entry as Dictionary).get("command", ""))
+		var entry_dict := entry as Dictionary
+		var sub_command := str(entry_dict.get("command", ""))
+		# Refuse to nest run_commands in itself: re-dispatching it would recurse
+		# _cmd_run_commands -> _route -> _cmd_run_commands and crash the editor.
+		var sub: Dictionary
+		if sub_command == "cmd_run_commands" or sub_command == "run_commands":
+			sub = _fail("VALIDATION_ERROR", "run_commands cannot be nested inside run_commands.")
+		else:
+			sub = _route(entry_dict)
+		sub["command"] = sub_command
 		results.append(sub)
 		if not bool(sub.get("ok", false)):
 			ok_all = false

--- a/godot/tests/run_commands_smoke.gd
+++ b/godot/tests/run_commands_smoke.gd
@@ -1,0 +1,79 @@
+@tool
+extends SceneTree
+## Headless behavior test for the cmd_run_commands batch meta-command (issue #167).
+##
+## Run via: godot --headless --path godot/ --script res://tests/run_commands_smoke.gd
+## Exercises the router's batch dispatch without EditorInterface: editor-free
+## sub-commands (cmd_ping) run in order; a nested run_commands is rejected (no
+## recursion/crash); and a malformed entry yields a structured per-command error
+## that still carries a "command" field (so the server's SubCommandResult validates).
+
+const Router := preload("res://addons/godot_mcp/command_router.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+	var router := Router.new()
+
+	# A batch of editor-free sub-commands runs in one call, in order.
+	var ok_batch: Dictionary = router.handle({
+		"id": "1",
+		"command": "cmd_run_commands",
+		"params": {"commands": [
+			{"command": "cmd_ping", "params": {}},
+			{"command": "cmd_ping", "params": {}},
+		]},
+	})
+	var r: Dictionary = ok_batch.get("result", {})
+	_eq(failures, "batch.ok", ok_batch.get("ok"), true)
+	_eq(failures, "batch.ok_all", r.get("ok_all"), true)
+	_eq(failures, "batch.count", r.get("count"), 2)
+	var results: Array = r.get("results", [])
+	if results.size() == 2:
+		_eq(failures, "batch.cmd0", results[0].get("command"), "cmd_ping")
+		_eq(failures, "batch.sub_ok", results[0].get("ok"), true)
+	else:
+		failures.append("batch results size wrong: %d" % results.size())
+
+	# Nesting is rejected per-command — no recursion into _cmd_run_commands.
+	var nested: Dictionary = router.handle({
+		"id": "2",
+		"command": "cmd_run_commands",
+		"params": {"commands": [
+			{"command": "cmd_run_commands", "params": {"commands": []}},
+		], "stop_on_error": false},
+	})
+	var nr: Array = nested.get("result", {}).get("results", [])
+	_eq(failures, "nested.ok_all", nested.get("result", {}).get("ok_all"), false)
+	if nr.size() == 1:
+		_eq(failures, "nested.err", nr[0].get("error"), "VALIDATION_ERROR")
+		_eq(failures, "nested.cmd", nr[0].get("command"), "cmd_run_commands")
+	else:
+		failures.append("nested results size wrong: %d" % nr.size())
+
+	# A non-dict entry yields a structured per-command error carrying "command".
+	var bad: Dictionary = router.handle({
+		"id": "3",
+		"command": "cmd_run_commands",
+		"params": {"commands": ["not-a-dict"], "stop_on_error": false},
+	})
+	var br: Array = bad.get("result", {}).get("results", [])
+	if br.size() == 1:
+		_eq(failures, "bad.err", br[0].get("error"), "VALIDATION_ERROR")
+		_eq(failures, "bad.has_command", br[0].has("command"), true)
+	else:
+		failures.append("bad results size wrong: %d" % br.size())
+
+	if failures.is_empty():
+		print("RUN_COMMANDS_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("RUN_COMMANDS_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/run_commands.py
+++ b/mcp_server/models/run_commands.py
@@ -1,0 +1,44 @@
+"""Typed result models for the ``run_commands`` batch envelope (issue #167).
+
+The addon executes a list of sub-commands in a single ``_process`` frame and
+returns one response envelope per sub-command. Collapsing N round-trips into one
+is the only real throughput lever for scripted harnesses, since the editor
+drains commands serially on its main thread (~one frame of latency each).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class SubCommandResult(BaseModel):
+    """One sub-command's outcome within a ``run_commands`` batch.
+
+    Mirrors the response envelope shape: ``ok`` plus either ``result`` (success)
+    or ``error``/``hint`` (failure). ``command`` echoes the addon command so the
+    caller can correlate results even when ``stop_on_error`` truncates the list.
+    """
+
+    command: str
+    ok: bool
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    hint: str | None = None
+
+
+class RunCommandsResult(BaseModel):
+    """Result of a ``run_commands`` batch executed in one editor frame.
+
+    ``ok_all`` is True only when every sub-command succeeded; the batch envelope
+    itself is still a success (the commands ran) even if individual sub-commands
+    failed — inspect ``results`` for per-command status. ``dry_run`` returns the
+    ``planned`` command names without executing anything.
+    """
+
+    results: list[SubCommandResult] = []
+    ok_all: bool
+    count: int
+    planned: list[str] = []
+    dry_run: bool = False

--- a/mcp_server/tools/composite.py
+++ b/mcp_server/tools/composite.py
@@ -22,15 +22,23 @@ from mcp_server.models.composite import (
     BatchCreateNodesResult,
     ComposeNodeResult,
 )
+from mcp_server.models.run_commands import RunCommandsResult
 from mcp_server.safety import (
     MUTATING,
     enforce_preconditions,
     require_active_scene,
+    require_bridge_connected,
     require_node_exists,
 )
 from mcp_server.tools._route import run_or_preview
 
 COMPOSITE = {COMPOSITE_TAG}
+
+
+def _normalize_command(command: str) -> str:
+    """Accept either the addon command (``cmd_set_node_property``) or the bare
+    tool name (``set_node_property``); the addon dispatches on the ``cmd_`` form."""
+    return command if command.startswith("cmd_") else f"cmd_{command}"
 
 
 def _child_to_addon(child: dict[str, Any]) -> dict[str, Any]:
@@ -137,4 +145,44 @@ def register_composite(mcp: FastMCP, bridge: Bridge) -> None:
         preview = {"edited": [], "skipped": [], "count": 0, "saved": False}
         return await run_or_preview(
             dry_run, ApplyNodeEditsResult, preview, bridge, "cmd_apply_node_edits", params
+        )
+
+    @mcp.tool(meta=MUTATING, tags=COMPOSITE)
+    @enforce_preconditions
+    async def run_commands(
+        commands: list[dict[str, Any]],
+        stop_on_error: bool = True,
+        dry_run: bool = False,
+    ) -> RunCommandsResult:
+        """Execute a sequence of bridge commands in ONE round-trip (the addon runs
+        them in a single editor frame). The editor drains commands serially —
+        ~one frame of latency each — so batching N independent commands here is
+        the main throughput lever for scripted harnesses.
+
+        ``commands`` is a list of ``{command, params}``; ``command`` may be the
+        bare tool name (``set_node_property``) or the addon form
+        (``cmd_set_node_property``). Each sub-mutation still wraps its own
+        UndoRedo action. Returns one envelope per command under ``results``;
+        ``ok_all`` is True only if every command succeeded. With
+        ``stop_on_error=True`` (default) the batch halts at the first failure;
+        set it False to run them all. Read-only and mutating commands may be
+        mixed, but order is preserved — do not rely on it for unordered writes.
+        """
+        require_bridge_connected(bridge)
+        normalized = [
+            {
+                "command": _normalize_command(str(c.get("command", ""))),
+                "params": c.get("params", {}),
+            }
+            for c in commands
+        ]
+        params: dict[str, Any] = {"commands": normalized, "stop_on_error": stop_on_error}
+        preview = {
+            "results": [],
+            "ok_all": True,
+            "count": len(normalized),
+            "planned": [c["command"] for c in normalized],
+        }
+        return await run_or_preview(
+            dry_run, RunCommandsResult, preview, bridge, "cmd_run_commands", params
         )

--- a/mcp_server/tools/composite.py
+++ b/mcp_server/tools/composite.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import COMPOSITE_TAG
@@ -176,6 +177,13 @@ def register_composite(mcp: FastMCP, bridge: Bridge) -> None:
             }
             for c in commands
         ]
+        # Reject nesting up front: a run_commands inside run_commands would recurse
+        # the editor's dispatch and crash it (the addon rejects it too, defensively).
+        if any(c["command"] == "cmd_run_commands" for c in normalized):
+            raise ToolError(
+                "PARAM_ERROR: run_commands cannot be nested inside run_commands. "
+                "[required=commands]"
+            )
         params: dict[str, Any] = {"commands": normalized, "stop_on_error": stop_on_error}
         preview = {
             "results": [],

--- a/tests/contract/test_run_commands.py
+++ b/tests/contract/test_run_commands.py
@@ -149,3 +149,19 @@ async def test_run_commands_dry_run_sends_nothing() -> None:
     assert data["planned"] == ["cmd_create_node"]
     assert data["count"] == 1
     assert "cmd_run_commands" not in _commands(conn)
+
+
+async def test_run_commands_rejects_nesting() -> None:
+    # #167 review: a nested run_commands would recurse the editor dispatch and crash
+    # it. The server rejects the batch up front (either bare or cmd_ form), sending nothing.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "run_commands",
+            {"commands": [{"command": "run_commands", "params": {"commands": []}}]},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "nested" in str(result.content).lower()
+    assert "cmd_run_commands" not in _commands(conn)  # nothing sent

--- a/tests/contract/test_run_commands.py
+++ b/tests/contract/test_run_commands.py
@@ -1,0 +1,151 @@
+"""Contract tests for the run_commands batch envelope (issue #167).
+
+A scripted harness collapses N independent bridge round-trips into one: the addon
+executes the sub-commands in a single frame and returns one envelope per command.
+These pin the typed I/O, the gated/mutating safety class, stop-on-error vs
+continue, and that ``dry_run`` previews without sending the batch — driven by a
+fake addon peer, no live editor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_run_commands(p: dict[str, Any]) -> dict[str, Any]:
+    """Simulate the addon executing each sub-command in one frame, in order."""
+    results: list[dict[str, Any]] = []
+    ok_all = True
+    for entry in p.get("commands", []):
+        cmd = entry.get("command", "")
+        is_ghost = entry.get("params", {}).get("node_path") == "Ghost"
+        if cmd == "cmd_set_node_property" and is_ghost:
+            results.append(
+                {"command": cmd, "ok": False, "error": "RESOURCE_NOT_FOUND", "hint": "No node."}
+            )
+            ok_all = False
+            if p.get("stop_on_error", True):
+                break
+        else:
+            results.append({"command": cmd, "ok": True, "result": {"echo": cmd}})
+    return {"results": results, "ok_all": ok_all, "count": len(results)}
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    if cmd.command == "cmd_run_commands":
+        return ResponseEnvelope.success(cmd.id, _fake_run_commands(cmd.params))
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+def _commands(conn: FakeAddonConnection) -> list[str]:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+
+
+async def test_run_commands_is_gated_mutating() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        before = {t.name for t in await client.list_tools()}
+        assert "run_commands" not in before, "run_commands must be gated off by default"
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["run_commands"].meta["safety_class"] == "mutating"
+
+
+async def test_run_commands_executes_batch_in_one_round_trip() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "run_commands",
+            {
+                "commands": [
+                    {"command": "cmd_create_node", "params": {"parent_path": ".", "name": "A"}},
+                    {"command": "set_node_property", "params": {"node_path": "A"}},
+                ]
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is True
+    assert data["count"] == 2
+    # bare names are normalized to the addon cmd_* form
+    assert [r["command"] for r in data["results"]] == ["cmd_create_node", "cmd_set_node_property"]
+    # N sub-commands collapse into ONE bridge round-trip
+    assert _commands(conn).count("cmd_run_commands") == 1
+    assert "cmd_create_node" not in _commands(conn)  # not sent individually
+
+
+async def test_run_commands_stop_on_error_truncates() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "run_commands",
+            {
+                "commands": [
+                    {"command": "cmd_set_node_property", "params": {"node_path": "Ghost"}},
+                    {"command": "cmd_set_node_property", "params": {"node_path": "A"}},
+                ],
+                "stop_on_error": True,
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is False
+    assert data["count"] == 1  # stopped after the first failure
+    assert data["results"][0]["error"] == "RESOURCE_NOT_FOUND"
+
+
+async def test_run_commands_continue_on_error_runs_all() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "run_commands",
+            {
+                "commands": [
+                    {"command": "cmd_set_node_property", "params": {"node_path": "Ghost"}},
+                    {"command": "cmd_set_node_property", "params": {"node_path": "A"}},
+                ],
+                "stop_on_error": False,
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is False
+    assert data["count"] == 2  # both ran despite the first failing
+    assert data["results"][1]["ok"] is True
+
+
+async def test_run_commands_dry_run_sends_nothing() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "run_commands",
+            {
+                "commands": [
+                    {"command": "cmd_create_node", "params": {"parent_path": ".", "name": "A"}}
+                ],
+                "dry_run": True,
+            },
+        )
+    data = result.structured_content
+    assert data["dry_run"] is True
+    assert data["planned"] == ["cmd_create_node"]
+    assert data["count"] == 1
+    assert "cmd_run_commands" not in _commands(conn)


### PR DESCRIPTION
### **User description**
## Summary
A generic batch envelope: run an arbitrary sequence of bridge commands in **one** round-trip. The editor drains commands serially on its main thread (~one frame each), so collapsing N round-trips into one is the main throughput lever for scripted harnesses (#167).

**Addon** — `cmd_run_commands({commands:[{command,params}], stop_on_error})` re-dispatches each sub-command through the router's `_route` in a single `_process` frame and returns one response body per command. Each sub-mutation still registers its own `UndoRedo`. The outer envelope is always `ok:true` (the batch ran); `ok_all` reflects whether every sub-command succeeded.

**Server** — gated `run_commands` tool (`composite` toolset, `mutating`, `dry_run` preview) returning a typed `RunCommandsResult`. `command` accepts the bare tool name or the `cmd_*` form (normalized).

## Acceptance criteria
- [x] Addon `cmd_run_commands` executes a list in one frame, returns an array of result envelopes, optional stop-on-first-error
- [x] Each sub-mutation wraps UndoRedo (preserved — sub-commands re-enter their normal handlers)
- [x] Server `run_commands` tool with a typed result model

## Test plan
- `tests/contract/test_run_commands.py`: gated/mutating; **N→1** round-trip (one `cmd_run_commands` sent, sub-commands not sent individually); stop-on-error truncates vs continue runs all; `dry_run` sends nothing and returns `planned`.
- Preflight: ruff ✓, mypy ✓ (201 files), 466 passed (non-e2e), zero-skip ✓. GDScript parse-checked under Godot 4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `run_commands` to batch multiple commands.

- Support `stop_on_error` and `dry_run` in batches.

- Reduce round-trip count for better performance.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client"] -- "batch of commands" --> B["Server: run_commands"]
  B -- "1 round-trip" --> C["Addon: cmd_run_commands"]
  C -- "process all" --> D["Sub-commands"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_commands.py</strong><dd><code>Define Pydantic models for batch results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/run_commands.py

<ul><li>Define <code>SubCommandResult</code> and <code>RunCommandsResult</code>.<br> <li> Support batch status tracking.<br> <li> Include <code>dry_run</code> and <code>count</code> fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/191/files#diff-d4505401047e0081646a06d04611166ac1f3afabafd5c13c95b36f092de731e4">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>composite.py</strong><dd><code>Implement run_commands tool and normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/composite.py

<ul><li>Add <code>run_commands</code> tool to the suite.<br> <li> Implement command normalization logic.<br> <li> Handle <code>stop_on_error</code> and <code>dry_run</code> flags.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/191/files#diff-3134dd429903ee6dbd7fc4c698fb4befeace957e783fb15bb65326863aaa6e08">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>command_router.gd</strong><dd><code>Add addon handler for batch commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/command_router.gd

<ul><li>Register <code>cmd_run_commands</code> in the router.<br> <li> Process batch commands in one frame.<br> <li> Map results to individual items.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/191/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_run_commands.py</strong><dd><code>Add contract tests for batching features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_run_commands.py

<ul><li>Add contract tests for batching.<br> <li> Verify <code>stop_on_error</code> behavior.<br> <li> Validate <code>dry_run</code> functionality.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/191/files#diff-b86dcc948fa92d8e41be01eaaf90e905dc5fc4e09a4c564b9ae2ee9ca2a52139">+151/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Update documentation for the new tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Update tool contracts for <code>run_commands</code>.<br> <li> Describe batching behavior and parameters.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/191/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

