### PR TITLE
Label non-representative evaluation runs for clarity

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -112,6 +112,19 @@ Experiment: `Godot AI` (the unified experiment shared with the godot-agents proj
 
 3. **Cloud model costs**: Running the full 28-task suite against Claude/GPT costs ~$2-5 in API tokens. Use `--tasks` to run a subset for quick validation.
 
+## Representativeness — addon-direct vs. server-mediated (#197)
+
+The LLM eval agents here (`OllamaAgent`, `CloudAgent`) execute tool calls by sending `cmd_*` envelopes **straight to the addon bridge** (`CloudAgent._execute`), bypassing the FastMCP server's safety classes, preconditions, `dry_run`/`confirm`, the approval webhook, and toolset gating. So their results do **not** reflect the safety behaviour a real, *server-mediated* client (e.g. [godot-agents](https://github.com/hybridindie/godot-agents), which already goes through the server) experiences — PRD FR3 wants the agent-representative path to run through the server.
+
+**Decision:** rather than migrate the execution path now (which means standing up an MCP client/session and switching from addon `cmd_*` param keys to the server tool surface), every `llm_eval_v2` run is **explicitly labelled non-representative** until that migration lands:
+
+- MLflow run params `execution_path="addon_direct"` and `agent_representative="false"` (see `evals/representativeness.py`, emitted by `log_results`), so dashboards can filter representative vs. non-representative runs.
+- A console banner on every run output.
+
+**Intentionally still addon-direct** (these test the bridge/addon contract and perf directly — not agent-representativeness — and should stay as-is): `batch_perf_test.py`, `composition_test.py`, `negative_test.py`.
+
+When the agent is routed through the server, drop the label and flip `agent_representative` to `"true"`.
+
 ## Results Archive
 
 Historical reports and ad-hoc test logs are in `evals/results/archive/`.

--- a/evals/llm_eval_v2.py
+++ b/evals/llm_eval_v2.py
@@ -35,6 +35,10 @@ from evals.cloud_client import CloudAgent  # noqa: E402
 from evals.mlflow_tracker import EvalTracker  # noqa: E402
 from evals.ollama_agent import OllamaAgent  # noqa: E402
 from evals.profiler import ToolProfiler  # noqa: E402
+from evals.representativeness import (  # noqa: E402
+    REPRESENTATIVENESS_BANNER,
+    representativeness_params,
+)
 from evals.variants import VARIANTS, apply_variant  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -1624,8 +1628,9 @@ def log_results(
     variant: str = "expanded-v2",
     model: str = "qwen3-coder:30b",
     provider: str = "ollama",
+    tracker: EvalTracker | None = None,
 ) -> None:
-    tracker = EvalTracker()
+    tracker = tracker or EvalTracker()
     git_sha = get_git_sha()
 
     tracker.start_run(
@@ -1638,6 +1643,13 @@ def log_results(
     tracker.log_param("git_sha", git_sha)
     tracker.log_param("variant", variant)
     tracker.log_param("task_count", len(results))
+
+    # Label this run addon-direct / non-representative: the eval agents send
+    # cmd_* straight to the addon bridge, bypassing the server's safety layer,
+    # so results don't reflect a server-mediated client (#197).
+    for key, value in representativeness_params().items():
+        tracker.log_param(key, value)
+    print(REPRESENTATIVENESS_BANNER)
 
     if results:
         mean_score = sum(r.score.overall for r in results) / len(results)

--- a/evals/representativeness.py
+++ b/evals/representativeness.py
@@ -1,0 +1,43 @@
+"""Eval representativeness labelling (#197).
+
+The LLM eval agents in this package (``OllamaAgent``, ``CloudAgent``) execute
+tool calls by sending ``cmd_*`` envelopes **straight to the addon bridge** (see
+``CloudAgent._execute`` / ``OllamaAgent``), bypassing the FastMCP server's
+safety classes, preconditions, ``dry_run``/``confirm``, the approval webhook,
+and toolset gating. Their results therefore do **not** reflect the safety
+behaviour a real, *server-mediated* client experiences (PRD FR3).
+
+Migrating that execution path onto the server (an MCP client/session, switching
+from addon ``cmd_*`` param keys to the server tool surface) is tracked as the
+representative path; until then, runs are labelled addon-direct /
+non-representative so the distinction is explicit in MLflow and console output.
+
+Intentionally out of scope (these *should* stay addon-direct — they test the
+bridge/addon contract and perf, not agent-representativeness):
+``batch_perf_test.py``, ``composition_test.py``, ``negative_test.py``.
+"""
+
+from __future__ import annotations
+
+# Stable, machine-readable execution-path marker for the addon-direct eval path.
+EXECUTION_PATH_ADDON_DIRECT = "addon_direct"
+
+# Console banner surfaced alongside addon-direct eval output.
+REPRESENTATIVENESS_BANNER = (
+    "⚠️  addon-direct eval path: tool calls bypass the FastMCP server's safety "
+    "classes / preconditions / dry_run / approval / toolset gating — results are "
+    "NOT representative of a server-mediated client (#197)."
+)
+
+
+def representativeness_params() -> dict[str, str]:
+    """MLflow params marking a run as addon-direct / non-representative.
+
+    String-valued because MLflow params are strings; ``agent_representative`` is
+    ``"false"`` so dashboards can filter representative vs. non-representative
+    runs without inferring it from the provider.
+    """
+    return {
+        "execution_path": EXECUTION_PATH_ADDON_DIRECT,
+        "agent_representative": "false",
+    }

--- a/tests/unit/test_eval_representativeness.py
+++ b/tests/unit/test_eval_representativeness.py
@@ -1,0 +1,72 @@
+"""Eval representativeness labelling (#197).
+
+The LLM eval agents (OllamaAgent, CloudAgent) execute tool calls by sending
+``cmd_*`` envelopes straight to the addon bridge, bypassing the FastMCP server's
+safety classes, preconditions, dry_run/confirm, approval webhook, and toolset
+gating. Their runs are therefore NOT representative of a server-mediated client.
+Until the path is migrated through the server, runs must be explicitly labelled
+addon-direct / non-representative in their MLflow traces and console output.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from evals.mlflow_tracker import EvalTracker
+from evals.representativeness import (
+    EXECUTION_PATH_ADDON_DIRECT,
+    REPRESENTATIVENESS_BANNER,
+    representativeness_params,
+)
+
+
+def test_representativeness_params_mark_addon_direct() -> None:
+    params = representativeness_params()
+    assert params["execution_path"] == EXECUTION_PATH_ADDON_DIRECT
+    assert params["execution_path"] == "addon_direct"
+    # Machine-readable "not representative" flag, string-valued for MLflow params.
+    assert params["agent_representative"] == "false"
+
+
+def test_banner_warns_it_bypasses_server_safety() -> None:
+    lowered = REPRESENTATIVENESS_BANNER.lower()
+    assert "addon-direct" in lowered
+    assert "not" in lowered and "representative" in lowered
+
+
+class _FakeTracker:
+    """Records log_param calls; no-ops the rest of the EvalTracker surface."""
+
+    def __init__(self) -> None:
+        self.params: dict[str, Any] = {}
+
+    def start_run(self, run_name: str | None = None, variant: str = "baseline") -> None:
+        return None
+
+    def log_param(self, key: str, value: Any) -> None:
+        self.params[key] = value
+
+    def log_metric(self, key: str, value: float, step: int | None = None) -> None:
+        return None
+
+    def end_run(self, status: str = "FINISHED") -> None:
+        return None
+
+
+def test_log_results_labels_run_non_representative(capsys: Any) -> None:
+    from evals.llm_eval_v2 import log_results
+
+    tracker = _FakeTracker()
+    # Empty results still logs run-level params (provider/model/... + labels).
+    log_results(
+        [],
+        variant="t",
+        model="m",
+        provider="anthropic",
+        tracker=cast(EvalTracker, tracker),
+    )
+
+    assert tracker.params["execution_path"] == "addon_direct"
+    assert tracker.params["agent_representative"] == "false"
+    # The non-representativeness is also surfaced in console output.
+    assert "addon-direct" in capsys.readouterr().out.lower()


### PR DESCRIPTION
### **User description**
Closes #197. Split out of hybridindie/godot-agents#102 (PRD FR3).

## Problem
`evals/cloud_client.py` (and `OllamaAgent`) execute tool calls via `bridge.send(f"cmd_{call.tool}", params)` — straight to the addon, bypassing the FastMCP server's safety classes, preconditions, `dry_run`/`confirm`, approval webhook, and toolset gating. So eval results don't reflect the safety behaviour a real, server-mediated client experiences.

## Decision (the issue's labelling option)
Full server-mediation (standing up an MCP client/session and switching from addon `cmd_*` param keys to the server tool surface) is deferred; until then, every `llm_eval_v2` run is **explicitly labelled non-representative**:

- **`evals/representativeness.py`** — `EXECUTION_PATH_ADDON_DIRECT`, a console banner, and `representativeness_params() -> {execution_path: "addon_direct", agent_representative: "false"}`.
- **`log_results()`** logs those MLflow params and prints the banner. The MLflow tracker is now injectable so the labelling is unit-testable.
- **`evals/README.md`** records the decision and re-affirms the intentionally addon-direct contract/perf tools (`batch_perf_test.py`, `composition_test.py`, `negative_test.py`) stay as-is.

When the agent is routed through the server, drop the label and flip `agent_representative` to `"true"`.

## Acceptance
- [x] Route through the server **or** explicitly label runs as non-representative in MLflow traces / output — done via the label + banner.
- [x] Decision recorded in the eval docs (`evals/README.md`).

## Test plan
- `tests/unit/test_eval_representativeness.py`: pins the params/banner, and asserts `log_results([], …, tracker=fake)` logs `execution_path=addon_direct` + `agent_representative=false` and prints the banner.
- Preflight: ruff + mypy clean (205 files); zero-skip clean; `uv run pytest -q` → 505 passed. The 4 `test_live_*` failures are pre-existing local-only (`skipif(GODOT_BIN is None)` tests needing a running addon-enabled editor; they fail identically on clean `main` and skip in CI, which has no Godot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Label non-representative runs due to safety bypass.

- Add warning banners for direct execution paths.

- Update documentation on execution path differences.

- Add unit tests for tracking logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Evaluation Run"] -- "Identify Path" --> B["Apply Labels"]
  B -- "Log Params" --> C["MLflow Tracker"]
  B -- "Print Banner" --> D["Console Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm_eval_v2.py</strong><dd><code>Integrate representativeness parameters into evaluation logic</code></dd></summary>
<hr>

evals/llm_eval_v2.py

<ul><li>Integrate <code>representativeness_params</code> into logging.<br> <li> Add warning banner for direct paths.<br> <li> Support optional <code>EvalTracker</code> injection.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/199/files#diff-819f0679d86ad594e693e6e67bbc878d19bda4cafa2870d08d60fc5104f23ae8">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>representativeness.py</strong><dd><code>Define constants and helpers for representation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

evals/representativeness.py

<ul><li>Define constants for execution paths.<br> <li> Provide helper for MLflow parameters.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/199/files#diff-a965b95ace69be2725db94e5e61e13d449d681fff91ed7206b7849c4daa30724">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_eval_representativeness.py</strong><dd><code>Add unit tests for reporting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_eval_representativeness.py

- Verify correct parameter logging.
- Validate console banner output.


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/199/files#diff-c8e60e49aa848e82be1f83a573fda77e95696ffce0a79e37c08dd55a865ac1c9">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation on execution path differences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

evals/README.md

- Explain difference between direct and mediated paths.


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/199/files#diff-a1a9eeb43d4de7693b860e126cdd7ffd4a8f6f8264f084a451b684cf143a86dc">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

