### PR TITLE
Add explicit scene-relative paths to scene tree nodes

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -166,9 +166,12 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 | `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
 | `get_node_property_list` | `node_path: str` | `NodePropertyList { node_path, type, properties[] }` | `cmd_get_node_property_list` |
 
-`SceneNode = { name, type, script?, children: [SceneNode] }`. `lightweight=True` (#168) drops
-`script` → `{ name, type, children }` for a smaller discovery payload (pair with `max_depth`).
-`get_node_properties` errors
+`SceneNode = { name, type, path, script?, children: [SceneNode] }`. Each node's `path` (#180)
+is scene-relative (`"."` for the root, e.g. `Player/Weapon` below it) and is accepted verbatim
+by the path-taking tools (`set_node_property`, `create_node` parent, `attach_script`,
+`get_node_properties`) — clients must not reconstruct paths by walking the tree.
+`lightweight=True` (#168) drops `script` → `{ name, type, path, children }` for a smaller
+discovery payload (pair with `max_depth`). `get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
 `get_node_property_list` returns every valid property name for a node (useful before calling
 `set_node_property`).

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -10,14 +10,23 @@ extends RefCounted
 const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
 
 
-## Recursive { name, type, script, children } for a subtree.
+## Recursive { name, type, path, script, children } for a subtree.
 ## max_depth < 0 is unlimited; max_depth == 0 returns the node with no children.
+## Every node carries an explicit scene-relative `path` (#180) — "." for the scene
+## root, e.g. "Player/Weapon" below it — in exactly the form the path-taking tools
+## accept, so clients never have to reconstruct paths by walking the tree.
 ## lightweight (#168) drops the `script` field (skips the per-node get_script call)
-## for a smaller discovery payload — { name, type, children } only.
-static func serialize_tree(node: Node, max_depth: int = -1, lightweight: bool = false) -> Dictionary:
+## for a smaller discovery payload — { name, type, path, children } only.
+## scene_root threads the root down the recursion; it defaults to `node` (the top
+## call passes the root), so existing 1-3 arg callers keep working.
+static func serialize_tree(
+	node: Node, max_depth: int = -1, lightweight: bool = false, scene_root: Node = null
+) -> Dictionary:
+	var root: Node = scene_root if scene_root != null else node
 	var data: Dictionary = {
 		"name": String(node.name),
 		"type": node.get_class(),
+		"path": relative_path(node, root),
 	}
 	if not lightweight:
 		data["script"] = script_path(node)
