### PR TITLE
refactor(server): single-source the toolset protocol text (closes #230)

### DIFF
--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from fastmcp import FastMCP
 from fastmcp.prompts import Message
 
+from mcp_server.toolset_protocol import TOOLSET_PROTOCOL
+
 
 def register_prompts(mcp: FastMCP) -> None:
     """Register all workflow prompts on the server."""
@@ -34,66 +36,9 @@ def _register_toolset_discovery(mcp: FastMCP) -> None:
     )
     def toolset_discovery() -> list[Message]:
         """Teach the agent the toolset gating system so it never fails to find tools."""
-        return [
-            Message(
-                role="user",
-                content=(
-                    "You are working with a godot-mcp server that gates its tools into "
-                    "categories called 'toolsets'. Only 'core' (diagnostics, toolset "
-                    "management) and 'inspection' (read-only project/scene/node reading) "
-                    "are enabled by default. Every other capability is hidden until you "
-                    "explicitly enable it.\n\n"
-                    "WARNING: If you skip step 2, EVERY tool call will fail with "
-                    "'ToolError: unknown tool'. There is NO fallback.\n\n"
-                    "MANDATORY PROTOCOL — follow this order exactly:\n"
-                    "1. Call list_toolsets() to see what is available and which are enabled.\n"
-                    "2. Call enable_toolset(category) for EVERY category you plan to use.\n"
-                    "3. Only after enabling can you call the tools in that category.\n\n"
-                    "QUICK DECISION TREE — what do you want to do?\n"
-                    "- Build or edit a scene, add/move/remove nodes, change properties\n"
-                    "  → enable_toolset('scene_edit')\n"
-                    "- Write a GDScript, attach it to a node, fix parse errors\n"
-                    "  → enable_toolset('scripts')\n"
-                    "- Run the game live inside the editor (play, inspect, simulate input)\n"
-                    "  → enable_toolset('runtime') + enable_toolset('input')\n"
-                    "- Pause at a specific line, step through code, inspect stack variables\n"
-                    "  → enable_toolset('debugger') + enable_toolset('runtime')\n"
-                    "- Test that a node property meets an expectation\n"
-                    "  → enable_toolset('testing') + enable_toolset('runtime')\n"
-                    "- Apply changes to many nodes at once\n"
-                    "  → enable_toolset('batch') + enable_toolset('scene_edit')\n"
-                    "- Add physics bodies, collision shapes, tweak gravity/materials\n"
-                    "  → enable_toolset('physics') + enable_toolset('scene_edit')\n"
-                    "- Register autoloads, create custom resources\n"
-                    "  → enable_toolset('resources_edit')\n"
-                    "- Check performance, find bottlenecks\n"
-                    "  → enable_toolset('profiling')\n"
-                    "- Analyze circular dependencies, unused resources, signal flow\n"
-                    "  → enable_toolset('analysis')\n"
-                    "- Export a build for a target platform\n"
-                    "  → enable_toolset('export')\n"
-                    "- Import textures, audio, models\n"
-                    "  → enable_toolset('asset_import')\n\n"
-                    "Common toolsets you will need:\n"
-                    "- scene_edit  → create_node, set_node_property, attach_script, save_scene\n"
-                    "- scripts     → write_script, read_script, get_parse_errors\n"
-                    "- runtime     → run_and_capture (headless), play_scene (editor)\n"
-                    "- input       → simulate_action, simulate_key, play_input_sequence\n"
-                    "- testing     → assert_node_state, run_test_scenario\n"
-                    "- batch       → batch_set_property, find_nodes_by_type\n"
-                    "- physics     → setup_physics_body, setup_collision\n"
-                    "- resources_edit → register_autoload, create_resource\n\n"
-                    "SERVER VS ADDON BOUNDARY — critical to understand:\n"
-                    "- Some tools run in the Python server: list_toolsets, enable_toolset, "
-                    "get_server_info. These never send messages to Godot.\n"
-                    "- Most tools send commands to the Godot addon via a WebSocket bridge.\n"
-                    "- Server-side tools through the bridge = 'unknown tool'.\n"
-                    "- Addon tools before enable_toolset = 'unknown tool'.\n\n"
-                    "If you try to call a tool and get 'ToolError: unknown tool', the toolset "
-                    "is not enabled. Call enable_toolset first."
-                ),
-            ),
-        ]
+        # Single-sourced from mcp_server.toolset_protocol so this prompt and the
+        # server instructions can never drift apart (issue #230).
+        return [Message(role="user", content=TOOLSET_PROTOCOL)]
 
 
 def _register_build_scene(mcp: FastMCP) -> None:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -58,6 +58,7 @@ from mcp_server.tools.testing import register_testing
 from mcp_server.tools.theme_ui import register_theme_ui
 from mcp_server.tools.tilemap import register_tilemap
 from mcp_server.tools.visual_shader import register_visual_shader
