### PR TITLE
Introduce contract and compatibility versioning in server info

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -852,12 +852,28 @@ result. The `rect` pairs with `simulate_mouse` to click located UI.
 
 | Tool | Params | Returns | Notes |
 |------|--------|---------|-------|
-| `get_server_info` | — | `ServerDiagnostics { server, version, transport, toolsets[], prompts[], resources[], bridge{}, active_scene?, common_errors[], next_steps[] }` | capability snapshot — call first |
+| `get_server_info` | — | `ServerDiagnostics { server, version, contract_version, min_compatible_contract, transport, toolsets[], prompts[], resources[], bridge{}, active_scene?, common_errors[], next_steps[] }` | capability snapshot — call first |
 | `debug_workflow` | `scene="", timeout_seconds=5.0` | `DebugWorkflowResult { bridge{}, scene_tree?, run?, parse{ok, errors[], skipped_reason}, findings[], suggestions[] }` | one-call comprehensive check |
 
 `get_server_info` returns the full server surface so an agent can discover everything in one call: toolset summaries with counts, registered prompt names, resource URIs, bridge state, active scene, common errors with fixes, and suggested next steps.
 
 `debug_workflow` aggregates multiple read-only checks — parse errors across all `.gd` files, active scene tree, headless run capture, and bridge state — into a unified report with actionable findings and suggestions.