@@ -25,7 +34,7 @@ static func serialize_tree(node: Node, max_depth: int = -1, lightweight: bool = 
 	if max_depth != 0:
 		var child_depth: int = (max_depth - 1) if max_depth > 0 else -1
 		for child in node.get_children():
-			children.append(serialize_tree(child, child_depth, lightweight))
+			children.append(serialize_tree(child, child_depth, lightweight, root))
 	data["children"] = children
 	return data
 

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -96,11 +96,17 @@ func _test_serialize_tree(failures: Array[String]) -> void:
 	_eq(failures, "tree.name", full.get("name"), "World")
 	_eq(failures, "tree.type", full.get("type"), "Node2D")
 	_eq(failures, "tree.script", full.get("script"), null)
+	# Every node carries an explicit scene-relative path (#180): "." at the root,
+	# and nested paths below it ("Sprite", "Sprite/Deep") in path-taking-tool form.
+	_eq(failures, "tree.path", full.get("path"), ".")
 	var children: Array = full.get("children")
 	if children.size() != 1 or children[0].get("name") != "Sprite":
 		failures.append("tree children wrong: %s" % str(children))
 	elif children[0].get("children")[0].get("name") != "Deep":
 		failures.append("tree grandchild wrong")
+	else:
+		_eq(failures, "tree.child.path", children[0].get("path"), "Sprite")
+		_eq(failures, "tree.grandchild.path", children[0].get("children")[0].get("path"), "Sprite/Deep")
 
 	# max_depth=1 ⇒ root + immediate children, but their children truncated.
 	var shallow: Dictionary = Inspect.serialize_tree(world, 1)
@@ -113,6 +119,7 @@ func _test_serialize_tree(failures: Array[String]) -> void:
 	_eq(failures, "light.name", light.get("name"), "World")
 	_eq(failures, "light.type", light.get("type"), "Node2D")
 	_eq(failures, "light.no_script", light.has("script"), false)
+	_eq(failures, "light.path", light.get("path"), ".")  # path stays even when lightweight (#180)
 	var light_children: Array = light.get("children")
 	_eq(failures, "light.child", light_children[0].get("name"), "Sprite")
 	_eq(failures, "light.child_no_script", light_children[0].has("script"), false)

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -30,10 +30,16 @@ class ActiveScene(BaseModel):
 
 
 class SceneNode(BaseModel):
-    """A node in the recursive scene-tree serialization."""
+    """A node in the recursive scene-tree serialization.
+
+    ``path`` is the scene-relative path (``"."`` for the root, e.g. ``Player/Weapon``
+    below it), accepted verbatim by the path-taking tools (#180) — clients never have
+    to reconstruct paths by walking the tree.
+    """
 
     name: str
     type: str
+    path: str = ""
     script: str | None = None
     children: list[SceneNode] = Field(default_factory=list)
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -44,7 +44,12 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_scene_tree(max_depth: int = -1, lightweight: bool = False) -> SceneTree:
-        """Get the open scene as a recursive tree of {name, type, script, children}.
+        """Get the open scene as a recursive tree of {name, type, path, script, children}.
+
+        Each node carries an explicit scene-relative ``path`` ("." for the root,
+        e.g. "Player/Weapon" below it) — pass it verbatim to set_node_property,
+        create_node (as parent_path), attach_script, or get_node_properties; do not
+        reconstruct paths by hand.
 
         ``max_depth`` limits how many child levels are returned (-1 = unlimited,
         0 = root only); use it to avoid huge payloads on deep scenes. ``tree`` is

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -40,7 +40,23 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_get_scene_tree":
             return ResponseEnvelope.success(
                 cmd.id,
-                {"tree": {"name": "Main", "type": "Node2D", "script": None, "children": []}},
+                {
+                    "tree": {
+                        "name": "Main",
+                        "type": "Node2D",
+                        "path": ".",
+                        "script": None,
+                        "children": [
+                            {
+                                "name": "Player",
+                                "type": "CharacterBody2D",
+                                "path": "Player",
+                                "script": None,
+                                "children": [],
+                            }
+                        ],
+                    }
+                },
             )
         case "cmd_get_selected_node":
             return ResponseEnvelope.success(
@@ -112,6 +128,21 @@ async def test_get_scene_tree_passes_max_depth() -> None:
         result = await client.call_tool("get_scene_tree", {"max_depth": 2})
     assert result.structured_content["tree"]["name"] == "Main"
     assert conn.last_command().params["max_depth"] == 2
+
+
+async def test_scene_tree_carries_path_round_trips_into_tool() -> None:
+    # #180: every node carries a scene-relative `path`; that exact string is accepted
+    # verbatim by a path-taking tool (here get_node_properties) with no reconstruction.
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        tree = await client.call_tool("get_scene_tree", {})
+        root = tree.structured_content["tree"]
+        assert root["path"] == "."
+        child_path = root["children"][0]["path"]
+        assert child_path == "Player"
+        # Feed the discovered path straight into a path-taking tool — no walking.
+        info = await client.call_tool("get_node_properties", {"node_path": child_path})
+    assert info.structured_content["node_path"] == "Player"
 
 
 async def test_get_scene_tree_lightweight_passes_flag() -> None:


### PR DESCRIPTION
### **User description**
## Summary
`get_scene_tree` returned only nesting, so any client targeting a node had to reconstruct its path by walking the tree — which LLM planners repeatedly got wrong (`/GameManager`, `.GameManager`) → `RESOURCE_NOT_FOUND`. Every node now carries an explicit scene-relative `path` (`"."` for the root, e.g. `Player/Weapon` below it), in exactly the form the path-taking tools accept. Targeting a node becomes copy-the-path, not guess-the-path. (#180)

`serialize_tree` threads the scene root down the recursion (defaulted, so existing callers are unaffected); `SceneNode` gains `path`. Present in lightweight mode (#168) too.

## Acceptance criteria
- [x] Each node carries a scene-relative `path` accepted verbatim by `set_node_property` / `create_node` (parent) / `attach_script` / `get_node_properties`
- [x] Documented in `docs/tool-contracts.md`
- [x] Contract test pins the `path` field + round-trips a path into a path-taking tool

## Test plan
- Contract test: a discovered child `path` (`"Player"`) is fed straight into `get_node_properties` and resolves; root is `"."`.
- Headless addon smoke (`inspect_smoke.gd` → `INSPECT_TEST_OK`): `"."` at the root, `Sprite`/`Sprite/Deep` below, and `path` retained in lightweight mode.
- Preflight: ruff ✓, mypy ✓ (204), full suite green (non-e2e), zero-skip ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add explicit scene-relative paths to all nodes.

- Simplify client interaction with path-taking tools.

- Update documentation and contract tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scene Tree"] -- "includes" --> B["Nodes with Paths"]
  B -- "used by" --> C["Path-taking Tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inspection.py</strong><dd><code>Add path property to SceneNode model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/inspection.py

- Add `path` field to `SceneNode`.
- Update docstring for path usage.


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-45806d2c459fe7dbb15e90f53c37192b5e4140ab53ed87ffc293a30f7b33edfa">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scene_inspect.gd</strong><dd><code>Implement path serialization in Godot addon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/scene_inspect.gd

<ul><li>Update <code>serialize_tree</code> to calculate relative paths.<br> <li> Introduce <code>scene_root</code> parameter for recursion.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-f46999a59ce9b8f6f5042f77e6b0f9c181037b948b691f6e06d4c7b02efeb8e7">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inspection.py</strong><dd><code>Update get_scene_tree tool documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/inspection.py

<ul><li>Update <code>get_scene_tree</code> documentation.<br> <li> Mention the new <code>path</code> field in docs.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-eaaefb58a15b52cc64457889aff9fdfa9a10aadebf62c85b676e43375f167bf0">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Update tool contract documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Update documentation for <code>SceneNode</code>.<br> <li> Clarify usage of the <code>path</code> field.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_inspection.py</strong><dd><code>Add contract tests for node paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_inspection.py

<ul><li>Add contract tests for path round-tripping.<br> <li> Update mock data to include paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-f52b5e8ce780e310798b29270e857c1ade095a13a2af6ff9c76176e54a5e24b9">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>inspect_smoke.gd</strong><dd><code>Update smoke tests for path validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/tests/inspect_smoke.gd

<ul><li>Add smoke tests for path verification.<br> <li> Verify paths in both standard and lightweight modes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/195/files#diff-a046752542cde07fc09ed46ac7b1541937a79a2a282322efcc4711ca346621dd">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

