### PR TITLE
feat(inspection): lightweight get_scene_tree mode (closes #168)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -161,12 +161,14 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 |------|--------|---------|----------------|
 | `get_project_info` | — | `ProjectInfo { name, godot_version, main_scene?, autoloads, input_actions }` | `cmd_get_project_info` |
 | `get_active_scene` | — | `ActiveScene { is_open, path?, name? }` | `cmd_get_active_scene` |
-| `get_scene_tree` | `max_depth: int = -1` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
+| `get_scene_tree` | `max_depth: int = -1, lightweight: bool = False` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
 | `get_selected_node` | — | `SelectedNode { selected: NodeInfo? }` | `cmd_get_selected_node` |
 | `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
 | `get_node_property_list` | `node_path: str` | `NodePropertyList { node_path, type, properties[] }` | `cmd_get_node_property_list` |
 
-`SceneNode = { name, type, script?, children: [SceneNode] }`. `get_node_properties` errors
+`SceneNode = { name, type, script?, children: [SceneNode] }`. `lightweight=True` (#168) drops
+`script` → `{ name, type, children }` for a smaller discovery payload (pair with `max_depth`).
+`get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
 `get_node_property_list` returns every valid property name for a node (useful before calling
 `set_node_property`).

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -37,7 +37,8 @@ func _cmd_get_scene_tree(params: Dictionary) -> Dictionary:
 	if root == null:
 		return _router._ok({"tree": null})
 	var max_depth := int(params.get("max_depth", -1))
-	return _router._ok({"tree": Inspect.serialize_tree(root, max_depth)})
+	var lightweight := bool(params.get("lightweight", false))
+	return _router._ok({"tree": Inspect.serialize_tree(root, max_depth, lightweight)})
 
 
 func _cmd_get_selected_node(_params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -12,17 +12,20 @@ const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
 
 ## Recursive { name, type, script, children } for a subtree.
 ## max_depth < 0 is unlimited; max_depth == 0 returns the node with no children.
-static func serialize_tree(node: Node, max_depth: int = -1) -> Dictionary:
+## lightweight (#168) drops the `script` field (skips the per-node get_script call)
+## for a smaller discovery payload — { name, type, children } only.
+static func serialize_tree(node: Node, max_depth: int = -1, lightweight: bool = false) -> Dictionary:
 	var data: Dictionary = {
 		"name": String(node.name),
 		"type": node.get_class(),
-		"script": script_path(node),
 	}
+	if not lightweight:
+		data["script"] = script_path(node)
 	var children: Array = []
 	if max_depth != 0:
 		var child_depth: int = (max_depth - 1) if max_depth > 0 else -1
 		for child in node.get_children():
-			children.append(serialize_tree(child, child_depth))
+			children.append(serialize_tree(child, child_depth, lightweight))
 	data["children"] = children
 	return data
 

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -108,6 +108,15 @@ func _test_serialize_tree(failures: Array[String]) -> void:
 	_eq(failures, "depth1.child", shallow_children[0].get("name"), "Sprite")
 	_eq(failures, "depth1.truncated", shallow_children[0].get("children"), [])
 
+	# lightweight=true ⇒ {name, type, children} only, no script serialization (#168).
+	var light: Dictionary = Inspect.serialize_tree(world, -1, true)
+	_eq(failures, "light.name", light.get("name"), "World")
+	_eq(failures, "light.type", light.get("type"), "Node2D")
+	_eq(failures, "light.no_script", light.has("script"), false)
+	var light_children: Array = light.get("children")
+	_eq(failures, "light.child", light_children[0].get("name"), "Sprite")
+	_eq(failures, "light.child_no_script", light_children[0].has("script"), false)
+
 	# Output must be JSON-safe (stringify must not error).
 	if JSON.stringify(full) == "":
 		failures.append("serialized tree is not JSON-safe")

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -43,19 +43,24 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         return ActiveScene(**await route(bridge, "cmd_get_active_scene"))
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
-    async def get_scene_tree(max_depth: int = -1) -> SceneTree:
+    async def get_scene_tree(max_depth: int = -1, lightweight: bool = False) -> SceneTree:
         """Get the open scene as a recursive tree of {name, type, script, children}.
 
         ``max_depth`` limits how many child levels are returned (-1 = unlimited,
         0 = root only); use it to avoid huge payloads on deep scenes. ``tree`` is
         null when no scene is open.
 
+        ``lightweight=True`` returns only {name, type, children} (no ``script``) —
+        a smaller payload for a discovery pass where you just need the shape; pair
+        it with ``max_depth`` to keep large scenes out of context.
+
         WHEN TO USE: You need to understand the static scene structure before
         making edits (adding nodes, attaching scripts, setting properties).
         WHEN NOT TO USE: The game is running and you need live state — use
         get_game_scene_tree() to read the running game's current hierarchy.
         """
-        return SceneTree(**await route(bridge, "cmd_get_scene_tree", {"max_depth": max_depth}))
+        params = {"max_depth": max_depth, "lightweight": lightweight}
+        return SceneTree(**await route(bridge, "cmd_get_scene_tree", params))
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_selected_node() -> SelectedNode:

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -114,6 +114,23 @@ async def test_get_scene_tree_passes_max_depth() -> None:
     assert conn.last_command().params["max_depth"] == 2
 
 
+async def test_get_scene_tree_lightweight_passes_flag() -> None:
+    # #168: lightweight=True forwards to the addon so it can skip script serialization.
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("get_scene_tree", {"lightweight": True})
+    assert result.structured_content["tree"]["name"] == "Main"
+    assert conn.last_command().params["lightweight"] is True
+
+
+async def test_get_scene_tree_defaults_to_full() -> None:
+    # Default stays full (lightweight=False) for back-compat.
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        await client.call_tool("get_scene_tree", {})
+    assert conn.last_command().params["lightweight"] is False
+
+
 async def test_get_selected_node() -> None:
     async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
         result = await client.call_tool("get_selected_node", {})


### PR DESCRIPTION
## Summary
A discovery pass usually needs only the scene shape, not per-node script info. `get_scene_tree(lightweight=True)` returns `{name, type, children}` — skipping the per-node `get_script` call and the `script` field — for a smaller payload (fewer tokens in agent context, less bridge serialization). Default stays full for back-compat. Pairs with `max_depth` (#168).

## Acceptance criteria
- [x] `fields`/`lightweight` option on `cmd_get_scene_tree` returning only `{name, type, children}`
- [x] Default stays full for back-compat

## Test plan
- Server contract test: `lightweight=True` is forwarded to the addon; default is `False`.
- Headless addon smoke test (`inspect_smoke.gd`, run under Godot 4.x → `INSPECT_TEST_OK`): `serialize_tree(..., lightweight=true)` omits `script` at every level.
- Preflight: ruff ✓, mypy ✓ (201), 468 passed (non-e2e), zero-skip ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)