### PR TITLE
Enhance long-running tools with FastMCP Context for progress/logging

### DIFF
--- a/mcp_server/tools/export.py
+++ b/mcp_server/tools/export.py
@@ -9,7 +9,7 @@ see the architecture note there), so it's `runtime` and uses a generous timeout.
 
 from __future__ import annotations
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
@@ -50,6 +50,8 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         output_path: str,
         debug: bool = False,
         timeout_seconds: float = DEFAULT_EXPORT_TIMEOUT_SECONDS,
+        *,
+        ctx: Context,
     ) -> ExportResult:
         """Export the project with the named ``preset`` to ``output_path`` (relative paths
         resolve against the project dir). ``debug`` does a debug export. Runs Godot headless
@@ -66,8 +68,17 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         if preset not in names:
             raise ToolError(f"No export preset named '{preset}'. Available: {names}.")
         project_dir = await resolve_project_dir(bridge, config)
+        await ctx.info(
+            f"Exporting preset '{preset}' → {output_path} (timeout {timeout_seconds:g}s)…"
+        )
+        await ctx.report_progress(0, 1)
         run = await runner.export(project_dir, preset, output_path, debug, float(timeout_seconds))
+        await ctx.report_progress(1, 1)
         summary = summarize_run(run)
+        await ctx.info(
+            f"Export finished: exit={summary.exit_code}, "
+            f"{len(summary.errors)} error(s), {len(summary.warnings)} warning(s)"
+        )
         return ExportResult(
             exported=summary.exit_code == 0 and not summary.timed_out,
             preset=preset,

--- a/mcp_server/tools/navigation.py
+++ b/mcp_server/tools/navigation.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import NAVIGATION_TAG
@@ -86,7 +86,9 @@ def register_navigation(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=MUTATING, tags=NAVIGATION)
     @enforce_preconditions
-    async def bake_navigation_mesh(node_path: str, dry_run: bool = False) -> BakeNavigationResult:
+    async def bake_navigation_mesh(
+        node_path: str, dry_run: bool = False, *, ctx: Context
+    ) -> BakeNavigationResult:
         """Bake the navigation mesh/polygon for the NavigationRegion2D/3D at
         ``node_path`` from the scene geometry (synchronous). The region must have a
         navmesh resource assigned (``setup_navigation_region`` creates one).
@@ -94,9 +96,16 @@ def register_navigation(mcp: FastMCP, bridge: Bridge) -> None:
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path}
         preview = {"node_path": node_path, "baked": False}
