### PR TITLE
Add run_tests tool for headless GUT suite execution

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -814,10 +814,13 @@ screenshot diff are `read_only`.
 
 | Tool | Params | Returns |
 |------|--------|---------|
+| `run_tests` | `test_dir="res://test", timeout_seconds=120.0` | `RunTestsResult { ran, framework, framework_absent, passed, failed, total, failures[{test, file, line, message}], timed_out, exit_code, raw_summary }` |
 | `assert_node_state` | `node_path, property, expected, op="==", timeout_ms=1500` | `AssertionResult { …, actual, passed, error }` |
 | `run_test_scenario` | `scene="", events[], assertions[], setup_ms=800, settle_ms=300, stop_after=True` | `ScenarioResult { passed, played, connected, assertions[] }` |
 | `run_stress_test` | `iterations=100, actions[], seed=0, delay_ms=8` | `StressTestResult { survived, iterations, playing_after, seed }` |
 | `compare_screenshots` | `image_a, image_b (base64 PNG), tolerance=0.0` | `ScreenshotDiffResult { same_size, diff_pixels, diff_ratio, mean_abs_diff, match }` |
+
+`run_tests` runs the project's GDScript test suite ([GUT](https://github.com/bitwes/Gut)) headlessly (`godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=<test_dir> -gexit`) and returns structured pass/fail with best-effort per-failure detail — the same out-of-process pattern as `get_parse_errors`. It is a **neutral capability** (execute + report); it encodes no test-first/TDD workflow — the agent composes it. When GUT is not installed (no `res://addons/gut/`), it returns `framework_absent=true` (a normal outcome, not an error) without launching Godot, so the caller can fall back. `runtime` safety class (it executes project code). Counts/overall are reliable; the `failures[]` detail (test name/file/line) is scraped best-effort and may vary by GUT version.
 
 `assert_node_state` reads a live property (one sample via the runtime probe) and compares
 with `op` (==, !=, <, <=, >, >=, contains, approx). `run_test_scenario` plays a scene,

--- a/mcp_server/defaults.py
+++ b/mcp_server/defaults.py
@@ -26,6 +26,8 @@ DEFAULT_PROBE_POLL_INTERVAL_SECONDS: float = 0.2
 # -- Testing -------------------------------------------------------------------
 DEFAULT_TEST_SETUP_MS: int = 800
 DEFAULT_TEST_SETTLE_MS: int = 300
+# A whole headless test-suite run needs a longer budget than a single scene run.
+DEFAULT_TEST_RUN_TIMEOUT_SECONDS: float = 120.0
 DEFAULT_STRESS_ITERATIONS: int = 100
 DEFAULT_STRESS_DELAY_MS: int = 8
 DEFAULT_STRESS_MAX_WAIT_SECONDS: float = 10.0