+
+#### Contract / compatibility versioning (issue #196)
+
+`get_server_info` carries two integers — `contract_version` and `min_compatible_contract` — that let a consuming client (e.g. [godot-agents](https://github.com/hybridindie/godot-agents)) negotiate compatibility against the **tool/envelope contract**, independent of the model layer.
+
+- **`version`** is CalVer (`YYYY.MM.DD[-N]`) — the *build*. It moves on every release, including additive and internal changes, so it cannot tell a client whether a change was breaking.
+- **`contract_version`** is a monotonic integer — the *contract*. It is bumped **only on a breaking change** to the surface clients depend on: a removed or renamed tool, a changed/removed required parameter, a changed result-model field, or a bridge-envelope shape change. **Additive, backward-compatible changes do not bump it** (new tools, new toolsets, new *optional* fields, new error codes).
+- **`min_compatible_contract`** is the oldest client contract this server still serves.
+
+A client carries the `contract_version` it was built against and is compatible when:
+
+```
+min_compatible_contract  ≤  client_contract  ≤  contract_version
+```
+
+Below the floor, the client is too new for an old server (it may rely on contract behavior the server lacks); above the ceiling cannot occur for a faithful client. CalVer remains a usable coarse signal (and is what godot-agents pins today), but `contract_version` is the stable thing to gate on as the surface evolves. Bumping `CONTRACT_VERSION` (in `mcp_server/__init__.py`) is a deliberate, documented act — record the breaking change in the PR and, when the floor moves, `MIN_COMPATIBLE_CONTRACT` too.
 
 #### Safety introspection (issue #14) — `read_only`
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -10,3 +10,14 @@ See ``docs/architecture.md`` for the bridge contract.
 
 # CalVer, kept in sync with pyproject.toml and .claude/rules/enforcement.md.
 __version__ = "2026.06.01"
+
+# Tool-contract / compatibility version — a monotonic integer, deliberately
+# distinct from the CalVer build version. It expresses the *contract*: bump it
+# only on a BREAKING change to the tool surface or bridge envelope (a removed/
+# renamed tool, a changed required field, an envelope-shape change). Additive,
+# backward-compatible changes (new tools, new optional fields) do NOT bump it.
+# Clients negotiate against this via get_server_info — see docs/tool-contracts.md.
+CONTRACT_VERSION = 1
+# Oldest client contract version this server still serves. A client is compatible
+# when MIN_COMPATIBLE_CONTRACT <= client_contract <= CONTRACT_VERSION.
+MIN_COMPATIBLE_CONTRACT = 1

--- a/mcp_server/diagnostics.py
+++ b/mcp_server/diagnostics.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 from pydantic import BaseModel
 
-from mcp_server import __version__
+from mcp_server import CONTRACT_VERSION, MIN_COMPATIBLE_CONTRACT, __version__
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
 from mcp_server.config import ServerConfig
@@ -50,6 +50,11 @@ class ServerDiagnostics(BaseModel):
 
     server: str
     version: str
+    # Contract/compat negotiation surface (#196), distinct from the CalVer
+    # `version`. A client is compatible when
+    # ``min_compatible_contract <= client_contract <= contract_version``.
+    contract_version: int
+    min_compatible_contract: int
     transport: str
     toolsets: list[ToolsetSummary]
     prompts: list[str]
@@ -251,6 +256,8 @@ def register_diagnostics(
         return ServerDiagnostics(
             server="godot-mcp",
             version=__version__,
+            contract_version=CONTRACT_VERSION,
+            min_compatible_contract=MIN_COMPATIBLE_CONTRACT,
             transport=config.transport,
             toolsets=_build_toolset_summaries(mcp, manager),
             prompts=_list_prompts(mcp),

--- a/tests/contract/test_diagnostics_contract.py
+++ b/tests/contract/test_diagnostics_contract.py
@@ -73,3 +73,25 @@ def test_diagnostics_contains_next_steps(server: FastMCP) -> None:
     """The response suggests next actions based on bridge/scene state."""
     result_text = asyncio.run(_call_tool(server, "get_server_info"))
     assert "next_steps" in result_text
+
+
+def test_diagnostics_exposes_contract_version(server: FastMCP) -> None:
+    """The response carries a machine-readable contract/compat surface (#196).
+
+    A monotonic integer contract version distinct from the CalVer build version,
+    plus the oldest client contract the server still serves, so clients can
+    negotiate against contract drift rather than guessing from CalVer.
+    """
+    import json
+
+    from mcp_server import CONTRACT_VERSION, MIN_COMPATIBLE_CONTRACT
+
+    result_text = asyncio.run(_call_tool(server, "get_server_info"))
+    payload = json.loads(result_text)
+
+    assert payload["contract_version"] == CONTRACT_VERSION
+    assert payload["min_compatible_contract"] == MIN_COMPATIBLE_CONTRACT
+    # Negotiation range is well-formed and distinct from the CalVer build version.
+    assert isinstance(payload["contract_version"], int)
+    assert payload["min_compatible_contract"] <= payload["contract_version"]
+    assert payload["contract_version"] >= 1


### PR DESCRIPTION
### **User description**
Closes #196.

## Why
Consuming agents (godot-agents, #107) need to verify they're talking to a compatible server before issuing work. Today the server reports CalVer `version` + toolset list, but **CalVer alone can't express a compatibility range** — it moves on every release, additive or breaking alike, so a client can't tell whether a change broke the contract it depends on.

## Change
A monotonic integer contract surface, distinct from the build CalVer, exposed via `get_server_info` for client negotiation:

- **`CONTRACT_VERSION` / `MIN_COMPATIBLE_CONTRACT`** (`mcp_server/__init__.py`). `CONTRACT_VERSION` is bumped **only on a breaking change** to the tool surface or bridge envelope (removed/renamed tool, changed required param, changed result field, envelope-shape change). Additive, backward-compatible changes (new tools, new optional fields, new error codes) **do not** bump it.
- **`ServerDiagnostics`** gains `contract_version` + `min_compatible_contract`. A client carries the contract version it was built against and is compatible when `min_compatible_contract <= client_contract <= contract_version`.
- **`docs/tool-contracts.md`** documents the semantics (what bumps it, additive vs breaking, the negotiation inequality).

`health_check` is intentionally left unchanged — the issue scopes negotiation to `get_server_info`, the capability-snapshot call clients hit first.

## Acceptance
- [x] Stable, machine-readable contract/compat indicator distinct from build CalVer (+ explicit min-compatible field) via `get_server_info`.
- [x] Compatibility semantics documented in `docs/tool-contracts.md`.
- [x] Contract test pinning the fields in the `get_server_info` response.

## Test plan
- New `test_diagnostics_exposes_contract_version` pins both fields against the `mcp_server` constants and asserts a well-formed range.
- Preflight: ruff + mypy clean; `uv run pytest -q` → 503 passed (the 4 `test_live_*` failures are pre-existing local-only — `skipif(GODOT_BIN is None)` tests that need a running addon-enabled editor; they fail identically on clean `main` and skip in CI, which has no Godot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduce monotonic contract versions for client negotiation.

- Update `ServerDiagnostics` to include compatibility fields.

- Document difference between build and contract versions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client (e.g. godot-agents)"] -- "Requests get_server_info" --> Server["Server"]
  Server -- "Returns ServerDiagnostics" --> Client
  subgraph "Compatibility Check"
  Client -- "Checks contract_version & min_compatible_contract" --> Logic["Is client compatible?"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add contract and compatibility constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/__init__.py

<ul><li>Define <code>CONTRACT_VERSION</code> as a monotonic integer for breaking changes.<br> <li> Define <code>MIN_COMPATIBLE_CONTRACT</code> to establish the minimum supported <br>client version.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/198/files#diff-0ee260f94eefb5341ba2f880808d78577c1e28ab8efa6209e2b12753496409d6">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>diagnostics.py</strong><dd><code>Update diagnostics with contract info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/diagnostics.py

<ul><li>Update <code>ServerDiagnostics</code> model with <code>contract_version</code> and <br><code>min_compatible_contract</code>.<br> <li> Update <code>get_server_info</code> to populate these new fields from constants.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/198/files#diff-c8ba61cbd90bbf995dfcaf7874fa4a6380828a9fc41a522495dff17a35aae099">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_diagnostics_contract.py</strong><dd><code>Test contract version fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_diagnostics_contract.py

<ul><li>Add <code>test_diagnostics_exposes_contract_version</code> to verify new fields.<br> <li> Assert that version fields are present and within valid ranges.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/198/files#diff-f8af52f7d0c8d60bac2ea0dca2511662f22a2c6c20749e21078fab875613a2bb">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document contract versioning logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Update <code>get_server_info</code> definition in documentation.<br> <li> Add detailed explanation of contract vs. build versions.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/198/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

