### PR TITLE
docs(tools): document accepted shapes for value: Any setters (closes #229)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -34,6 +34,26 @@ Every `@mcp.tool()`:
 The addon handler is `cmd_<verb>_<noun>`; the matching MCP tool drops the `cmd_` prefix
 (`cmd_create_node` ⇄ `create_node`). All domain/data fields are `snake_case`.
 
+### Value shapes
+
+Polymorphic `value: Any` setters (`set_node_property`, `set_setting`,
+`set_resource_property`, `batch_set_property`, `cross_scene_set_property`,
+`insert_keyframe`, `set_shader_param`, `set_shader_node_param`) accept JSON that the
+addon coerces to the target Godot type (`type_coerce.gd`, the single source of truth).
+The accepted shapes:
+
+| Godot type | Accepted JSON | Example |
+|------------|---------------|---------|
+| `Vector2` / `Vector2i` | `{"x":…,"y":…}` or `[x, y]` or `"Vector2(x, y)"` | `{"x": 100, "y": 64}` |
+| `Vector3` / `Vector3i` | `{"x":…,"y":…,"z":…}` or `[x, y, z]` | `{"x": 1, "y": 2, "z": 3}` |
+| `Color` | `{"r":…,"g":…,"b":…,"a":…}` or hex string | `"#ff0000"` / `{"r":1,"g":0,"b":0,"a":1}` |
+| `Rect2` / `Rect2i` | `{"position":{x,y},"size":{x,y}}` or `"Rect2(x, y, w, h)"` | `{"position":{"x":0,"y":0},"size":{"x":4,"y":5}}` |
+| `NodePath` / `StringName` | string | `"Player/Sprite2D"` |
+| `int` / `float` / `bool` / `String` | the primitive as-is | `42`, `1.5`, `true`, `"hi"` |
+
+The addon coercion is the fallback: a string like `"Vector2(100, 200)"` or a bare array
+also works for vectors. When in doubt, the dict form is the most explicit.
+
 ### Safety classes
 
 Every tool is tagged with exactly one:

--- a/mcp_server/tools/animation.py
+++ b/mcp_server/tools/animation.py
@@ -90,6 +90,10 @@ def register_animation(mcp: FastMCP, bridge: Bridge) -> None:
     ) -> KeyframeResult:
         """Insert a keyframe on ``track`` at ``time`` with ``value`` (Godot string
         forms like "Vector2(10, 20)" are accepted). ``easing`` is the key transition.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         await require_node_exists(bridge, node_path)
         params = {

--- a/mcp_server/tools/batch.py
+++ b/mcp_server/tools/batch.py
@@ -57,6 +57,10 @@ def register_batch(mcp: FastMCP, bridge: Bridge) -> None:
         action. Target by explicit ``node_paths`` or by ``node_type`` (all matching nodes).
         Nodes lacking the property are reported in ``skipped``. ``dry_run`` returns the plan
         (applied/skipped) without changing anything.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         await require_active_scene(bridge)
         params: dict[str, Any] = {"property": property, "value": value, "dry_run": dry_run}
@@ -79,6 +83,10 @@ def register_batch(mcp: FastMCP, bridge: Bridge) -> None:
         ``scenes`` (``res://*.tscn`` files), editing them on disk and re-scanning. The
         currently-edited scene is skipped (reported as an error). Each scene's result lists
         the ``modified`` count and any ``error``. ``dry_run`` reports counts without saving.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         params = {
             "scenes": scenes,

--- a/mcp_server/tools/project_fs.py
+++ b/mcp_server/tools/project_fs.py
@@ -71,6 +71,10 @@ def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
     async def set_setting(name: str, value: Any, dry_run: bool = False) -> SetSettingResult:
         """Set a project setting and persist it. Coerced to the setting's existing type
         when it already exists. Not undo-tracked (it writes project settings).
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         params = {"name": name, "value": value}
         preview = {"name": name, "value": value, "set": False}

