### PR TITLE
feat(tools): set standard MCP annotations from safety_class (closes #220)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -51,6 +51,11 @@ Every tool is tagged with exactly one:
   from `safety.py`, e.g. `@mcp.tool(meta=MUTATING)`.
 - `list_tools_by_safety_class()` is a `read_only` tool returning `{ class: [tool names] }`
   for agent introspection.
+- Each `safety_class` also drives the tool's **standard MCP `annotations`** (issue #220), set
+  for every tool (incl. gated-off ones) at server build so clients render them natively:
+  `read_only` → `readOnlyHint=true, idempotentHint=true`; `destructive` → `destructiveHint=true`;
+  `mutating`/`runtime` → `readOnlyHint=false, destructiveHint=false`. An annotation set
+  explicitly at registration is preserved.
 
 ### Human-in-the-loop approval (issue #153)
 

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -95,7 +95,11 @@ def _iter_registered_tools(mcp: FastMCP) -> Iterator[Any]:
     access is guarded so a future FastMCP internals change degrades to a no-op
     rather than breaking server startup.
     """
-    from fastmcp.tools import Tool
+    try:
+        from fastmcp.tools import Tool
+    except ImportError:
+        logger.warning("fastmcp.tools.Tool not importable; skipping safety annotations")
+        return
 
     for provider in getattr(mcp, "providers", []):
         for component in getattr(provider, "_components", {}).values():

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from mcp.types import ToolAnnotations
 from pydantic import ValidationError
 
 from mcp_server.bridge import Bridge
@@ -55,6 +56,68 @@ READ_ONLY = _meta(SafetyClass.READ_ONLY)
 MUTATING = _meta(SafetyClass.MUTATING)
 DESTRUCTIVE = _meta(SafetyClass.DESTRUCTIVE)
 RUNTIME = _meta(SafetyClass.RUNTIME)
+
+
+# --- standard MCP annotations (issue #220) ---------------------------------
+#
+# Clients (e.g. Claude) consume the *standard* MCP ``annotations`` natively to
+# reason about which tools are safe vs. state-changing; the custom ``safety_class``
+# meta above only helps this server. Derive the standard hints from it so both are
+# kept in sync from a single source of truth.
+
+
+def annotations_for_safety_class(safety_class: str) -> ToolAnnotations | None:
+    """Map a ``safety_class`` value to standard MCP :class:`ToolAnnotations`.
+
+    Returns ``None`` for unknown / unclassified tools (no hints asserted).
+    A fresh instance is returned per call so callers never share mutable state.
+    """
+    try:
+        cls = SafetyClass(safety_class)
+    except ValueError:
+        return None
+    if cls is SafetyClass.READ_ONLY:
+        # Reads never mutate and are repeatable with no additional effect.
+        return ToolAnnotations(readOnlyHint=True, idempotentHint=True)
+    if cls is SafetyClass.DESTRUCTIVE:
+        return ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+    # mutating (reversible via UndoRedo) and runtime (controls execution):
+    # state-changing but not destructive.
+    return ToolAnnotations(readOnlyHint=False, destructiveHint=False)
+
+
+def _iter_registered_tools(mcp: FastMCP) -> Iterator[Any]:
+    """Yield every registered tool object, including toolset-gated (disabled) ones.
+
+    FastMCP's public ``list_tools()`` filters out disabled tools, but annotations
+    must be applied to *all* tools so they are already correct the moment a gated
+    toolset is enabled. We read the providers' component registry directly; the
+    access is guarded so a future FastMCP internals change degrades to a no-op
+    rather than breaking server startup.
+    """
+    from fastmcp.tools import Tool
+
+    for provider in getattr(mcp, "providers", []):
+        for component in getattr(provider, "_components", {}).values():
+            if isinstance(component, Tool):
+                yield component
+
+
+def apply_safety_annotations(mcp: FastMCP) -> None:
+    """Set standard MCP ``annotations`` on every tool from its ``safety_class``.
+
+    Call once after all tools are registered. An annotation set explicitly at
+    registration is preserved (treated as an intentional override).
+    """
+    for tool in _iter_registered_tools(mcp):
+        if tool.annotations is not None:
+            continue
+        safety_class = (tool.meta or {}).get("safety_class")
+        if not safety_class:
+            continue
+        annotations = annotations_for_safety_class(safety_class)
+        if annotations is not None:
+            tool.annotations = annotations
 
 
 class PreconditionError(Exception):

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,7 +23,7 @@ from mcp_server.diagnostics import register_diagnostics
 from mcp_server.prompts import register_prompts
 from mcp_server.resources.context import register_resources
 from mcp_server.runtime import GodotRunner, Runner
-from mcp_server.safety import ApprovalGate, register_safety_tools
+from mcp_server.safety import ApprovalGate, apply_safety_annotations, register_safety_tools
 from mcp_server.tools.analysis import register_analysis
 from mcp_server.tools.animation import register_animation
 from mcp_server.tools.audio import register_audio
@@ -229,5 +229,9 @@ def create_server(
 
     # Register workflow prompts (instruction templates for the agent).
     register_prompts(mcp)
+
+    # Derive standard MCP annotations (readOnlyHint/destructiveHint/...) from each
+    # tool's safety_class, for every tool incl. gated-off ones (issue #220).
+    apply_safety_annotations(mcp)
 
     return mcp

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -1,0 +1,72 @@
+"""Contract tests for standard MCP tool annotations (issue #220).
+
+Every tool carries a custom ``meta={"safety_class": ...}``; clients (e.g. Claude)
+consume the *standard* MCP ``annotations`` (readOnlyHint / destructiveHint /
+idempotentHint) instead. These tests pin that the standard annotations are
+derived from ``safety_class`` for the whole tool surface — including toolset-gated
+(disabled) tools, which the public ``list_tools()`` filters out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for, make_addon_responder
+
+pytestmark = pytest.mark.asyncio
+
+
+def _server() -> FastMCP:
+    config = ServerConfig()
+    conn = FakeAddonConnection(make_addon_responder())
+    bridge = Bridge(config.bridge, connector=connector_for(conn))
+    return create_server(config, bridge=bridge)
+
+
+async def test_every_classified_tool_carries_annotations() -> None:
+    server = _server()
+    # _list_tools returns ALL registered tools, including toolset-gated ones.
+    tools = await server._list_tools()
+    assert tools, "expected a non-empty tool surface"
+
+    seen = {"read_only": 0, "mutating": 0, "destructive": 0, "runtime": 0}
+    for tool in tools:
+        safety_class = (tool.meta or {}).get("safety_class")
+        if safety_class is None:
+            continue
+        seen[safety_class] = seen.get(safety_class, 0) + 1
+        ann = tool.annotations
+        assert ann is not None, f"{tool.name} ({safety_class}) has no MCP annotations"
+
+        if safety_class == "read_only":
+            assert ann.readOnlyHint is True, tool.name
+            assert ann.idempotentHint is True, tool.name
+        elif safety_class == "destructive":
+            assert ann.readOnlyHint is False, tool.name
+            assert ann.destructiveHint is True, tool.name
+        elif safety_class in ("mutating", "runtime"):
+            assert ann.readOnlyHint is False, tool.name
+            assert ann.destructiveHint is False, tool.name
+
+    # Make sure the assertions above actually ran for each class.
+    assert seen["read_only"] > 0
+    assert seen["mutating"] > 0
+    assert seen["destructive"] > 0
+    assert seen["runtime"] > 0
+
+
+async def test_annotations_visible_on_public_surface() -> None:
+    # The default-exposed read-only tools must surface readOnlyHint to clients.
+    server = _server()
+    from fastmcp import Client
+
+    async with Client(server) as client:
+        tools = {t.name: t for t in await client.list_tools()}
+
+    health = tools["health_check"]
+    assert health.annotations is not None
+    assert health.annotations.readOnlyHint is True

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -35,6 +35,56 @@ def test_safety_meta_constants() -> None:
     assert SafetyClass.DESTRUCTIVE.value == "destructive"
 
 
+def test_annotations_for_safety_class_mapping() -> None:
+    from mcp_server.safety import annotations_for_safety_class
+
+    ro = annotations_for_safety_class("read_only")
+    assert ro is not None and ro.readOnlyHint is True and ro.idempotentHint is True
+
+    mut = annotations_for_safety_class("mutating")
+    assert mut is not None and mut.readOnlyHint is False and mut.destructiveHint is False
+
+    dest = annotations_for_safety_class("destructive")
+    assert dest is not None and dest.readOnlyHint is False and dest.destructiveHint is True
+
+    run = annotations_for_safety_class("runtime")
+    assert run is not None and run.readOnlyHint is False and run.destructiveHint is False
+
+    assert annotations_for_safety_class("unclassified") is None
+    assert annotations_for_safety_class("bogus") is None
+
+
+def test_apply_safety_annotations_respects_explicit_override() -> None:
+    from fastmcp import FastMCP
+    from mcp.types import ToolAnnotations
+
+    from mcp_server.safety import READ_ONLY, apply_safety_annotations
+
+    mcp = FastMCP("t")
+
+    @mcp.tool(meta=READ_ONLY)
+    async def derived() -> str:
+        """doc"""
+        return "x"
+
+    @mcp.tool(meta=READ_ONLY, annotations=ToolAnnotations(title="Custom", readOnlyHint=False))
+    async def overridden() -> str:
+        """doc"""
+        return "x"
+
+    apply_safety_annotations(mcp)
+
+    # Read back via the component registry the production code uses.
+    from mcp_server.safety import _iter_registered_tools
+
+    by_name = {t.name: t for t in _iter_registered_tools(mcp)}
+    assert by_name["derived"].annotations is not None
+    assert by_name["derived"].annotations.readOnlyHint is True
+    # An explicit annotation set at registration is preserved, not overwritten.
+    assert by_name["overridden"].annotations.title == "Custom"
+    assert by_name["overridden"].annotations.readOnlyHint is False
+
+
 async def _connected(responder: Responder) -> Bridge:
     conn = FakeAddonConnection(responder=responder)
     bridge = Bridge(BridgeConfig(), connector=connector_for(conn))


### PR DESCRIPTION
## Summary
Derives standard MCP `annotations` (`readOnlyHint` / `destructiveHint` / `idempotentHint`) from each tool's existing `safety_class` meta, via a single post-registration pass (`apply_safety_annotations`) in `create_server`. MCP clients (e.g. Claude) consume these natively for safety reasoning and rendering; the custom `safety_class` meta only helped this server.

Mapping:
- `read_only` → `readOnlyHint=true`, `idempotentHint=true`
- `destructive` → `destructiveHint=true`
- `mutating` / `runtime` → `readOnlyHint=false`, `destructiveHint=false`

Applied to **every** tool including toolset-gated (disabled) ones — the public `list_tools()` filters disabled tools, so the pass walks the provider component registry directly (guarded to degrade to a no-op if FastMCP internals change). An annotation set explicitly at registration is preserved.

## Acceptance criteria
- [x] Standard `annotations` derived from `SafetyClass` at registration
- [x] `read_only` → `readOnlyHint`; `destructive` → `destructiveHint`; idempotent reads → `idempotentHint`
- [x] Single change covers all ~121 tools (no per-tool edits)
- [x] Docs updated (`docs/tool-contracts.md`)

## Test plan
- `tests/unit/test_safety.py`: mapping function + explicit-override preservation
- `tests/contract/test_tool_annotations.py`: every classified tool (incl. gated) carries correct annotations; `health_check` exposes `readOnlyHint` on the public surface
- Preflight: `ruff` clean, `mypy` clean (209 files), 454 unit+contract tests pass. (14 integration e2e failures are environmental — a live Godot editor is running locally and those tests assert no editor; CI runs with none.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #220