--- a/mcp_server/gut_parse.py
+++ b/mcp_server/gut_parse.py
@@ -1,0 +1,88 @@
+"""Tool-independent parsing of GUT command-line output (issue #206).
+
+Kept free of FastMCP / tool-layer imports (cf. ``scripts_parse.py``) so the
+testing tool can use it without pulling in tool-registration code.
+
+GUT's stdout summary varies a little across versions, so counts use lenient
+regexes and the overall pass/fail is derived from them. Per-failure detail
+(test name, file, line) is **best-effort** scraped from the run log.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mcp_server.models.testing import RunTestsResult, TestFailure
+
+_PASSING_RE = re.compile(r"Passing(?:\s+tests)?\s+(\d+)", re.IGNORECASE)
+_FAILING_RE = re.compile(r"Failing(?:\s+tests)?\s+(\d+)", re.IGNORECASE)
+# Fallback summary line, e.g. "1 of 3 tests failed (3 ran)".
+_OF_Y_RE = re.compile(r"(\d+)\s+of\s+(\d+)\s+tests?\s+failed", re.IGNORECASE)
+
+_FILE_RE = re.compile(r"(res://\S+?\.gd)")
+_TEST_RE = re.compile(r"^\s+([A-Za-z_]\w*)\s*$")
+_FAILED_RE = re.compile(r"\[Failed\]:?\s*(.*)")
+_AT_LINE_RE = re.compile(r"at line (\d+)", re.IGNORECASE)
+
+
+def _counts(text: str) -> tuple[int, int, int] | None:
+    """Return (passed, failed, total) from the totals block, or None if absent."""
+    passing = _PASSING_RE.search(text)
+    failing = _FAILING_RE.search(text)
+    if passing and failing:
+        p, f = int(passing.group(1)), int(failing.group(1))
+        return p, f, p + f
+    of_y = _OF_Y_RE.search(text)
+    if of_y:
+        failed, total = int(of_y.group(1)), int(of_y.group(2))
+        return total - failed, failed, total
+    return None
+
+
+def _failures(lines: list[str]) -> list[TestFailure]:
+    """Best-effort: pair each ``[Failed]`` marker with the nearest test/file/line."""
+    failures: list[TestFailure] = []
+    current_file: str | None = None
+    current_test = ""
+    for i, line in enumerate(lines):
+        file_match = _FILE_RE.search(line)
+        if file_match and not _FAILED_RE.search(line):
+            current_file = file_match.group(1)
+        test_match = _TEST_RE.match(line)
+        if test_match and not _FILE_RE.search(line):
+            current_test = test_match.group(1)
+        failed_match = _FAILED_RE.search(line)
+        if failed_match:
+            line_no: int | None = None
+            for look in lines[i : i + 3]:
+                at = _AT_LINE_RE.search(look)
+                if at:
+                    line_no = int(at.group(1))
+                    break
+            failures.append(
+                TestFailure(
+                    test=current_test,
+                    file=current_file,
+                    line=line_no,
+                    message=failed_match.group(1).strip(),
+                )
+            )
+    return failures
+
+
+def parse_gut_results(stdout: str) -> RunTestsResult:
+    """Parse GUT stdout into a ``RunTestsResult`` (framework="gut", ran=True).
+
+    The tool layer fills ``timed_out`` / ``exit_code`` / ``framework_absent``.
+    """
+    counts = _counts(stdout)
+    passed, failed, total = counts if counts else (0, 0, 0)
+    return RunTestsResult(
+        ran=True,
+        framework="gut",
+        passed=passed,
+        failed=failed,
+        total=total,
+        failures=_failures(stdout.splitlines()),
+        raw_summary=stdout.strip()[-2000:],
+    )

--- a/mcp_server/models/testing.py
+++ b/mcp_server/models/testing.py
@@ -42,3 +42,32 @@ class StressTestResult(BaseModel):
     playing_after: bool
     seed: int
     error: str = ""
+
+
+class TestFailure(BaseModel):
+    """One failing test, as scraped from the runner's output (best-effort detail)."""
+
+    test: str = ""
+    file: str | None = None
+    line: int | None = None
+    message: str = ""
+
+
+class RunTestsResult(BaseModel):
+    """Structured result of a headless test-suite run (issue #206).
+
+    A neutral capability — execute the project's test suite and report results.
+    It encodes no TDD workflow; the agent composes it. ``framework_absent`` is a
+    normal (non-error) outcome so the caller can fall back gracefully.
+    """
+
+    ran: bool
+    framework: str | None = None
+    framework_absent: bool = False
+    passed: int = 0
+    failed: int = 0
+    total: int = 0
+    failures: list[TestFailure] = Field(default_factory=list)
+    timed_out: bool = False
+    exit_code: int | None = None
+    raw_summary: str = ""

--- a/mcp_server/runtime.py
+++ b/mcp_server/runtime.py
@@ -90,6 +90,8 @@ class Runner(Protocol):
         self, project_dir: str, preset: str, output_path: str, debug: bool, timeout: float
     ) -> RunOutput: ...
 
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput: ...
+
 
 @dataclass
 class GodotRunner:
@@ -131,6 +133,20 @@ class GodotRunner:
         command = [self.binary, "--headless", "--path", project_dir, flag, preset, output_path]
         # Run from the project dir so a relative output_path resolves against it (as documented).
         return await self._exec(command, timeout, cwd=project_dir)