--- a/mcp_server/tools/resource_files.py
+++ b/mcp_server/tools/resource_files.py
@@ -60,6 +60,10 @@ def register_resource_files(mcp: FastMCP, bridge: Bridge) -> None:
     ) -> SetResourcePropertyResult:
         """Set a property on the resource file at ``resource_path`` and re-save it.
         Reversible via the editor's undo.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         params = {"resource_path": resource_path, "property": property, "value": value}
         preview = {"resource_path": resource_path, "property": property, "value": value}

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -80,6 +80,10 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         ``param_type`` coerces ``value``: float / int / bool / vector2 / vector3 /
         vector4 / color (omit to infer — number/bool as-is, ``[x,y,z]`` → vector,
         HTML string → color). The node must have a ShaderMaterial assigned.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "name": name, "value": value, "param_type": param_type}

--- a/mcp_server/tools/visual_shader.py
+++ b/mcp_server/tools/visual_shader.py
@@ -129,6 +129,10 @@ def register_visual_shader(mcp: FastMCP, bridge: Bridge) -> None:
         """Set ``property`` on the node identified by ``node_id`` in the
         VisualShader at ``shader_path``.  Values are coerced by the addon to
         the property's declared Godot type.
+        ``value`` accepts JSON for the target Godot type — Vector2/3 as
+        ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
+        ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
+        as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
         """
         params: dict[str, Any] = {
             "shader_path": shader_path,

--- a/tests/contract/test_value_shapes.py
+++ b/tests/contract/test_value_shapes.py
@@ -1,0 +1,42 @@
+"""Contract test: polymorphic ``value: Any`` setters document accepted shapes (issue #229).
+
+Godot's value types are polymorphic (Vector2/Color/NodePath/…); the agent gets no
+schema hint from ``value: Any``. Each setter's docstring must spell out the accepted
+JSON shapes with concrete examples so first-try calls aren't malformed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp_server.server import create_server
+
+# Every tool that takes a polymorphic ``value: Any``.
+VALUE_SETTERS = {
+    "set_setting",
+    "set_shader_param",
+    "set_shader_node_param",
+    "set_node_property",
+    "batch_set_property",
+    "cross_scene_set_property",
+    "insert_keyframe",
+    "set_resource_property",
+}
+
+# Concrete shape markers the docstring must mention to actually guide the agent.
+REQUIRED_MARKERS = ("Vector2", "Color", "NodePath")
+
+
+def test_value_setters_document_accepted_shapes() -> None:
+    server = create_server()
+    tools = {t.name: t for t in asyncio.run(server._list_tools())}
+
+    missing_tools = VALUE_SETTERS - set(tools)
+    assert not missing_tools, f"setter tools not found: {sorted(missing_tools)}"
+
+    offenders: list[str] = []
+    for name in VALUE_SETTERS:
+        doc = tools[name].description or ""
+        if not all(marker in doc for marker in REQUIRED_MARKERS):
+            offenders.append(name)
+    assert not offenders, f"setters missing value-shape docs: {sorted(offenders)}"


### PR DESCRIPTION
## Summary
The polymorphic `value: Any` setters gave the agent no schema hint for Godot's value types (Vector2/Color/NodePath/Rect2/…). This documents the accepted JSON shapes:

- **Canonical reference:** a new `### Value shapes` table in `docs/tool-contracts.md`, sourced from the addon's `type_coerce.gd` (the single source of truth for coercion).
- **Per-setter docstrings:** a compact accepted-shapes note added to the 7 setters that lacked it (`set_setting`, `set_resource_property`, `batch_set_property`, `cross_scene_set_property`, `insert_keyframe`, `set_shader_param`, `set_shader_node_param`). `set_node_property` already documented them.

Kept addon coercion as the fallback (string forms like `"Vector2(100, 200)"` and bare arrays still work). Took the docstring route over a typed union — Godot's value space is too polymorphic to model precisely without losing the coercion flexibility.

## Acceptance criteria
- [x] Accepted shapes documented with concrete examples (Vector2 `{"x":..,"y":..}`, Color, NodePath as string)
- [x] Addon coercion preserved as fallback

## Test plan
- `tests/contract/test_value_shapes.py`: every `value: Any` setter's description mentions concrete shape markers (`Vector2`, `Color`, `NodePath`).
- Preflight: `ruff` clean, `mypy` clean, 451 unit+contract tests pass.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)