### PR TITLE
Pin fastmcp dependency to validated 3.x range to prevent breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
-    # The MCP framework (PrefectHQ/fastmcp). Server bootstrap lands in issue #4.
-    "fastmcp>=2.0",
+    # The MCP framework (PrefectHQ/fastmcp). Capped below 4.0: 2.x→3.x had breaking
+    # API changes and the server is validated on the 3.3 line (issue #228).
+    "fastmcp>=3.3,<4",
     # WebSocket transport for the addon/server bridge (issue #3).
     "websockets>=13.0",
     # Domain models and typed tool I/O (issue #7).

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -48,7 +48,7 @@ def test_fastmcp_pinned_below_major_4() -> None:
     assert fastmcp is not None, "fastmcp dependency missing from pyproject"
     spec = fastmcp.replace(" ", "")
     assert ">=3.3" in spec, f"fastmcp must floor at the validated 3.3 line, got {fastmcp!r}"
-    assert "<4" in spec, f"fastmcp must be capped below 4.0 to avoid a breaking major, got {fastmcp!r}"
+    assert "<4" in spec, f"fastmcp must cap below the next major (4.0), got {fastmcp!r}"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -39,6 +39,18 @@ def test_version_matches_pyproject() -> None:
     assert mcp_server.__version__ == pyproject["project"]["version"]
 
 
+def test_fastmcp_pinned_below_major_4() -> None:
+    # fastmcp 2.x→3.x had breaking API changes; the server is validated on 3.x.
+    # A clean resolve must not pull 4.x (issue #228) — require an explicit upper cap.
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    dependencies = pyproject["project"]["dependencies"]
+    fastmcp = next((d for d in dependencies if d.replace(" ", "").startswith("fastmcp")), None)
+    assert fastmcp is not None, "fastmcp dependency missing from pyproject"
+    spec = fastmcp.replace(" ", "")
+    assert ">=3.3" in spec, f"fastmcp must floor at the validated 3.3 line, got {fastmcp!r}"
+    assert "<4" in spec, f"fastmcp must be capped below 4.0 to avoid a breaking major, got {fastmcp!r}"
+
+
 @pytest.mark.parametrize(
     "module",
     ["mcp_server.tools", "mcp_server.resources", "mcp_server.prompts", "mcp_server.models"],

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.0" },
+    { name = "fastmcp", specifier = ">=3.3,<4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pypng", specifier = ">=0.20" },


### PR DESCRIPTION
### **User description**
## Summary
`fastmcp>=2.0` (installed 3.3.1) spans a major version with breaking 2.x→3.x API changes; a clean dependency resolve could pick an incompatible 4.x. Pin to the validated range:

```
fastmcp>=3.3,<4
```

`uv.lock` resolution is unchanged (still 3.3.1); the lock's recorded specifier is updated to match.

## Acceptance criteria
- [x] `fastmcp` floored at the validated minor and capped below the next major
- [x] Reproducible installs — no surprise breakage on a fresh resolve

## Test plan
- `tests/unit/test_smoke.py::test_fastmcp_pinned_below_major_4`: asserts the pyproject constraint floors at `>=3.3` and caps `<4` (guards the pin from regressing).
- `uv lock` re-resolved cleanly (158 packages); `fastmcp` stays 3.3.1.
- Preflight: 10 smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Pins fastmcp dependency to >=3.3,<4 to avoid breaking API changes

- Adds test to guard against regression of fastmcp version pin

- Ensures reproducible installs with validated dependency range

- Maintains compatibility with existing server functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml"] -- "Update fastmcp constraint" --> B["fastmcp>=3.3,<4"]
  C["test_smoke.py"] -- "Add test guard" --> D["test_fastmcp_pinned_below_major_4"]
  B -- "Prevent 4.x breakage" --> E["Reproducible installs"]
  D -- "Guard against regression" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Pin fastmcp to validated 3.x range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Replaced fastmcp dependency constraint from <code>>=2.0</code> to <code>>=3.3,<4</code><br> <li> Added comment explaining the reason for pinning below major version 4<br> <li> Addresses breaking API changes between fastmcp 2.x and 3.x</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/236/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_smoke.py</strong><dd><code>Add test to guard fastmcp version pin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_smoke.py

<ul><li>Added new test function <code>test_fastmcp_pinned_below_major_4</code><br> <li> Validates that fastmcp dependency is pinned below major version 4<br> <li> Ensures floor at >=3.3 and cap below <4<br> <li> Guards against accidental regression of the version pin</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/236/files#diff-008371c35537b64b848b5bf9bbbdde45d83123a288bf5e4b763733844a17bcb8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

Closes #228