+from mcp_server.toolset_protocol import SERVER_INSTRUCTIONS
 from mcp_server.toolsets import ToolsetManager, register_toolset_tools
 
 logger = logging.getLogger(__name__)
@@ -100,58 +101,7 @@ def create_server(
     mcp = FastMCP(
         SERVER_NAME,
         lifespan=lifespan,
-        instructions=(
-            "WARNING: You MUST follow the steps below or EVERY tool call will fail.\n\n"
-            "You are connected to a godot-mcp server that gates its tools into categories "
-            "called 'toolsets'. Only 'core' (diagnostics, toolset management) and "
-            "'inspection' (read-only project/scene/node reading) are enabled by default. "
-            "Every other capability is hidden until you explicitly enable it.\n\n"
-            "MANDATORY PROTOCOL:\n"
-            "1. Call get_server_info() for a full capability snapshot "
-            "(toolsets, bridge state, troubleshooting).\n"
-            "2. Call list_toolsets() to see what is available and which are enabled.\n"
-            "3. Call enable_toolset(category) for EVERY category you plan to use.\n"
-            "4. Only after enabling can you call the tools in that category.\n\n"
-            "QUICK DECISION TREE:\n"
-            "- Build/edit scenes, nodes, properties → scene_edit\n"
-            "- Write/attach scripts → scripts\n"
-            "- Run the game live (editor play session) → runtime + input\n"
-            "- Debug breakpoints, step, stack → debugger + runtime\n"
-            "- Test/assert node state → testing + runtime\n"
-            "- Batch changes to many nodes → batch + scene_edit\n"
-            "- Physics bodies/collision → physics + scene_edit\n"
-            "- Autoloads/custom resources → resources_edit\n"
-            "- Performance analysis → profiling\n"
-            "- Dependency/signal analysis → analysis\n"
-            "- Export builds → export\n"
-            "- Import assets → asset_import\n\n"
-            "SERVER VS ADDON BOUNDARY:\n"
-            "Some tools run in the Python server (list_toolsets, enable_toolset, "
-            "get_server_info) and never send messages to Godot. "
-            "Most tools send commands to the Godot addon via a WebSocket bridge. "
-            "If you get 'unknown tool', the toolset is not enabled OR you confused "
-            "server-side and addon tools.\n\n"
-            "Common toolsets you will need:\n"
-            "- scene_edit  → create_node, set_node_property, attach_script, save_scene\n"
-            "- scripts     → write_script, read_script, get_parse_errors\n"
-            "- runtime     → run_and_capture (headless), play_scene (editor)\n"
-            "- input       → simulate_action, simulate_key, play_input_sequence\n"
-            "- testing     → assert_node_state, run_test_scenario\n"
-            "- batch       → batch_set_property, find_nodes_by_type\n"
-            "- physics     → setup_physics_body, setup_collision\n"
-            "- resources_edit → register_autoload, create_resource\n"
-            "- asset_import → import_asset, create_material_from_textures\n\n"
-            "DOCUMENTATION:\n"
-            "- Tutorial (prompt-driven walkthrough): https://github.com/hybridindie/godot-mcp/blob/main/TUTORIAL.md\n"
-            "- Tool contracts (per-tool spec): https://github.com/hybridindie/godot-mcp/blob/main/docs/tool-contracts.md\n"
-            "- Architecture (bridge contract): https://github.com/hybridindie/godot-mcp/blob/main/docs/architecture.md\n\n"
-            "If you try to call a tool and get 'ToolError: unknown tool', the toolset "
-            "is not enabled. Call enable_toolset first.\n\n"
-            "This server exposes workflow prompts (toolset_discovery, build_scene, "
-            "play_test, script_edit, debug_scene, troubleshoot) and a diagnostics tool "
-            "(get_server_info) that returns tool counts, bridge state, active scene, "
-            "and common errors with fixes."
-        ),
+        instructions=SERVER_INSTRUCTIONS,
         website_url="https://github.com/hybridindie/godot-mcp",
         experimental_capabilities={
             "godot_mcp": {

--- a/mcp_server/toolset_protocol.py
+++ b/mcp_server/toolset_protocol.py
@@ -1,0 +1,90 @@
+"""Single source of truth for the toolset-gating protocol text (issue #230).
+
+This protocol — how the agent discovers and enables gated toolsets — was
+duplicated across the server ``instructions`` block and the ``toolset_discovery``
+prompt, risking drift and paying a per-session token cost. Both now compose from
+the constants here.
+"""
+
+from __future__ import annotations
+
+DOC_LINKS = (
+    "- Tutorial: https://github.com/hybridindie/godot-mcp/blob/main/TUTORIAL.md\n"
+    "- Tool contracts: https://github.com/hybridindie/godot-mcp/blob/main/docs/tool-contracts.md\n"
+    "- Architecture: https://github.com/hybridindie/godot-mcp/blob/main/docs/architecture.md"
+)
+
+GATING_INTRO = (
+    "You are connected to a godot-mcp server that gates its tools into categories "
+    "called 'toolsets'. Only 'core' (diagnostics, toolset management) and 'inspection' "
+    "(read-only project/scene/node reading) are enabled by default. Every other "
+    "capability is hidden until you explicitly enable it."
+)
+
+MANDATORY_PROTOCOL = (
+    "MANDATORY PROTOCOL — follow this order exactly:\n"
+    "1. Call get_server_info() for a full capability snapshot "
+    "(toolsets, bridge state, troubleshooting).\n"
+    "2. Call list_toolsets() to see what is available and which are enabled.\n"
+    "3. Call enable_toolset(category) for EVERY category you plan to use.\n"
+    "4. Only after enabling can you call the tools in that category.\n\n"
+    "WARNING: skip step 3 and EVERY gated tool call fails with "
+    "'ToolError: unknown tool'. There is NO fallback."
+)
+
+DECISION_TREE = (
+    "QUICK DECISION TREE — what do you want to do?\n"
+    "- Build/edit scenes, add/move/remove nodes, change properties → scene_edit\n"
+    "- Write/attach GDScript, fix parse errors → scripts\n"
+    "- Run the game live in the editor (play, inspect, simulate input) → runtime + input\n"
+    "- Pause/step/inspect stack at a line → debugger + runtime\n"
+    "- Assert a node property meets an expectation → testing + runtime\n"
+    "- Apply changes to many nodes at once → batch + scene_edit\n"
+    "- Physics bodies, collision shapes, gravity/materials → physics + scene_edit\n"
+    "- Register autoloads, create custom resources → resources_edit\n"
+    "- Performance, bottlenecks → profiling\n"
+    "- Circular deps, unused resources, signal flow → analysis\n"
+    "- Export a build for a platform → export\n"
+    "- Import textures/audio/models → asset_import"
+)
+
+COMMON_TOOLSETS = (
+    "Common toolsets you will need:\n"
+    "- scene_edit  → create_node, set_node_property, attach_script, save_scene\n"
+    "- scripts     → write_script, read_script, get_parse_errors\n"
+    "- runtime     → run_and_capture (headless), play_scene (editor)\n"
+    "- input       → simulate_action, simulate_key, play_input_sequence\n"
+    "- testing     → assert_node_state, run_test_scenario\n"
+    "- batch       → batch_set_property, find_nodes_by_type\n"
+    "- physics     → setup_physics_body, setup_collision\n"
+    "- resources_edit → register_autoload, create_resource\n"
+    "- asset_import → import_asset, create_material_from_textures"
+)
+
+SERVER_VS_ADDON = (
+    "SERVER VS ADDON BOUNDARY:\n"
+    "Some tools run in the Python server (list_toolsets, enable_toolset, "
+    "get_server_info) and never message Godot. Most tools send commands to the Godot "
+    "addon via a WebSocket bridge. 'ToolError: unknown tool' means the toolset is not "
+    "enabled OR you confused a server-side tool with an addon tool — call "
+    "enable_toolset first."
+)
+
+# The full gating protocol, shared verbatim by the server instructions and the
+# toolset_discovery prompt. Edit the parts above; both surfaces stay in sync.
+TOOLSET_PROTOCOL = "\n\n".join(
+    [GATING_INTRO, MANDATORY_PROTOCOL, DECISION_TREE, COMMON_TOOLSETS, SERVER_VS_ADDON]
+)
+
+# What the server advertises as its instructions on every session. Leads with the
+# protocol, then points at the workflow prompts and docs.
+SERVER_INSTRUCTIONS = (
+    "WARNING: You MUST follow the steps below or EVERY tool call will fail.\n\n"
+    + TOOLSET_PROTOCOL
+    + "\n\nDOCUMENTATION:\n"
+    + DOC_LINKS
+    + "\n\nThis server also exposes workflow prompts (toolset_discovery, build_scene, "
+    "play_test, script_edit, debug_scene, troubleshoot) and a diagnostics tool "
+    "(get_server_info) that returns tool counts, bridge state, active scene, and "
+    "common errors with fixes."
+)

--- a/tests/unit/test_toolset_protocol.py
+++ b/tests/unit/test_toolset_protocol.py
@@ -1,0 +1,45 @@
+"""Unit tests: the toolset protocol text is single-sourced (issue #230).
+
+The toolset-gating protocol was duplicated across the server ``instructions`` and
+the ``toolset_discovery`` prompt. Both must now compose from the same constants in
+``mcp_server.toolset_protocol`` so the text cannot drift between them.
+"""
+
+from __future__ import annotations
+
+from mcp_server.server import create_server
+from mcp_server.toolset_protocol import (
+    COMMON_TOOLSETS,
+    GATING_INTRO,
+    TOOLSET_PROTOCOL,
+)
+
+
+def test_server_instructions_use_shared_protocol() -> None:
+    server = create_server()
+    assert server.instructions is not None
+    # The shared protocol block is the source of the instructions' gating text.
+    assert GATING_INTRO in server.instructions
+    assert COMMON_TOOLSETS in server.instructions
+
+
+def test_toolset_discovery_prompt_uses_shared_protocol() -> None:
+    import asyncio
+
+    server = create_server()
+    result = asyncio.run(server.render_prompt("toolset_discovery"))
+    # Read the raw text (not the TextContent repr, which escapes newlines).
+    content = "\n".join(getattr(m.content, "text", str(m.content)) for m in result.messages)
+    # Same shared fragments appear verbatim in the prompt — single source.
+    assert GATING_INTRO in content
+    assert COMMON_TOOLSETS in content
+
+
+def test_shared_protocol_is_self_consistent() -> None:
+    # The composed protocol contains each of its parts (guards accidental drift in
+    # the join).
+    assert GATING_INTRO in TOOLSET_PROTOCOL
+    assert COMMON_TOOLSETS in TOOLSET_PROTOCOL
+    # And it still names the two calls the agent must make.
+    assert "list_toolsets" in TOOLSET_PROTOCOL
+    assert "enable_toolset" in TOOLSET_PROTOCOL


### PR DESCRIPTION
## Summary
The toolset-gating protocol text was duplicated across the ~50-line server `instructions` block (`server.py`) and the `toolset_discovery` prompt (`prompts/prompts.py`), with the same content drifting between them (3-step vs 4-step protocol, two decision-tree formats, near-identical "common toolsets" lists). This extracts the protocol into a single module, `mcp_server/toolset_protocol.py`, as composable constants:

- `GATING_INTRO`, `MANDATORY_PROTOCOL`, `DECISION_TREE`, `COMMON_TOOLSETS`, `SERVER_VS_ADDON`, `DOC_LINKS`
- `TOOLSET_PROTOCOL` — the joined block, used by the `toolset_discovery` prompt
- `SERVER_INSTRUCTIONS` — protocol + docs + workflow-prompt pointer, used by the server

Both surfaces now derive from the same source, so they cannot drift. The two protocol variants were converged onto one canonical form (4-step, leading with `get_server_info`).

## Acceptance criteria
- [x] One constant (`TOOLSET_PROTOCOL`) referenced by both the instructions and the prompt
- [x] Repetition trimmed (per-session instructions no longer carry a separate copy)
- [x] Less drift risk

## Test plan
- `tests/unit/test_toolset_protocol.py`: shared fragments (`GATING_INTRO`, `COMMON_TOOLSETS`) appear verbatim in both `server.instructions` and the rendered `toolset_discovery` prompt; protocol self-consistency.
- Existing `tests/contract/test_prompts_contract.py` still green (prompt mentions `list_toolsets`/`enable_toolset`).
- Preflight: `ruff` clean, `mypy` clean, 453 unit+contract tests pass, zero-skip clean.

## Notes / follow-up
- Scope limited to the two surfaces the issue names. The `debug_scene`/`troubleshoot` prompts also embed doc links in a slightly different format; folding those onto `DOC_LINKS` is a separate low-risk cleanup if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #230
