### PR TITLE
Add Pydantic Field constraints to tool inputs for improved validation

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -28,6 +28,10 @@ Every `@mcp.tool()`:
 - Validates inputs and checks preconditions **before** any side effect.
 - Is **delegation only** — no domain branching in the handler body.
 - Carries a `safety_class`.
+- **Bounds resource/safety-relevant numeric params** with the `Annotated[...]` aliases in
+  `mcp_server/constraints.py` (timeouts, sample/result counts, depths, delays, TileMap ids),
+  so absurd input is rejected before the bridge round-trip and the bounds show in the schema
+  (issue #221). Pass-through geometry/identifiers (coordinates, node/port ids) stay unbounded.
 - **Bounds large reads** (issue #222): list-shaped tools (`find_nodes_by_type`, `list_scripts`)
   paginate with `offset`/`limit` and report `total`/`returned`/`truncated`/`next_offset`;
   reads that can be huge (the scene tree, `godot://scene/tree`) are capped at

--- a/mcp_server/constraints.py
+++ b/mcp_server/constraints.py
@@ -1,0 +1,46 @@
+"""Reusable bounded parameter types for tool inputs (issue #221).
+
+Numeric tool params were unbounded, deferring all validation to the addon. These
+``Annotated`` aliases attach Pydantic ``Field`` bounds so bad input is rejected
+*before* the bridge round-trip and the bounds appear in the JSON schema the agent
+sees. Bounds are deliberately generous — they reject absurd/typo values (a
+negative timeout, a million samples), not legitimate use. Pass-through geometry
+and identifiers (coordinates, node/port ids, device/axis indices) are left
+unbounded on purpose: an artificial cap there would break valid Godot usage.
+
+Each alias carries only the constraint; the per-tool default stays at the call
+site, e.g. ``samples: Samples = DEFAULT_MONITOR_SAMPLES``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from mcp_server.defaults import DEFAULT_STRESS_MAX_ITERATIONS
+
+# --- timeouts (caps stop a stalled call from hanging indefinitely) ----------
+TimeoutSeconds = Annotated[float, Field(ge=0.1, le=3600.0)]
+TimeoutMs = Annotated[int, Field(ge=1, le=600_000)]
+
+# --- counts / limits on returned or generated items -------------------------
+Samples = Annotated[int, Field(ge=1, le=1000)]
+MaxResults = Annotated[int, Field(ge=1, le=10_000)]
+ParticleAmount = Annotated[int, Field(ge=0, le=1_000_000)]
+StressIterations = Annotated[int, Field(ge=1, le=DEFAULT_STRESS_MAX_ITERATIONS)]
+
+# --- tree traversal depth; -1 means "unbounded" (whole tree) ----------------
+MaxDepth = Annotated[int, Field(ge=-1, le=1000)]
+
+# --- inter-event delays in milliseconds -------------------------------------
+DelayMs = Annotated[int, Field(ge=0, le=600_000)]
+
+# --- TileMap / TileSet identifiers ------------------------------------------
+# source_id -1 is Godot's "empty/erase" sentinel; layer and alternative_tile are
+# non-negative indices. No upper cap — these are open-ended Godot ids.
+TileSourceId = Annotated[int, Field(ge=-1)]
+TileSourceIdOpt = Annotated[int | None, Field(ge=-1)]
+TileLayer = Annotated[int, Field(ge=0)]
+TileLayerOpt = Annotated[int | None, Field(ge=0)]
+TileAlternative = Annotated[int, Field(ge=0)]

--- a/mcp_server/tools/debug_workflow.py
+++ b/mcp_server/tools/debug_workflow.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
 from mcp_server.config import ServerConfig
+from mcp_server.constraints import TimeoutSeconds
 from mcp_server.debug_workflow import run_debug_workflow
 from mcp_server.models.debug_workflow import DebugWorkflowResult
 from mcp_server.runtime import Runner
@@ -26,7 +27,7 @@ def register_debug_workflow(
     @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
     async def debug_workflow(
         scene: str = "",
-        timeout_seconds: float = 5.0,
+        timeout_seconds: TimeoutSeconds = 5.0,
     ) -> DebugWorkflowResult:
         """Run a comprehensive debug check on the project and return a unified report.
 

--- a/mcp_server/tools/export.py
+++ b/mcp_server/tools/export.py
@@ -15,6 +15,7 @@ from fastmcp.exceptions import ToolError
 from mcp_server.bridge import Bridge
 from mcp_server.categories import EXPORT_TAG
 from mcp_server.config import ServerConfig
+from mcp_server.constraints import TimeoutSeconds
 from mcp_server.defaults import (
     DEFAULT_EXPORT_TIMEOUT_SECONDS,
 )
@@ -49,7 +50,7 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         preset: str,
         output_path: str,
         debug: bool = False,
-        timeout_seconds: float = DEFAULT_EXPORT_TIMEOUT_SECONDS,
+        timeout_seconds: TimeoutSeconds = DEFAULT_EXPORT_TIMEOUT_SECONDS,
         *,
         ctx: Context,
     ) -> ExportResult:

--- a/mcp_server/tools/input_sim.py
+++ b/mcp_server/tools/input_sim.py
@@ -17,6 +17,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import INPUT_TAG
+from mcp_server.constraints import DelayMs, TimeoutMs
 from mcp_server.defaults import (
     DEFAULT_INPUT_RECORDING_TIMEOUT_MS,
     DEFAULT_INPUT_STRENGTH,
@@ -119,7 +120,7 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=RUNTIME, tags=INPUT)
     async def play_input_sequence(
-        events: list[dict[str, Any]], delay_ms: int = 0
+        events: list[dict[str, Any]], delay_ms: DelayMs = 0
     ) -> SimInputResult:
         """Play a sequence of input events in order, ``delay_ms`` apart. Each event is a
         dict with ``type`` = "key" | "mouse" | "action" and that type's fields (as for
@@ -153,7 +154,7 @@ def register_input_sim(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=READ_ONLY, tags=INPUT)
     async def stop_recording(
-        timeout_ms: int = DEFAULT_INPUT_RECORDING_TIMEOUT_MS,
+        timeout_ms: TimeoutMs = DEFAULT_INPUT_RECORDING_TIMEOUT_MS,
     ) -> RecordingResult:
         """Stop recording and return the captured ``events`` (in the
         ``play_input_sequence`` format). Polls the addon up to ``timeout_ms`` for the

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import INSPECTION_TAG
+from mcp_server.constraints import MaxDepth
 from mcp_server.models.inspection import (
     ActiveScene,
     NodeInfo,
@@ -44,7 +45,7 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         return ActiveScene(**await route(bridge, "cmd_get_active_scene"))
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
-    async def get_scene_tree(max_depth: int = -1, lightweight: bool = False) -> SceneTree:
+    async def get_scene_tree(max_depth: MaxDepth = -1, lightweight: bool = False) -> SceneTree:
         """Get the open scene as a recursive tree of {name, type, path, script, children}.
 
         Each node carries an explicit scene-relative ``path`` ("." for the root,

--- a/mcp_server/tools/particles.py
+++ b/mcp_server/tools/particles.py
@@ -15,6 +15,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import PARTICLES_TAG
+from mcp_server.constraints import ParticleAmount
 from mcp_server.defaults import (
     DEFAULT_PARTICLE_AMOUNT,
     DEFAULT_PARTICLE_LIFETIME,
@@ -43,7 +44,7 @@ def register_particles(mcp: FastMCP, bridge: Bridge) -> None:
         parent_path: str,
         particles_type: str = "GPUParticles2D",
         name: str = "",
-        amount: int = DEFAULT_PARTICLE_AMOUNT,
+        amount: ParticleAmount = DEFAULT_PARTICLE_AMOUNT,
         lifetime: float = DEFAULT_PARTICLE_LIFETIME,
         properties: dict[str, Any] | None = None,
         dry_run: bool = False,

--- a/mcp_server/tools/profiling.py
+++ b/mcp_server/tools/profiling.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import PROFILING_TAG
+from mcp_server.constraints import TimeoutMs
 from mcp_server.defaults import (
     DEFAULT_PERF_MONITORS_TIMEOUT_MS,
 )
@@ -39,7 +40,7 @@ def register_profiling(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=READ_ONLY, tags=PROFILING)
     async def get_performance_monitors(
-        timeout_ms: int = DEFAULT_PERF_MONITORS_TIMEOUT_MS,
+        timeout_ms: TimeoutMs = DEFAULT_PERF_MONITORS_TIMEOUT_MS,
     ) -> GamePerformanceResult:
         """Read the *running* game's Performance monitors (same metrics, live) via the
         runtime probe. Requires a play session; if the probe isn't connected, returns

--- a/mcp_server/tools/project_fs.py
+++ b/mcp_server/tools/project_fs.py
@@ -13,6 +13,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import PROJECT_TAG
+from mcp_server.constraints import MaxDepth, MaxResults
 from mcp_server.defaults import (
     DEFAULT_SEARCH_MAX_RESULTS,
 )
@@ -33,7 +34,9 @@ def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
     """Register the project & filesystem tools."""
 
     @mcp.tool(meta=READ_ONLY, tags=PROJECT)
-    async def get_filesystem_tree(directory: str = "res://", max_depth: int = -1) -> FilesystemTree:
+    async def get_filesystem_tree(
+        directory: str = "res://", max_depth: MaxDepth = -1
+    ) -> FilesystemTree:
         """Get the project's file tree under ``directory`` ({name, path, type, children}).
         ``max_depth`` limits levels (-1 = unlimited, 0 = the directory only). Hidden
         entries (``.godot``, ``.git``, …) are skipped.
@@ -46,7 +49,7 @@ def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
         directory: str = "res://",
         name_glob: str = "",
         content: str = "",
-        max_results: int = DEFAULT_SEARCH_MAX_RESULTS,
+        max_results: MaxResults = DEFAULT_SEARCH_MAX_RESULTS,
     ) -> SearchResult:
         """Search ``directory`` recursively for files matching ``name_glob`` (e.g.
         "*.gd") and/or containing ``content``. ``truncated`` is true if capped at

--- a/mcp_server/tools/runtime.py
+++ b/mcp_server/tools/runtime.py
@@ -12,6 +12,7 @@ from fastmcp import Context, FastMCP
 from mcp_server.bridge import Bridge
 from mcp_server.categories import RUNTIME_TAG
 from mcp_server.config import ServerConfig
+from mcp_server.constraints import TimeoutSeconds
 from mcp_server.defaults import (
     DEFAULT_RUN_TIMEOUT_SECONDS,
 )
@@ -29,7 +30,7 @@ def register_runtime(
     @enforce_preconditions
     async def run_and_capture(
         scene: str | None = None,
-        timeout_seconds: float = DEFAULT_RUN_TIMEOUT_SECONDS,
+        timeout_seconds: TimeoutSeconds = DEFAULT_RUN_TIMEOUT_SECONDS,
         *,
         ctx: Context,
     ) -> RunCaptureResult:

--- a/mcp_server/tools/runtime_inspect.py
+++ b/mcp_server/tools/runtime_inspect.py
@@ -14,6 +14,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import RUNTIME_TAG
+from mcp_server.constraints import Samples, TimeoutMs
 from mcp_server.defaults import (
     DEFAULT_MONITOR_SAMPLES,
     DEFAULT_RUNTIME_INSPECT_TIMEOUT_MS,
@@ -34,7 +35,7 @@ def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
     async def monitor_property(
-        node_path: str, property: str, samples: int = DEFAULT_MONITOR_SAMPLES
+        node_path: str, property: str, samples: Samples = DEFAULT_MONITOR_SAMPLES
     ) -> MonitorResult:
         """Start watching ``property`` on the running game's node at ``node_path`` (an
         absolute path from ``get_game_scene_tree``, e.g. "/root/Main/Player"). The probe
@@ -65,7 +66,7 @@ def register_runtime_inspect(mcp: FastMCP, bridge: Bridge) -> None:
         name_contains: str = "",
         class_filter: str = "",
         visible_only: bool = False,
-        timeout_ms: int = DEFAULT_RUNTIME_INSPECT_TIMEOUT_MS,
+        timeout_ms: TimeoutMs = DEFAULT_RUNTIME_INSPECT_TIMEOUT_MS,
     ) -> UiElementsResult:
         """Locate live UI (Control) nodes in the running game, each with its path, class,
         visibility, global ``rect`` (use it with ``simulate_mouse`` to click), and ``text``

--- a/mcp_server/tools/testing.py
+++ b/mcp_server/tools/testing.py
@@ -18,13 +18,13 @@ from fastmcp.exceptions import ToolError
 from mcp_server.bridge import Bridge
 from mcp_server.categories import TESTING_TAG
 from mcp_server.config import ServerConfig
+from mcp_server.constraints import DelayMs, StressIterations, TimeoutMs, TimeoutSeconds
 from mcp_server.defaults import (
     DEFAULT_ASSERT_NODE_TIMEOUT_MS,
     DEFAULT_PROBE_POLL_INTERVAL_SECONDS,
     DEFAULT_STRESS_BUFFER_SECONDS,
     DEFAULT_STRESS_DELAY_MS,
     DEFAULT_STRESS_ITERATIONS,
-    DEFAULT_STRESS_MAX_ITERATIONS,
     DEFAULT_STRESS_MAX_WAIT_SECONDS,
     DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
     DEFAULT_TEST_SETTLE_MS,
@@ -44,9 +44,6 @@ from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError
 from mcp_server.tools._route import poll_ready, route
 
 TESTING = {TESTING_TAG}
-_MAX_STRESS_ITERATIONS = DEFAULT_STRESS_MAX_ITERATIONS
-
-
 async def _read_live_value(
     bridge: Bridge, node_path: str, prop: str, timeout_ms: int
 ) -> tuple[Any, str]:
@@ -107,7 +104,7 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
     @mcp.tool(meta=RUNTIME, tags=TESTING)
     async def run_tests(
         test_dir: str = "res://test",
-        timeout_seconds: float = DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
+        timeout_seconds: TimeoutSeconds = DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
         *,
         ctx: Context,
     ) -> RunTestsResult:
@@ -151,7 +148,7 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         property: str,
         expected: Any,
         op: str = "==",
-        timeout_ms: int = DEFAULT_ASSERT_NODE_TIMEOUT_MS,
+        timeout_ms: TimeoutMs = DEFAULT_ASSERT_NODE_TIMEOUT_MS,
     ) -> AssertionResult:
         """Assert that a *running* game node's ``property`` satisfies ``op`` vs ``expected``
         (==, !=, <, <=, >, >=, contains, approx). Reads the live value via the runtime
@@ -168,8 +165,8 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         scene: str = "",
         events: list[dict[str, Any]] | None = None,
         assertions: list[dict[str, Any]] | None = None,
-        setup_ms: int = DEFAULT_TEST_SETUP_MS,
-        settle_ms: int = DEFAULT_TEST_SETTLE_MS,
+        setup_ms: DelayMs = DEFAULT_TEST_SETUP_MS,
+        settle_ms: DelayMs = DEFAULT_TEST_SETTLE_MS,
         stop_after: bool = True,
     ) -> ScenarioResult:
         """Run a play-test: play ``scene`` (or the main scene), wait ``setup_ms`` for the
@@ -203,18 +200,16 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
 
     @mcp.tool(meta=RUNTIME, tags=TESTING)
     async def run_stress_test(
-        iterations: int = DEFAULT_STRESS_ITERATIONS,
+        iterations: StressIterations = DEFAULT_STRESS_ITERATIONS,
         actions: list[str] | None = None,
         seed: int = 0,
-        delay_ms: int = DEFAULT_STRESS_DELAY_MS,
+        delay_ms: DelayMs = DEFAULT_STRESS_DELAY_MS,
     ) -> StressTestResult:
         """Fuzz the *running* game with ``iterations`` random input events drawn from
         ``actions`` (key names / input-map actions / "click"; a sensible default pool if
         omitted), ``seed`` for reproducibility. Reports whether the game survived (still
         playing afterward). Requires a play session + probe.
         """
-        if iterations < 1 or iterations > _MAX_STRESS_ITERATIONS:
-            raise ToolError(f"iterations must be in 1..{_MAX_STRESS_ITERATIONS}.")
         events = random_input_events(iterations, actions, seed)
         await route(bridge, "cmd_play_input_sequence", {"events": events, "delay_ms": delay_ms})
         # Give the sequence time to play out, then check the game is still alive.

--- a/mcp_server/tools/tilemap.py
+++ b/mcp_server/tools/tilemap.py
@@ -13,6 +13,13 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import TILEMAP_TAG
+from mcp_server.constraints import (
+    TileAlternative,
+    TileLayer,
+    TileLayerOpt,
+    TileSourceId,
+    TileSourceIdOpt,
+)
 from mcp_server.models.tilemap import (
     TileCellResult,
     TileClearResult,
@@ -58,10 +65,10 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
     async def tilemap_set_cell(
         node_path: str,
         coords: list[int],
-        source_id: int = -1,
+        source_id: TileSourceId = -1,
         atlas_coords: list[int] | None = None,
-        alternative_tile: int = 0,
-        layer: int = 0,
+        alternative_tile: TileAlternative = 0,
+        layer: TileLayer = 0,
         dry_run: bool = False,
     ) -> TileCellResult:
         """Set the tile at grid ``coords`` ``[x, y]`` to ``source_id`` +
@@ -92,10 +99,10 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
     async def tilemap_fill_rect(
         node_path: str,
         rect: list[int],
-        source_id: int = -1,
+        source_id: TileSourceId = -1,
         atlas_coords: list[int] | None = None,
-        alternative_tile: int = 0,
-        layer: int = 0,
+        alternative_tile: TileAlternative = 0,
+        layer: TileLayer = 0,
         dry_run: bool = False,
     ) -> TileFillResult:
         """Fill the rectangle ``rect`` ``[x, y, w, h]`` of cells with the same tile
@@ -123,7 +130,9 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
         )
 
     @mcp.tool(meta=READ_ONLY, tags=TILEMAP)
-    async def tilemap_get_cell(node_path: str, coords: list[int], layer: int = 0) -> TileGetResult:
+    async def tilemap_get_cell(
+        node_path: str, coords: list[int], layer: TileLayer = 0
+    ) -> TileGetResult:
         """Read the tile at grid ``coords`` ``[x, y]``: returns ``source_id``,
         ``atlas_coords``, ``alternative_tile``, and ``empty`` (true when no tile).
         ``layer`` applies to multi-layer TileMap only. Errors (RESOURCE_NOT_FOUND /
@@ -135,7 +144,7 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
     @mcp.tool(meta=MUTATING, tags=TILEMAP)
     @enforce_preconditions
     async def tilemap_clear(
-        node_path: str, layer: int | None = None, dry_run: bool = False
+        node_path: str, layer: TileLayerOpt = None, dry_run: bool = False
     ) -> TileClearResult:
         """Clear a layer's cells: for a multi-layer TileMap the given ``layer`` (default
         0), for a TileMapLayer the whole node. Undoable — the prior cells are restored
@@ -192,7 +201,7 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
         region_size: list[int],
         node_path: str = "",
         tileset_path: str = "",
-        source_id: int | None = None,
+        source_id: TileSourceIdOpt = None,
         dry_run: bool = False,
     ) -> TileSetSourceResult:
         """Add an atlas source (a texture sliced into a tile grid) to a TileSet, then
@@ -231,7 +240,7 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
     @mcp.tool(meta=MUTATING, tags=TILEMAP)
     @enforce_preconditions
     async def create_tile(
-        source_id: int,
+        source_id: TileSourceId,
         atlas_coords: list[int],
         node_path: str = "",
         tileset_path: str = "",

--- a/tests/contract/test_input_constraints.py
+++ b/tests/contract/test_input_constraints.py
@@ -1,0 +1,71 @@
+"""Contract tests: numeric tool inputs carry Pydantic Field bounds (issue #221).
+
+Unbounded numeric params deferred all validation to the addon. These tests pin
+that the resource/safety-relevant numeric params declare a lower bound (and, where
+meaningful, an upper bound) in the JSON schema the agent sees — across the whole
+tool surface, including toolset-gated tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+
+from mcp_server.server import create_server
+
+# Params that must be bounded wherever they appear (a lower bound at minimum).
+BOUNDED_PARAMS = {
+    "samples",
+    "max_depth",
+    "timeout_seconds",
+    "timeout_ms",
+    "max_results",
+    "delay_ms",
+    "setup_ms",
+    "settle_ms",
+    "iterations",
+    "amount",
+    "source_id",
+    "layer",
+    "alternative_tile",
+}
+
+
+def _numeric_leaf_has_minimum(schema: dict[str, Any]) -> bool:
+    """A numeric param schema declares a minimum, allowing for ``int | None`` (anyOf)."""
+    candidates = [schema, *schema.get("anyOf", [])]
+    numeric = [c for c in candidates if c.get("type") in ("integer", "number")]
+    if not numeric:
+        return True  # not a numeric leaf — not our concern
+    return all("minimum" in c for c in numeric)
+
+
+def test_targeted_numeric_params_declare_bounds() -> None:
+    server = create_server()
+    import asyncio
+
+    tools = asyncio.run(server._list_tools())
+    unbounded: list[str] = []
+    checked = 0
+    for tool in tools:
+        props = (tool.parameters or {}).get("properties", {})
+        for name, schema in props.items():
+            if name not in BOUNDED_PARAMS:
+                continue
+            checked += 1
+            if not _numeric_leaf_has_minimum(schema):
+                unbounded.append(f"{tool.name}.{name}")
+    assert checked > 0, "no targeted params found — test wiring is broken"
+    assert not unbounded, f"unbounded numeric params: {sorted(unbounded)}"
+
+
+async def test_out_of_range_rejected_before_bridge() -> None:
+    # get_scene_tree is in the default-on `inspection` toolset; an out-of-range
+    # max_depth must be rejected by the server schema, not sent to the addon.
+    server: FastMCP = create_server()
+    async with Client(server) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("get_scene_tree", {"max_depth": -5})

--- a/tests/contract/test_input_constraints.py
+++ b/tests/contract/test_input_constraints.py
@@ -34,13 +34,18 @@ BOUNDED_PARAMS = {
 }
 
 
-def _numeric_leaf_has_minimum(schema: dict[str, Any]) -> bool:
-    """A numeric param schema declares a minimum, allowing for ``int | None`` (anyOf)."""
+# Params that carry an explicit upper bound by design. TileMap ids are open-ended
+# Godot identifiers and intentionally have only a lower bound, so they are excluded.
+UPPER_BOUNDED_PARAMS = BOUNDED_PARAMS - {"source_id", "layer", "alternative_tile"}
+
+
+def _numeric_leaf_has(schema: dict[str, Any], key: str) -> bool:
+    """A numeric param schema declares ``key`` (minimum/maximum), allowing ``int | None``."""
     candidates = [schema, *schema.get("anyOf", [])]
     numeric = [c for c in candidates if c.get("type") in ("integer", "number")]
     if not numeric:
         return True  # not a numeric leaf — not our concern
-    return all("minimum" in c for c in numeric)
+    return all(key in c for c in numeric)
 
 
 def test_targeted_numeric_params_declare_bounds() -> None:
@@ -48,7 +53,8 @@ def test_targeted_numeric_params_declare_bounds() -> None:
     import asyncio
 
     tools = asyncio.run(server._list_tools())
-    unbounded: list[str] = []
+    missing_min: list[str] = []
+    missing_max: list[str] = []
     checked = 0
     for tool in tools:
         props = (tool.parameters or {}).get("properties", {})
@@ -56,10 +62,14 @@ def test_targeted_numeric_params_declare_bounds() -> None:
             if name not in BOUNDED_PARAMS:
                 continue
             checked += 1
-            if not _numeric_leaf_has_minimum(schema):
-                unbounded.append(f"{tool.name}.{name}")
+            if not _numeric_leaf_has(schema, "minimum"):
+                missing_min.append(f"{tool.name}.{name}")
+            # Upper-bounded params must also cap the high end (guards a dropped ``le=``).
+            if name in UPPER_BOUNDED_PARAMS and not _numeric_leaf_has(schema, "maximum"):
+                missing_max.append(f"{tool.name}.{name}")
     assert checked > 0, "no targeted params found — test wiring is broken"
-    assert not unbounded, f"unbounded numeric params: {sorted(unbounded)}"
+    assert not missing_min, f"params with no minimum: {sorted(missing_min)}"
+    assert not missing_max, f"upper-bounded params with no maximum: {sorted(missing_max)}"
 
 
 async def test_out_of_range_rejected_before_bridge() -> None:


### PR DESCRIPTION
### **User description**
## Summary
No tool used Pydantic `Field` constraints — numeric params were unbounded and all validation was deferred to the addon. This adds `mcp_server/constraints.py` with reusable `Annotated[...]` aliases and applies them across the tool surface so bad numeric input is rejected **before** the bridge round-trip and the bounds appear in the JSON schema the agent sees.

**Aliases:** `TimeoutSeconds` (0.1–3600), `TimeoutMs` (1–600k), `Samples` (1–1000), `MaxResults` (1–10k), `MaxDepth` (-1–1000), `DelayMs` (0–600k), `ParticleAmount` (0–1M), `StressIterations` (1–`DEFAULT_STRESS_MAX_ITERATIONS`), and TileMap id types (`TileSourceId` ≥-1, `TileLayer`/`TileAlternative` ≥0, plus `…Opt` variants for `int | None`).

**Applied to 28 params across 11 tool files:** `get_scene_tree`/`get_filesystem_tree` (max_depth), `monitor_property` (samples), `search_files` (max_results), `run_tests`/`run_and_capture`/`export_project`/`debug_workflow` (timeout_seconds), `assert_node_state`/`find_ui_elements`/`get_performance_monitors`/`stop_recording` (timeout_ms), `run_test_scenario` (setup_ms/settle_ms), `run_stress_test` (iterations/delay_ms), `play_input_sequence` (delay_ms), `create_particles` (amount), and the `tilemap_*` / tileset tools (source_id/layer/alternative_tile).

Replaces `testing.py`'s manual `iterations` range check with the declarative `StressIterations` bound. **Scope note:** pass-through geometry and identifiers (coordinates, node/port ids, device/axis indices, track/time/easing) are intentionally left unbounded — an artificial cap there would break valid Godot usage.

## Acceptance criteria
- [x] Numeric params bounded via `Annotated[int/float, Field(ge=…, le=…)]`
- [x] `timeout_seconds`, `samples`, `max_depth` (and siblings) bounded
- [x] Bad input rejected before the bridge; bounds enrich the schema

## Test plan
- `tests/contract/test_input_constraints.py`: every targeted numeric param (across all tools, incl. gated + `int|None`) declares a lower bound; an out-of-range `get_scene_tree(max_depth=-5)` raises `ToolError` before the bridge.
- Preflight: `ruff` clean, `mypy` clean (210 files), 452 unit+contract tests pass, zero-skip clean.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Introduces Pydantic Field constraints for numeric tool inputs

- Binds timeouts, counts, depths, delays, and TileMap identifiers with bounds

- Replaces manual validation with declarative constraints in 28 params

- Adds contract tests to verify schema bounds and input rejection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mcp_server/constraints.py"] -- "defines bounded types" --> B["tool files"]
  B -- "apply constraints" --> C["JSON schema bounds"]
  B -- "reject bad input" --> D["before bridge round-trip"]
  E["contract tests"] -- "verify bounds" --> F["schema validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>constraints.py</strong><dd><code>Add reusable bounded parameter types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-ee33543a7cd027739e78d6d8cc134dd4e1507cda59d83591aedf8bdcbcac36ab">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>debug_workflow.py</strong><dd><code>Apply TimeoutSeconds constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-0f40dffb3f1c972baa92b768d39b208f8d356707d516b55655f11a785c4f3a9b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.py</strong><dd><code>Apply TimeoutSeconds constraint to export_project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-7fdf0f2a3b9ea7e0e827480c3039e776a04b6d0eff503f42d6b7f3b7ff782d82">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_sim.py</strong><dd><code>Apply DelayMs and TimeoutMs constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-480b738d49c20af87fc54889e264af8e4fb85b998349d87073ad691cada6f077">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspection.py</strong><dd><code>Apply MaxDepth constraint to get_scene_tree</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-eaaefb58a15b52cc64457889aff9fdfa9a10aadebf62c85b676e43375f167bf0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particles.py</strong><dd><code>Apply ParticleAmount constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-a38f7e81286d0e7bc3ab0a8a7090f15827b73ea80c02b5c00bafb0934d764c47">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>profiling.py</strong><dd><code>Apply TimeoutMs constraint to get_performance_monitors</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-4845757c6116b83d1942121fce144374ed1c4e2690c823fcc1a45b148990ffab">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>project_fs.py</strong><dd><code>Apply MaxDepth and MaxResults constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-57f51063bdf8edff1bc3223daba69188202b052640f5b7eff8a1886e12cbffec">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong><dd><code>Apply TimeoutSeconds constraint to run_and_capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-732d0b7bb10bc98d244ce2b5bc6406a44159f04240b67931bbd851092977c359">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_inspect.py</strong><dd><code>Apply Samples and TimeoutMs constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-d333b921382e4410749eae74fc0c957ae00abf96b0499e0e80549a87832ea484">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>testing.py</strong><dd><code>Apply DelayMs, StressIterations, TimeoutMs, TimeoutSeconds constraints</code></dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-d58b2175c7e4752c6baa3075834a974044f18a0521c3755ed122e2f9adf0b930">+7/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tilemap.py</strong><dd><code>Apply TileMap ID constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-35e6aaf5902029283267d1e40814fb097eee14a34683f10e21099f82de522199">+19/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_input_constraints.py</strong><dd><code>Add contract tests for input bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-06546e5619830575eb8c85cf3690710fa2827a39e45ab4c6df17043e50e7cbb9">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document constraint usage in tool contracts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/237/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