+
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        """Run the project's GUT suite headlessly (``gut_cmdln.gd``, ``-gexit``)."""
+        command = [
+            self.binary,
+            "--headless",
+            "--path",
+            project_dir,
+            "-s",
+            "res://addons/gut/gut_cmdln.gd",
+            f"-gdir={test_dir}",
+            "-gexit",
+        ]
+        return await self._exec(command, timeout)
 
     async def _exec(
         self, command: list[str | None], timeout: float, cwd: str | None = None

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -206,7 +206,7 @@ def create_server(
     register_import_asset(mcp, bridge)
     register_input_sim(mcp, bridge)
     register_input_map(mcp, bridge, approval)
-    register_testing(mcp, bridge)
+    register_testing(mcp, bridge, config, runner)
     register_profiling(mcp, bridge)
     register_batch(mcp, bridge)
     register_composite(mcp, bridge)

--- a/mcp_server/tools/testing.py
+++ b/mcp_server/tools/testing.py
@@ -9,6 +9,7 @@ and diff screenshots. Gated `testing` toolset. Scenario/stress control the run
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
@@ -16,6 +17,7 @@ from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import TESTING_TAG
+from mcp_server.config import ServerConfig
 from mcp_server.defaults import (
     DEFAULT_ASSERT_NODE_TIMEOUT_MS,
     DEFAULT_PROBE_POLL_INTERVAL_SECONDS,
@@ -24,17 +26,21 @@ from mcp_server.defaults import (
     DEFAULT_STRESS_ITERATIONS,
     DEFAULT_STRESS_MAX_ITERATIONS,
     DEFAULT_STRESS_MAX_WAIT_SECONDS,
+    DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
     DEFAULT_TEST_SETTLE_MS,
     DEFAULT_TEST_SETUP_MS,
 )
+from mcp_server.gut_parse import parse_gut_results
 from mcp_server.models.testing import (
     AssertionResult,
+    RunTestsResult,
     ScenarioResult,
     ScreenshotDiffResult,
     StressTestResult,
 )
 from mcp_server.qa import ImageCompareError, compare_images, evaluate_assertion, random_input_events
-from mcp_server.safety import READ_ONLY, RUNTIME
+from mcp_server.runtime import Runner, resolve_project_dir
+from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError
 from mcp_server.tools._route import poll_ready, route
 
 TESTING = {TESTING_TAG}
@@ -90,8 +96,47 @@ async def _wait_connected(bridge: Bridge, timeout_ms: int) -> bool:
     return False
 
 
-def register_testing(mcp: FastMCP, bridge: Bridge) -> None:
+def _gut_present(project_dir: str) -> bool:
+    """True when the project has GUT installed (its command-line runner exists)."""
+    return (Path(project_dir) / "addons" / "gut" / "gut_cmdln.gd").is_file()
+
+
+def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: Runner) -> None:
     """Register the testing / QA tools."""
+
+    @mcp.tool(meta=RUNTIME, tags=TESTING)
+    async def run_tests(
+        test_dir: str = "res://test",
+        timeout_seconds: float = DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
+    ) -> RunTestsResult:
+        """Run the project's GDScript test suite (GUT) headlessly and return a
+        structured result: ``passed``/``failed``/``total``, per-failure detail, and
+        the raw summary. A neutral capability — it executes tests and reports; it
+        does not decide a workflow. ``test_dir`` is the GUT test directory.
+
+        Returns ``framework_absent=true`` (not an error) when GUT is not installed
+        (no ``res://addons/gut/``), so the caller can fall back.
+
+        WHEN TO USE: verify behavior against the project's existing tests.
+        WHEN NOT TO USE: there is no test suite — write one first, or use
+        run_and_capture / get_parse_errors for a smoke/parse check.
+        """
+        if runner.binary is None:
+            raise PreconditionError(
+                "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
+                required="godot_bin",
+            )
+        project_dir = await resolve_project_dir(bridge, config)
+        if not _gut_present(project_dir):
+            return RunTestsResult(ran=False, framework="gut", framework_absent=True)
+        output = await runner.run_tests(project_dir, test_dir, timeout=float(timeout_seconds))
+        if output.timed_out:
+            return RunTestsResult(
+                ran=True, framework="gut", timed_out=True, raw_summary=output.stdout.strip()[-2000:]
+            )
+        result = parse_gut_results(output.stdout)
+        result.exit_code = output.exit_code
+        return result
 
     @mcp.tool(meta=READ_ONLY, tags=TESTING)
     async def assert_node_state(

--- a/tests/contract/test_export.py
+++ b/tests/contract/test_export.py
@@ -47,6 +47,9 @@ class FakeRunner:
         self.exports.append((project_dir, preset, output_path, debug))
         return self._output
 
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        return self._output
+
 
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:

--- a/tests/contract/test_run_tests.py
+++ b/tests/contract/test_run_tests.py
@@ -1,0 +1,99 @@
+"""Contract tests for the run_tests tool (issue #206).
+
+In-memory client + fake addon peer + injected fake runner. Verifies the tool
+runs the suite and returns structured results, and that a missing GUT install is
+a normal ``framework_absent`` outcome (not an error) without launching Godot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.runtime import RunOutput
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+_GUT_FAIL = """\
+res://test/test_enemy.gd
+  test_spawns
+    [Failed]:  Expected [3] to equal [2]
+        at line 14
+Totals
+Passing tests      2
+Failing tests      1
+---- 1 of 3 tests failed (3 ran). ----
+"""
+
+
+class _FakeRunner:
+    binary: str | None = "fake-godot"
+
+    def __init__(self, output: RunOutput) -> None:
+        self._output = output
+        self.run_tests_calls: list[tuple[str, str]] = []
+
+    async def run(self, project_dir: str, scene: str | None, timeout: float) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def check_script(self, project_dir: str, script_path: str, timeout: float) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def export(
+        self, project_dir: str, preset: str, output_path: str, debug: bool, timeout: float
+    ) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        self.run_tests_calls.append((project_dir, test_dir))
+        return self._output
+
+
+def _build(project_dir: str, output: RunOutput) -> tuple[FastMCP, _FakeRunner]:
+    config = ServerConfig(godot_project_dir=project_dir)
+    bridge = Bridge(config.bridge, connector=connector_for(FakeAddonConnection()))
+    runner = _FakeRunner(output)
+    return create_server(config, bridge=bridge, runner=runner), runner
+
+
+def _with_gut(project_dir: Path) -> None:
+    gut = project_dir / "addons" / "gut"
+    gut.mkdir(parents=True, exist_ok=True)
+    (gut / "gut_cmdln.gd").write_text("# gut runner stub\n")
+
+
+async def test_run_tests_returns_structured_results(tmp_path: Path) -> None:
+    _with_gut(tmp_path)
+    output = RunOutput(command=["gut"], stdout=_GUT_FAIL, exit_code=1)
+    server, runner = _build(str(tmp_path), output)
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "testing"})
+        result = await client.call_tool("run_tests", {"test_dir": "res://test"})
+    data = result.data
+    assert data.ran is True and data.framework == "gut" and data.framework_absent is False
+    assert data.passed == 2 and data.failed == 1 and data.total == 3
+    assert data.exit_code == 1
+    assert any("Expected [3] to equal [2]" in f.message for f in data.failures)
+    assert runner.run_tests_calls == [(str(tmp_path), "res://test")]
+
+
+async def test_run_tests_reports_framework_absent_without_launching(tmp_path: Path) -> None:
+    # No addons/gut/ in the project.
+    server, runner = _build(str(tmp_path), RunOutput(command=["gut"], stdout=_GUT_FAIL))
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "testing"})
+        result = await client.call_tool("run_tests", {})
+    data = result.data
+    assert data.framework_absent is True and data.ran is False
+    assert runner.run_tests_calls == []  # never launched Godot
+
+
+async def test_run_tests_in_testing_toolset(tmp_path: Path) -> None:
+    server, _ = _build(str(tmp_path), RunOutput(command=["gut"]))
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "testing"})
+        names = {t.name for t in await client.list_tools()}
+    assert "run_tests" in names

--- a/tests/contract/test_runtime_tool.py
+++ b/tests/contract/test_runtime_tool.py
@@ -39,6 +39,9 @@ class FakeRunner:
         self.calls.append((project_dir, f"{preset}->{output_path}", timeout))
         return self._output
 
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        return self._output
+
 
 def _build(
     runner: FakeRunner, *, project_dir: str | None = "/tmp/proj"

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -64,6 +64,9 @@ class _FakeRunner:
     ) -> RunOutput:
         return RunOutput(command=["fake"])
 
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        return RunOutput(command=["fake"])
+
 
 def _build(check_output: RunOutput | None = None) -> tuple[FastMCP, FakeAddonConnection]:
     conn = FakeAddonConnection(responder=_responder)

--- a/tests/unit/test_gut_parse.py
+++ b/tests/unit/test_gut_parse.py
@@ -1,0 +1,86 @@
+"""Unit tests for GUT output parsing (issue #206).
+
+The parser turns GUT's command-line stdout into a structured ``RunTestsResult``:
+reliable counts + overall pass/fail, plus best-effort per-failure detail. Tested
+against captured representative GUT output so no live editor is needed.
+"""
+
+from __future__ import annotations
+
+from mcp_server.gut_parse import parse_gut_results
+
+_GUT_PASS = """\
+GUT version:  9.3.0
+Running tests
+res://test/test_player.gd
+  test_health_starts_full
+  test_takes_damage
+
+=============================================
+= Totals
+=============================================
+Scripts            1
+Passing tests      2
+Failing tests      0
+Risky/Pending      0
+Asserts            4
+Time               0.101s
+
+---- All tests passed! ----
+Tests finished.
+"""
+
+_GUT_FAIL = """\
+GUT version:  9.3.0
+Running tests
+res://test/test_player.gd
+  test_health_starts_full
+res://test/test_enemy.gd
+  test_spawns
+    [Failed]:  Expected [3] to equal [2]
+        at line 14
+
+=============================================
+= Totals
+=============================================
+Scripts            2
+Passing tests      2
+Failing tests      1
+Risky/Pending      0
+Asserts            5
+Time               0.214s
+
+---- 1 of 3 tests failed (3 ran). ----
+Tests finished.
+"""
+
+
+def test_parses_all_passing() -> None:
+    r = parse_gut_results(_GUT_PASS)
+    assert r.ran is True
+    assert r.framework == "gut"
+    assert r.passed == 2
+    assert r.failed == 0
+    assert r.total == 2
+    assert r.failures == []
+
+
+def test_parses_failures_with_counts() -> None:
+    r = parse_gut_results(_GUT_FAIL)
+    assert r.passed == 2
+    assert r.failed == 1
+    assert r.total == 3
+    assert len(r.failures) == 1
+    f = r.failures[0]
+    assert "Expected [3] to equal [2]" in f.message
+    # best-effort detail: the failing test + its script + line
+    assert f.test == "test_spawns"
+    assert f.file == "res://test/test_enemy.gd"
+    assert f.line == 14
+
+
+def test_unparseable_output_is_safe() -> None:
+    r = parse_gut_results("garbage with no totals")
+    assert r.ran is True
+    assert r.passed == 0 and r.failed == 0 and r.total == 0
+    assert r.failures == []


### PR DESCRIPTION
### **User description**
Closes #206. Prerequisite for godot-agents#127 (the agent-side TDD red-green loop), which consumes this.

## What
A **neutral capability**: run the project's GDScript test suite and report results. It encodes **no TDD/workflow opinion** — the agent composes it (keeping the MCP within its boundary: primitives + safety, not orchestration). Same out-of-process shape as `get_parse_errors`: launch headless Godot, parse stdout, return a typed model.

- **`GodotRunner.run_tests`** (+ `Runner` protocol): `godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=<test_dir> -gexit`.
- **`mcp_server/gut_parse.py`** — pure, tool-independent parse of GUT stdout: reliable `passed`/`failed`/`total` + overall, **best-effort** per-failure detail (test/file/line/message). Lenient regexes (GUT's summary varies by version) with a fallback "N of M tests failed" line.
- **`RunTestsResult` / `TestFailure`** models.
- **`run_tests` tool** (`testing` toolset, **`runtime`** safety class — it executes project code, like `run_and_capture`): resolves the project dir; returns **`framework_absent=true`** (a normal outcome, *not* an error) when GUT isn't installed — **without launching Godot** — so callers fall back gracefully; otherwise runs + parses, and surfaces `timed_out` distinctly.
- Docs in `docs/tool-contracts.md`; `Runner` fakes updated for the new protocol method.

## Notes
- Safety class is `runtime`, not the `read_only` floated in the issue — it executes the suite (game code), matching `run_and_capture`. It still mutates nothing in the project.
- `failures[]` detail is scraped best-effort and may vary by GUT version; counts + overall are reliable. (A JUnit-XML path could harden detail later.)

## Acceptance
- [x] `run_tests` runs a GUT suite headlessly and returns structured pass/fail + per-failure evidence.
- [x] `framework_absent` path when no runner is present (no Godot launch).
- [x] Typed result + docs + deterministic, fixture-based contract test (no live editor).

## Test plan
- `tests/unit/test_gut_parse.py` — parser over captured GUT output (all-pass, failures w/ counts + detail, unparseable-safe).
- `tests/contract/test_run_tests.py` — tool returns structured results (fake runner), `framework_absent` without launching, and is registered in the `testing` toolset.
- Preflight: ruff + mypy clean (208 files); zero-skip clean; `uv run pytest -q` → **512 passed** (the 4 deselected are the local-only live-editor tests; they skip in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `run_tests` tool for headless execution.

- Implement structured parsing of GUT stdout.

- Handle missing frameworks gracefully via flags.

- Update internal models and documentation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Request"] -- "run_tests" --> B["Tool Layer"]
  B -- "Check Gut Presence" --> C{Gut Installed?}
  C -- "No" --> D["Return framework_absent=true"]
  C -- "Yes" --> E["Runner: Execute Headless Godot"]
  E --> F["Parser: Process GUT Stdout"]
  F --> G["Structured RunTestsResult"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>defaults.py</strong><dd><code>Add default timeout for test runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-a6ad8c55b88e2cff58f5520c83fd4fa58c918e97c4b263aec70225dd107a867f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.py</strong><dd><code>Register testing tools with configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-f24be50e829d65c1c3626dad15c1b306dd882fc305e41024df58c9a7649f07b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>gut_parse.py</strong><dd><code>New module for parsing GUT output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-a5bbd00cf94911d7ce9263fb0e394a2e6787af17038c5922079bbfa7c31337fc">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testing.py</strong><dd><code>Define new models for test results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-d92c4ae55ad860b50bd0588a533f1b2e78cf3eb0d16ae29a6ec7ff1d879f976a">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Update runner to support headless tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-25ef7ff0360d28727b39f3f70affc18240c45bbd4b29b05179e853f2e7cd5a96">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testing.py</strong><dd><code>Implement the run_tests tool logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-d58b2175c7e4752c6baa3075834a974044f18a0521c3755ed122e2f9adf0b930">+47/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_run_tests.py</strong><dd><code>Add contract tests for new tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-77102b7205650f27589561476491e21cad95b68e202fafa8f0d7dfad0095119f">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_gut_parse.py</strong><dd><code>Add unit tests for parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-af8937e95989081ad4a6c3a24d7d5bc06f9f04896ef47b40117d302532f97c1b">+86/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Update documentation for new test capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_export.py</strong></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-b6d11490efca19de8b6589d251eb1e63524d04f696eb4c185945ae7a861feef5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_runtime_tool.py</strong></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-8346e2c00ff6b8617820bbf0df83129f619a956f08dd8cc1558d8d9c769a2b24">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scripts.py</strong></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/208/files#diff-9549267864d28f3304b4acded59f0df00eb2a24150480e2c261e2ca158979f4b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

