### PR TITLE
Remove dead permission_mode config and clarify approval mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ All configuration is optional and passed via environment variables:
 | `GODOT_MCP_GODOT_BIN` | auto-discovered | Godot executable for `run_and_capture` / `export_project` |
 | `GODOT_MCP_PROJECT_DIR` | connected editor's project | Project directory for runner, export, and analysis |
 | `GODOT_MCP_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) — JSON to stderr |
-| `GODOT_MCP_PERMISSION_MODE` | `ask` | Reserved. Currently unenforced; safety is via per-tool classes + `dry_run`/`confirm`. |
+| `GODOT_MCP_APPROVAL_WEBHOOK` | unset | Optional human-in-the-loop approval webhook for destructive tools (`ApprovalGate`) |
 
 ---
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -51,8 +51,11 @@ class ServerConfig(BaseModel):
 
     Transport defaults to ``stdio`` (the spec'd, auth-free local transport);
     ``http`` exposes the server over Streamable HTTP for clients that want a
-    long-lived shared server. ``permission_mode`` is plumbed here but enforced in
-    issue #14.
+    long-lived shared server.
+
+    There is no per-mode "permission" gate: safety is enforced by per-tool
+    ``safety_class`` + ``dry_run``/``confirm`` (issue #14), plus the optional
+    human-in-the-loop :class:`~mcp_server.safety.ApprovalGate` webhook below.
     """
 
     bridge: BridgeConfig = Field(default_factory=BridgeConfig)
@@ -60,7 +63,6 @@ class ServerConfig(BaseModel):
     host: str = DEFAULT_HTTP_HOST
     port: int = DEFAULT_HTTP_PORT
     log_level: str = "INFO"
-    permission_mode: str = "ask"
     # Runtime loop (issue #13): path to the Godot binary and the project directory.
     # Both optional — the binary is auto-discovered and the project dir falls back to
     # the connected editor's project.
@@ -82,7 +84,6 @@ class ServerConfig(BaseModel):
             host=os.environ.get("GODOT_MCP_HTTP_HOST", DEFAULT_HTTP_HOST),
             port=int(os.environ.get("GODOT_MCP_HTTP_PORT", DEFAULT_HTTP_PORT)),
             log_level=os.environ.get("GODOT_MCP_LOG_LEVEL", "INFO"),
-            permission_mode=os.environ.get("GODOT_MCP_PERMISSION_MODE", "ask"),
             godot_bin=os.environ.get("GODOT_MCP_GODOT_BIN"),
             godot_project_dir=os.environ.get("GODOT_MCP_PROJECT_DIR"),
             approval_webhook=os.environ.get("GODOT_MCP_APPROVAL_WEBHOOK"),

--- a/tests/unit/test_server_config.py
+++ b/tests/unit/test_server_config.py
@@ -36,3 +36,16 @@ def test_from_env_falls_back_to_stdio_on_unknown_transport(monkeypatch: pytest.M
     config = ServerConfig.from_env()
     # Unknown transports fall back to "stdio" rather than crashing.
     assert config.transport == "stdio"
+
+
+def test_no_dead_permission_mode_field() -> None:
+    # permission_mode was plumbed but never enforced; removed (issue #225).
+    # Approval is webhook-only via ApprovalGate. The field must not reappear as a
+    # misleading "permission gate" that does nothing.
+    assert "permission_mode" not in ServerConfig.model_fields
+
+
+def test_from_env_ignores_permission_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_PERMISSION_MODE", "deny")
+    config = ServerConfig.from_env()
+    assert not hasattr(config, "permission_mode")


### PR DESCRIPTION
### **User description**
## Summary
`ServerConfig.permission_mode` was read from `GODOT_MCP_PERMISSION_MODE` and plumbed through `config.py`, but **never enforced** anywhere — the docstring's "enforced in issue #14" was incomplete and implied a permission gate that does not exist. Actual gating is per-tool `safety_class` + `dry_run`/`confirm`, plus the optional `ApprovalGate` webhook.

Per the issue's recommendation, this **removes** the dead field rather than implementing a redundant gate:
- Drop the `permission_mode` field and its `from_env` read.
- Rewrite the `ServerConfig` docstring to state approval is `safety_class`/`dry_run`/`confirm` + the webhook-only `ApprovalGate`.
- Replace the misleading `GODOT_MCP_PERMISSION_MODE` README row with the real `GODOT_MCP_APPROVAL_WEBHOOK` row.

## Acceptance criteria
- [x] Dead/misleading config removed (or implemented) — removed
- [x] Documented that approval is webhook-only (`ApprovalGate`)

## Test plan
- `tests/unit/test_server_config.py`: `permission_mode` not in `model_fields`; `from_env` ignores `GODOT_MCP_PERMISSION_MODE`.
- Preflight: `ruff` clean, `mypy` clean, 183 unit tests pass. Only `config.py` and the README referenced the field (confirmed via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed dead `permission_mode` config field that was never enforced

- Updated documentation to clarify approval is webhook-only via `ApprovalGate`

- Added tests to ensure field is not present in config model or env parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ServerConfig"] -- "Remove permission_mode field" --> B["Config parsing"]
  B -- "Ignore GODOT_MCP_PERMISSION_MODE env" --> C["README updated"]
  C -- "Document ApprovalGate webhook only" --> D["Tests verify removal"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Remove dead permission_mode config field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/config.py

<ul><li>Removed <code>permission_mode</code> field from <code>ServerConfig</code> class definition<br> <li> Updated docstring to clarify safety enforcement is via tool-level <br><code>safety_class</code> and <code>dry_run</code>/<code>confirm</code><br> <li> Removed <code>permission_mode</code> from <code>from_env</code> parsing logic</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/235/files#diff-70c54c60ddd61d321160841d8d270dc00ca2c729e8f76114d4b66a2d1eb00769">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_server_config.py</strong><dd><code>Add tests for permission_mode removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_server_config.py

<ul><li>Added test to verify <code>permission_mode</code> is not in <br><code>ServerConfig.model_fields</code><br> <li> Added test to ensure <code>from_env</code> ignores <code>GODOT_MCP_PERMISSION_MODE</code> <br>environment variable<br> <li> Validates the field removal is effective and prevents regression</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/235/files#diff-c4c03f03b5a23b62e8a761f26437021d94ccd2da18f97f91158f3cd8dcdd0443">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect webhook-only approval mechanism</code>&nbsp; </dd></summary>
<hr>

README.md

<ul><li>Replaced <code>GODOT_MCP_PERMISSION_MODE</code> row with <code>GODOT_MCP_APPROVAL_WEBHOOK</code> <br>documentation<br> <li> Updated description to clarify approval is webhook-only via <br><code>ApprovalGate</code><br> <li> Removed misleading documentation about unenforced permission mode</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/235/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

Closes #225
