### PR TITLE
feat(harness): per-session client-side read cache (closes #170)

### DIFF
--- a/docs/harness-performance.md
+++ b/docs/harness-performance.md
@@ -57,3 +57,28 @@ for the allowed set.
 > `run_commands` is one tool call (good when going through the MCP tool surface);
 > `gather_reads` is a direct-bridge helper (good for a harness that already holds a
 > `Bridge`, e.g. the eval runner). Pick whichever your call path already uses.
+
+## 3. Cache stable reads — `ReadCache` (#170)
+
+Scene structure and node-property lists don't change *between* mutations, yet harnesses
+often re-fetch them every step. `mcp_server.harness.ReadCache` memoizes read-only results
+per session and drops them on a write, so repeated identical reads cost one round-trip
+instead of many — and don't re-enter the agent's context as fresh tokens.
+
+```python
+from mcp_server.harness import ReadCache
+
+cache = ReadCache(bridge)          # one instance per session
+tree = await cache.read("cmd_get_scene_tree", {"max_depth": 2})
+tree_again = await cache.read("cmd_get_scene_tree", {"max_depth": 2})  # cache hit, no round-trip
+
+# Route mutations through write(), which invalidates the cache so no stale read survives:
+await cache.write("cmd_set_node_property", {"node_path": "Player", "property": "visible", "value": False})
+fresh = await cache.read("cmd_get_scene_tree", {"max_depth": 2})       # re-fetched
+```
+
+The cache is **per session** (one `ReadCache` per session) — unlike the old server-side
+preflight cache, which was a process-global cleared on every mutation and could bleed
+across sessions (removed in #166). If a mutation is issued *outside* the cache (not via
+`write`), call `cache.invalidate()` so the next read is fresh. `read` accepts only
+read-only commands (see `READ_ONLY_COMMANDS`); a mutation raises `ValueError`.

--- a/mcp_server/harness.py
+++ b/mcp_server/harness.py
@@ -16,6 +16,7 @@ the editor is a single writer, so writes must stay ordered — batch those with 
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from mcp_server.bridge import Bridge
@@ -59,3 +60,55 @@ async def gather_reads(
                 "Mutations must stay ordered — batch them with the run_commands tool."
             )
     return list(await asyncio.gather(*(route(bridge, c, p) for c, p in reads)))
+
+
+class ReadCache:
+    """Per-session client-side cache for read-only bridge results (issue #170).
+
+    Scene structure and node-property lists are stable *between* mutations, so a
+    harness that re-reads them repeatedly wastes round-trips and re-spends tokens.
+    ``read`` memoizes a result keyed by ``(command, params)``; any mutation
+    invalidates the whole cache (call ``invalidate``, or use ``write`` which does it
+    for you). It is correctly scoped **per session** — one instance per session —
+    unlike the removed server-side global cache that bled across sessions (#166).
+
+    Runs in the client/harness process (not an MCP tool) and is not thread-safe;
+    use one instance per session, driven from a single task.
+    """
+
+    def __init__(self, bridge: Bridge) -> None:
+        self._bridge = bridge
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _key(command: str, params: dict[str, Any]) -> str:
+        return f"{command}:{json.dumps(params, sort_keys=True, default=str)}"
+
+    async def read(self, command: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Return a cached read result, or fetch it over the bridge and cache it.
+
+        Only read-only commands are cacheable; anything else raises ``ValueError``
+        (a mutation must not be served from a cache). The cache holds until the next
+        ``invalidate``/``write``.
+        """
+        params = params or {}
+        if command not in READ_ONLY_COMMANDS:
+            raise ValueError(
+                f"ReadCache only caches read-only commands; '{command}' is not one. "
+                "Route mutations through write() (which invalidates the cache)."
+            )
+        key = self._key(command, params)
+        if key not in self._cache:
+            self._cache[key] = await route(self._bridge, command, params)
+        return self._cache[key]
+
+    def invalidate(self) -> None:
+        """Drop all cached reads. Call after any mutating command issued elsewhere."""
+        self._cache.clear()
+
+    async def write(self, command: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Route a (mutating) command, then invalidate the cache so stale reads can't
+        survive the write. Use for any command that changes editor state."""
+        result = await route(self._bridge, command, params or {})
+        self.invalidate()
+        return result

--- a/tests/unit/test_harness_read_cache.py
+++ b/tests/unit/test_harness_read_cache.py
@@ -1,0 +1,105 @@
+"""Unit tests for the client-side read cache harness helper (issue #170).
+
+ReadCache memoizes read-only results per session and drops them on a mutation, so
+a harness stops re-fetching stable scene state. These pin: a repeat read is served
+from cache (no second round-trip), distinct params cache separately, invalidate and
+write force a re-fetch, and a mutation cannot be read through the cache.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.harness import ReadCache
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from tests.fakes import FakeAddonConnection, connector_for, ping_responder
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    if cmd.command == "cmd_get_scene_tree":
+        return ResponseEnvelope.success(cmd.id, {"tree": {"name": "Main"}})
+    if cmd.command == "cmd_get_node_properties":
+        return ResponseEnvelope.success(cmd.id, {"node_path": cmd.params["node_path"]})
+    if cmd.command == "cmd_set_node_property":
+        return ResponseEnvelope.success(cmd.id, {"updated": True})
+    return ping_responder(cmd)
+
+
+async def _bridge_conn() -> tuple[Bridge, FakeAddonConnection]:
+    conn = FakeAddonConnection(_responder)
+    bridge = Bridge(BridgeConfig(), connector=connector_for(conn))
+    await bridge.connect()
+    return bridge, conn
+
+
+def _count(conn: FakeAddonConnection, command: str) -> int:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent].count(command)
+
+
+def test_repeat_read_served_from_cache() -> None:
+    async def go() -> None:
+        bridge, conn = await _bridge_conn()
+        cache = ReadCache(bridge)
+        a = await cache.read("cmd_get_scene_tree")
+        b = await cache.read("cmd_get_scene_tree")
+        assert a == b == {"tree": {"name": "Main"}}
+        assert _count(conn, "cmd_get_scene_tree") == 1  # second read hit the cache
+        await bridge.close()
+
+    asyncio.run(go())
+
+
+def test_distinct_params_cache_separately() -> None:
+    async def go() -> None:
+        bridge, conn = await _bridge_conn()
+        cache = ReadCache(bridge)
+        await cache.read("cmd_get_node_properties", {"node_path": "A"})
+        await cache.read("cmd_get_node_properties", {"node_path": "B"})
+        await cache.read("cmd_get_node_properties", {"node_path": "A"})  # cached
+        assert _count(conn, "cmd_get_node_properties") == 2
+        await bridge.close()
+
+    asyncio.run(go())
+
+
+def test_invalidate_forces_refetch() -> None:
+    async def go() -> None:
+        bridge, conn = await _bridge_conn()
+        cache = ReadCache(bridge)
+        await cache.read("cmd_get_scene_tree")
+        cache.invalidate()
+        await cache.read("cmd_get_scene_tree")
+        assert _count(conn, "cmd_get_scene_tree") == 2
+        await bridge.close()
+
+    asyncio.run(go())
+
+
+def test_write_invalidates_cache() -> None:
+    async def go() -> None:
+        bridge, conn = await _bridge_conn()
+        cache = ReadCache(bridge)
+        await cache.read("cmd_get_scene_tree")
+        # A mutation through write() drops cached reads so the next read is fresh.
+        await cache.write("cmd_set_node_property", {"node_path": "A", "property": "x", "value": 1})
+        await cache.read("cmd_get_scene_tree")
+        assert _count(conn, "cmd_get_scene_tree") == 2
+        assert _count(conn, "cmd_set_node_property") == 1
+        await bridge.close()
+
+    asyncio.run(go())
+
+
+def test_read_rejects_mutation() -> None:
+    async def go() -> None:
+        bridge, _ = await _bridge_conn()
+        cache = ReadCache(bridge)
+        with pytest.raises(ValueError, match="read-only"):
+            await cache.read("cmd_set_node_property", {"node_path": "A"})
+        await bridge.close()
+
+    asyncio.run(go())


### PR DESCRIPTION
## Summary
Scene structure and node-property lists are stable *between* mutations, yet harnesses re-fetch them every step. `mcp_server.harness.ReadCache` memoizes read-only results per session and drops them on a write, so repeated identical reads cost one round-trip instead of many — and don't re-enter the agent's context as fresh tokens (#170).

Correctly scoped **per session** (one instance per session), unlike the removed server-side global preflight cache that could bleed across sessions (#166). Runs in the client/harness process (not an MCP tool).

## Acceptance criteria
- [x] Per-session client-side read cache for read-only results (scene tree, node property lists)
- [x] Invalidated when the client issues a mutating command (`write()` does it; `invalidate()` for external writes)
- [x] Correctly scoped per session (not a process global)
- [x] Pattern documented (`docs/harness-performance.md`)

## Test plan
- `tests/unit/test_harness_read_cache.py`: repeat read served from cache (one round-trip); distinct params cache separately; `invalidate`/`write` force a re-fetch; `read` rejects a mutation.
- Preflight: ruff ✓, mypy ✓ (204), 476 passed (non-e2e), zero-skip ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)