-        return await run_or_preview(
+        if not dry_run:
+            await ctx.info(f"Baking navigation mesh for {node_path}…")
+            await ctx.report_progress(0, 1)
+        result = await run_or_preview(
             dry_run, BakeNavigationResult, preview, bridge, "cmd_bake_navigation_mesh", params
         )
+        if not dry_run:
+            await ctx.report_progress(1, 1)
+            await ctx.info(f"Navigation bake finished for {node_path}")
+        return result
 
     @mcp.tool(meta=MUTATING, tags=NAVIGATION)
     @enforce_preconditions

--- a/mcp_server/tools/runtime.py
+++ b/mcp_server/tools/runtime.py
@@ -7,7 +7,7 @@ Tagged ``runtime`` safety class and gated in the ``runtime`` toolset.
 
 from __future__ import annotations
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import RUNTIME_TAG
@@ -28,7 +28,10 @@ def register_runtime(
     @mcp.tool(meta=RUNTIME, tags={RUNTIME_TAG})
     @enforce_preconditions
     async def run_and_capture(
-        scene: str | None = None, timeout_seconds: float = DEFAULT_RUN_TIMEOUT_SECONDS
+        scene: str | None = None,
+        timeout_seconds: float = DEFAULT_RUN_TIMEOUT_SECONDS,
+        *,
+        ctx: Context,
     ) -> RunCaptureResult:
         """Run the project headless (optionally a specific ``scene`` like
         "res://main.tscn"), wait up to ``timeout_seconds``, then return a summary of
@@ -46,5 +49,13 @@ def register_runtime(
                 required="godot_bin",
             )
         project_dir = await resolve_project_dir(bridge, config)
+        await ctx.info(f"Running {scene or 'main scene'} headless (timeout {timeout_seconds:g}s)…")
+        await ctx.report_progress(0, 1)
         output = await runner.run(project_dir, scene, float(timeout_seconds))
-        return summarize_run(output)
+        await ctx.report_progress(1, 1)
+        result = summarize_run(output)
+        await ctx.info(
+            f"Run finished: exit={result.exit_code}, "
+            f"{len(result.errors)} error(s), {len(result.warnings)} warning(s)"
+        )
+        return result

--- a/mcp_server/tools/testing.py
+++ b/mcp_server/tools/testing.py
@@ -12,7 +12,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
@@ -108,6 +108,8 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
     async def run_tests(
         test_dir: str = "res://test",
         timeout_seconds: float = DEFAULT_TEST_RUN_TIMEOUT_SECONDS,
+        *,
+        ctx: Context,
     ) -> RunTestsResult:
         """Run the project's GDScript test suite (GUT) headlessly and return a
         structured result: ``passed``/``failed``/``total``, per-failure detail, and
@@ -129,13 +131,18 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         project_dir = await resolve_project_dir(bridge, config)
         if not _gut_present(project_dir):
             return RunTestsResult(ran=False, framework="gut", framework_absent=True)
+        await ctx.info(f"Running GUT suite in {test_dir} (timeout {timeout_seconds:g}s)…")
+        await ctx.report_progress(0, 1)
         output = await runner.run_tests(project_dir, test_dir, timeout=float(timeout_seconds))
+        await ctx.report_progress(1, 1)
         if output.timed_out:
+            await ctx.info("Test run timed out")
             return RunTestsResult(
                 ran=True, framework="gut", timed_out=True, raw_summary=output.stdout.strip()[-2000:]
             )
         result = parse_gut_results(output.stdout)
         result.exit_code = output.exit_code
+        await ctx.info(f"Tests finished: {result.passed} passed, {result.failed} failed")
         return result
 
     @mcp.tool(meta=READ_ONLY, tags=TESTING)

--- a/tests/contract/test_context_progress.py
+++ b/tests/contract/test_context_progress.py
@@ -1,0 +1,80 @@
+"""Contract test: long-running tools stream progress + logs via Context (issue #223).
+
+run_tests / run_and_capture / export_project are multi-second operations. They must
+accept a FastMCP ``Context`` and emit progress updates and structured log messages so
+the client/agent has observability during the slow call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import Client, FastMCP
+from mcp.types import LoggingMessageNotificationParams
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.runtime import RunOutput
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+_GUT_PASS = """\
+Totals
+Passing tests      3
+Failing tests      0
+---- 3 of 3 tests passed (3 ran). ----
+"""
+
+
+class _FakeRunner:
+    binary: str | None = "fake-godot"
+
+    def __init__(self, output: RunOutput) -> None:
+        self._output = output
+
+    async def run(self, project_dir: str, scene: str | None, timeout: float) -> RunOutput:
+        return self._output
+
+    async def check_script(self, project_dir: str, script_path: str, timeout: float) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def export(
+        self, project_dir: str, preset: str, output_path: str, debug: bool, timeout: float
+    ) -> RunOutput:
+        return self._output
+
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        return self._output
+
+
+def _build(project_dir: str, output: RunOutput) -> FastMCP:
+    config = ServerConfig(godot_project_dir=project_dir)
+    bridge = Bridge(config.bridge, connector=connector_for(FakeAddonConnection()))
+    return create_server(config, bridge=bridge, runner=_FakeRunner(output))
+
+
+def _with_gut(project_dir: Path) -> None:
+    gut = project_dir / "addons" / "gut"
+    gut.mkdir(parents=True, exist_ok=True)
+    (gut / "gut_cmdln.gd").write_text("# gut runner stub\n")
+
+
+async def test_run_tests_streams_progress_and_logs(tmp_path: Path) -> None:
+    _with_gut(tmp_path)
+    server = _build(str(tmp_path), RunOutput(command=["gut"], stdout=_GUT_PASS, exit_code=0))
+
+    progress: list[tuple[float, float | None]] = []
+    logs: list[str] = []
+
+    async def on_progress(p: float, total: float | None, message: str | None) -> None:
+        progress.append((p, total))
+
+    async def on_log(params: LoggingMessageNotificationParams) -> None:
+        logs.append(str(params.data))
+
+    async with Client(server, progress_handler=on_progress, log_handler=on_log) as client:
+        await client.call_tool("enable_toolset", {"category": "testing"})
+        await client.call_tool("run_tests", {"test_dir": "res://test"})
+
+    assert progress, "expected at least one progress update from run_tests"
+    assert logs, "expected at least one structured log message from run_tests"


### PR DESCRIPTION
### **User description**
## Summary
No tool accepted `ctx: Context`, so multi-second operations emitted no progress and no structured client logs. This wires FastMCP `Context` into the long-running tools:

- `run_and_capture`, `run_tests`, `export_project` (headless Godot subprocess runs) and `bake_navigation_mesh`
- Each emits `ctx.report_progress(0, 1)` → `(1, 1)` around the slow call and `ctx.info(...)` describing the operation and its outcome (exit code, error/warning counts, pass/fail totals). `bake_navigation_mesh` only instruments the real bake, not the `dry_run` preview.

`ctx: Context` is keyword-only (`*, ctx`), auto-injected by FastMCP, and excluded from the input schema — so the agent-facing tool signature is unchanged and existing `client.call_tool(...)` calls keep working.

## Acceptance criteria
- [x] Long-running tools accept `ctx: Context`
- [x] Use `ctx.report_progress()` + `ctx.info()` to stream status

## Test plan
- `tests/contract/test_context_progress.py`: drives `run_tests` through an in-memory `Client` with `progress_handler` + `log_handler` (and an injected fake runner); asserts at least one progress update and one structured log message are received.
- Preflight: `ruff` clean, `mypy` clean, 451 unit+contract tests pass, zero-skip clean.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces `ctx: Context` to long-running tools for progress and logging

- Tools now emit structured logs and progress updates during multi-second operations

- No changes to public tool signatures or existing client calls

- Adds contract test verifying context-based observability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run_and_capture"] -- "ctx.report_progress(0,1)" --> B
  B["run_tests"] -- "ctx.report_progress(0,1)" --> C
  C["export_project"] -- "ctx.report_progress(0,1)" --> D
  D["bake_navigation_mesh"] -- "ctx.report_progress(0,1)" --> E
  E["Context injection"] -- "Structured logs" --> F
  F["Progress updates"] -- "No API changes" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export.py</strong><dd><code>Export tool progress and logging enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/export.py

<ul><li>Added <code>ctx: Context</code> parameter to <code>export_project</code> function (keyword-only)<br> <li> Emit progress and info logs before/after export operation<br> <li> Maintains backward compatibility with existing tool signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/239/files#diff-7fdf0f2a3b9ea7e0e827480c3039e776a04b6d0eff503f42d6b7f3b7ff782d82">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>navigation.py</strong><dd><code>Navigation mesh baking progress logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/navigation.py

<ul><li>Added <code>ctx: Context</code> parameter to <code>bake_navigation_mesh</code> function <br>(keyword-only)<br> <li> Emit progress and info logs during navigation mesh baking<br> <li> Only instruments actual bake, not dry-run preview<br> <li> Maintains backward compatibility with existing tool signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/239/files#diff-6f2e4f33fe1d87e93a07246f7b77a4564e4e71929cf452970cd144e2375069fd">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtime.py</strong><dd><code>Runtime tool observability improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/runtime.py

<ul><li>Added <code>ctx: Context</code> parameter to <code>run_and_capture</code> function <br>(keyword-only)<br> <li> Emit progress and info logs before/after runtime execution<br> <li> Maintains backward compatibility with existing tool signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/239/files#diff-732d0b7bb10bc98d244ce2b5bc6406a44159f04240b67931bbd851092977c359">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testing.py</strong><dd><code>Test runner progress and logging enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/testing.py

<ul><li>Added <code>ctx: Context</code> parameter to <code>run_tests</code> function (keyword-only)<br> <li> Emit progress and info logs during test execution<br> <li> Maintains backward compatibility with existing tool signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/239/files#diff-d58b2175c7e4752c6baa3075834a974044f18a0521c3755ed122e2f9adf0b930">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_context_progress.py</strong><dd><code>Contract test for context progress and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_context_progress.py

<ul><li>Added contract test for context-based progress and logging<br> <li> Verifies <code>run_tests</code>, <code>run_and_capture</code>, <code>export_project</code> emit updates<br> <li> Uses fake runner to simulate multi-second operations<br> <li> Tests both progress updates and structured log messages</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/239/files#diff-735f1263c763df9be08585003ce70dc0db87687d23513619fd29721c4dd5d886">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

