### PR TITLE
Output Bounding for Large Read Tools and Resources

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -28,6 +28,11 @@ Every `@mcp.tool()`:
 - Validates inputs and checks preconditions **before** any side effect.
 - Is **delegation only** — no domain branching in the handler body.
 - Carries a `safety_class`.
+- **Bounds large reads** (issue #222): list-shaped tools (`find_nodes_by_type`, `list_scripts`)
+  paginate with `offset`/`limit` and report `total`/`returned`/`truncated`/`next_offset`;
+  reads that can be huge (the scene tree, `godot://scene/tree`) are capped at
+  `output.CHARACTER_LIMIT` (25k) — an oversized resource payload becomes a truncation
+  marker and `get_scene_tree` falls back to a lightweight view with `truncated=true`.
 
 ### Naming
 

--- a/mcp_server/models/batch.py
+++ b/mcp_server/models/batch.py
@@ -17,6 +17,11 @@ class FindNodesResult(BaseModel):
     type: str
     nodes: list[NodeRef] = Field(default_factory=list)
     count: int = 0
+    # Pagination (issue #222): ``nodes`` is a page of ``total`` matches.
+    total: int = 0
+    returned: int = 0
+    truncated: bool = False
+    next_offset: int | None = None
 
 
 class BatchSetResult(BaseModel):

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -48,6 +48,10 @@ class SceneTree(BaseModel):
     """The active scene tree, or ``tree=None`` when no scene is open."""
 
     tree: SceneNode | None = None
+    # Output bounding (issue #222): set when the full tree exceeded the character
+    # limit and a lightweight view was returned instead; ``hint`` says how to narrow.
+    truncated: bool = False
+    hint: str | None = None
 
 
 class NodeInfo(BaseModel):

--- a/mcp_server/models/scripts.py
+++ b/mcp_server/models/scripts.py
@@ -13,6 +13,11 @@ class ScriptContent(BaseModel):
 class ScriptList(BaseModel):
     directory: str
     scripts: list[str] = Field(default_factory=list)
+    # Pagination (issue #222): ``scripts`` is a page of ``total`` files.
+    total: int = 0
+    returned: int = 0
+    truncated: bool = False
+    next_offset: int | None = None
 
 
 class NodeScript(BaseModel):

--- a/mcp_server/output.py
+++ b/mcp_server/output.py
@@ -1,0 +1,68 @@
+"""Output bounding for read tools and resources (issue #222).
+
+Large reads (a deep scene tree) and unpaginated list operations bloat the agent's
+context window. This module centralizes two guards:
+
+* :func:`paginate` — slice a list to a ``limit``/``offset`` window and report the
+  ``total``/``truncated``/``next_offset`` so the agent can page.
+* :data:`CHARACTER_LIMIT` + :func:`cap_json` — replace an oversized JSON payload with
+  an explicit truncation marker so the client never receives a context-blowing blob.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# Max characters in a single read payload before it is truncated/marked.
+CHARACTER_LIMIT = 25_000
+
+# Hint shown to the agent when a read is bounded, so it knows how to narrow next time.
+_NARROW_HINT = (
+    "Output exceeded the character limit. Narrow the query: use a smaller max_depth "
+    "(or godot://scene/tree/{max_depth}) for the scene tree, lightweight=true, or a "
+    "paginated list tool (find_nodes_by_type / list_scripts) with limit/offset."
+)
+
+
+def paginate(items: list[T], offset: int, limit: int) -> tuple[list[T], int, bool, int | None]:
+    """Return ``(window, total, truncated, next_offset)`` for ``items[offset:offset+limit]``.
+
+    ``truncated`` is true when items remain past the window; ``next_offset`` is the
+    offset to pass for the next page (``None`` when the window reaches the end).
+    """
+    total = len(items)
+    start = max(0, min(offset, total))
+    window = items[start : start + limit]
+    end = start + len(window)
+    truncated = end < total
+    return window, total, truncated, (end if truncated else None)
+
+
+def cap_json(text: str, *, limit: int = CHARACTER_LIMIT) -> str:
+    """Return ``text`` unchanged, or a JSON truncation marker when it exceeds ``limit``.
+
+    Used for resource payloads (JSON strings): truncating the string itself would
+    yield invalid JSON, so an oversized payload is replaced wholesale with a marker.
+    """
+    if len(text) <= limit:
+        return text
+    return json.dumps(
+        {
+            "truncated": True,
+            "character_limit": limit,
+            "actual_length": len(text),
+            "hint": _NARROW_HINT,
+        },
+        indent=2,
+    )
+
+
+def over_character_limit(text: str, *, limit: int = CHARACTER_LIMIT) -> bool:
+    """True when ``text`` exceeds the character limit."""
+    return len(text) > limit
+
+
+TRUNCATION_HINT = _NARROW_HINT

--- a/mcp_server/resources/context.py
+++ b/mcp_server/resources/context.py
@@ -21,6 +21,7 @@ from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
+from mcp_server.output import cap_json
 from mcp_server.safety import READ_ONLY
 
 SCENE_TREE_PREFIX = "godot://scene/tree/"
@@ -41,7 +42,9 @@ async def _fetch_json(bridge: Bridge, command: str, params: dict[str, object]) -
     return the structured error as JSON (resources always return valid JSON)."""
     response = await bridge.send(command, params)
     if response.ok:
-        return json.dumps(response.result or {}, indent=2)
+        # Bound large reads (e.g. a deep scene tree) so a resource can't blow up the
+        # agent's context window — oversized JSON is replaced with a marker (#222).
+        return cap_json(json.dumps(response.result or {}, indent=2))
     error: dict[str, object] = {"error": response.error, "hint": response.hint}
     if response.required is not None:
         error["required"] = response.required

--- a/mcp_server/tools/batch.py
+++ b/mcp_server/tools/batch.py
@@ -12,9 +12,10 @@ there), background/closed scenes are edited and re-scanned, and every target is 
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
+from pydantic import Field
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import BATCH_TAG
@@ -24,8 +25,11 @@ from mcp_server.models.batch import (
     DependenciesResult,
     FindNodesResult,
 )
+from mcp_server.output import paginate
 from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_active_scene
 from mcp_server.tools._route import route
+
+DEFAULT_PAGE_LIMIT = 200
 
 BATCH = {BATCH_TAG}
 
@@ -35,14 +39,28 @@ def register_batch(mcp: FastMCP, bridge: Bridge) -> None:
 
     @mcp.tool(meta=READ_ONLY, tags=BATCH)
     async def find_nodes_by_type(
-        node_type: str, parent_path: str = ".", recursive: bool = True
+        node_type: str,
+        parent_path: str = ".",
+        recursive: bool = True,
+        offset: Annotated[int, Field(ge=0)] = 0,
+        limit: Annotated[int, Field(ge=1, le=1000)] = DEFAULT_PAGE_LIMIT,
     ) -> FindNodesResult:
         """Find nodes in the open scene whose class is (or derives from) ``node_type``
         (e.g. "Sprite2D", "Control") under ``parent_path``. Returns each node's path,
         name, and concrete type — feed the paths into ``batch_set_property``.
+
+        Paginated: ``nodes`` is a window of ``total`` matches starting at ``offset``
+        (default page ``limit`` 200). When ``truncated``, pass ``next_offset`` to page on.
         """
         params = {"type": node_type, "parent_path": parent_path, "recursive": recursive}
-        return FindNodesResult(**await route(bridge, "cmd_find_nodes_by_type", params))
+        result = FindNodesResult(**await route(bridge, "cmd_find_nodes_by_type", params))
+        window, total, truncated, next_offset = paginate(result.nodes, offset, limit)
+        result.nodes = window
+        result.total = total
+        result.returned = len(window)
+        result.truncated = truncated
+        result.next_offset = next_offset
+        return result
 
     @mcp.tool(meta=MUTATING, tags=BATCH)
     @enforce_preconditions

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -19,6 +19,7 @@ from mcp_server.models.inspection import (
     SceneTree,
     SelectedNode,
 )
+from mcp_server.output import TRUNCATION_HINT, over_character_limit
 from mcp_server.safety import READ_ONLY
 from mcp_server.tools._route import route
 
@@ -59,13 +60,25 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         a smaller payload for a discovery pass where you just need the shape; pair
         it with ``max_depth`` to keep large scenes out of context.
 
+        If the full tree exceeds the character limit, a lightweight view is returned
+        instead with ``truncated=true`` and a ``hint`` to narrow with ``max_depth``.
+
         WHEN TO USE: You need to understand the static scene structure before
         making edits (adding nodes, attaching scripts, setting properties).
         WHEN NOT TO USE: The game is running and you need live state — use
         get_game_scene_tree() to read the running game's current hierarchy.
         """
         params = {"max_depth": max_depth, "lightweight": lightweight}
-        return SceneTree(**await route(bridge, "cmd_get_scene_tree", params))
+        result = SceneTree(**await route(bridge, "cmd_get_scene_tree", params))
+        # Output bounding (issue #222): if the tree is too large, fall back to the
+        # lightweight view (a real, addon-supported reduction) and mark it truncated.
+        if over_character_limit(result.model_dump_json()):
+            if not lightweight:
+                light = {"max_depth": max_depth, "lightweight": True}
+                result = SceneTree(**await route(bridge, "cmd_get_scene_tree", light))
+            result.truncated = True
+            result.hint = TRUNCATION_HINT
+        return result
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_selected_node() -> SelectedNode:

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -78,6 +78,11 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
                 result = SceneTree(**await route(bridge, "cmd_get_scene_tree", light))
             result.truncated = True
             result.hint = TRUNCATION_HINT
+            # Strict cap: a very wide/deep scene can exceed the limit even when
+            # lightweight, so drop the tree entirely rather than return an oversized
+            # payload — parity with the resource path's cap_json (#222).
+            if over_character_limit(result.model_dump_json()):
+                result.tree = None
         return result
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)

--- a/mcp_server/tools/scripts.py
+++ b/mcp_server/tools/scripts.py
@@ -10,7 +10,10 @@ errors. All in the gated ``scripts`` toolset.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastmcp import FastMCP
+from pydantic import Field
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import SCRIPTS_TAG
@@ -23,12 +26,14 @@ from mcp_server.models.scripts import (
     ScriptList,
     WriteScriptResult,
 )
+from mcp_server.output import paginate
 from mcp_server.runtime import Runner, resolve_project_dir
 from mcp_server.safety import MUTATING, READ_ONLY, PreconditionError, enforce_preconditions
 from mcp_server.scripts_parse import parse_check_errors
 from mcp_server.tools._route import route, run_or_preview, validate_or_raise
 
 SCRIPTS = {SCRIPTS_TAG}
+DEFAULT_PAGE_LIMIT = 200
 
 
 async def _script_exists(bridge: Bridge, script_path: str) -> bool:
@@ -47,9 +52,24 @@ def register_scripts(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         return ScriptContent(**await route(bridge, "cmd_read_script", {"script_path": script_path}))
 
     @mcp.tool(meta=READ_ONLY, tags=SCRIPTS)
-    async def list_scripts(directory: str = "res://") -> ScriptList:
-        """List all ``.gd`` files under ``directory`` (recursive, ``res://`` path)."""
-        return ScriptList(**await route(bridge, "cmd_list_scripts", {"directory": directory}))
+    async def list_scripts(
+        directory: str = "res://",
+        offset: Annotated[int, Field(ge=0)] = 0,
+        limit: Annotated[int, Field(ge=1, le=1000)] = DEFAULT_PAGE_LIMIT,
+    ) -> ScriptList:
+        """List all ``.gd`` files under ``directory`` (recursive, ``res://`` path).
+
+        Paginated: ``scripts`` is a window of ``total`` files starting at ``offset``
+        (default page ``limit`` 200). When ``truncated``, pass ``next_offset`` to page on.
+        """
+        result = ScriptList(**await route(bridge, "cmd_list_scripts", {"directory": directory}))
+        window, total, truncated, next_offset = paginate(result.scripts, offset, limit)
+        result.scripts = window
+        result.total = total
+        result.returned = len(window)
+        result.truncated = truncated
+        result.next_offset = next_offset
+        return result
 
     @mcp.tool(meta=READ_ONLY, tags=SCRIPTS)
     async def get_script_for_node(node_path: str = "") -> NodeScript:

--- a/tests/contract/test_output_bounding.py
+++ b/tests/contract/test_output_bounding.py
@@ -1,0 +1,96 @@
+"""Contract tests: bounded read outputs — pagination + char cap (issue #222).
+
+List-shaped tools (find_nodes_by_type, list_scripts) paginate with limit/offset and
+report total/truncated/next_offset. Large reads (the scene tree) are capped at a
+character limit with an explicit truncation marker so they can't blow up context.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.output import CHARACTER_LIMIT
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, _default_base_responder, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _big_tree() -> dict[str, Any]:
+    children: list[dict[str, Any]] = [
+        {"name": f"Node{i}", "type": "Sprite2D", "path": f"Root/Node{i}", "script": None,
+         "children": []}
+        for i in range(700)
+    ]
+    return {"name": "Root", "type": "Node2D", "path": ".", "script": None, "children": children}
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+    base = _default_base_responder(cmd)
+    if base is not None:
+        return base
+    if cmd.command == "cmd_find_nodes_by_type":
+        nodes = [{"path": f"Root/N{i}", "name": f"N{i}", "type": "Sprite2D"} for i in range(10)]
+        return ResponseEnvelope.success(cmd.id, {"type": "Sprite2D", "nodes": nodes, "count": 10})
+    if cmd.command == "cmd_list_scripts":
+        scripts = [f"res://s{i}.gd" for i in range(10)]
+        return ResponseEnvelope.success(cmd.id, {"directory": "res://", "scripts": scripts})
+    if cmd.command == "cmd_get_scene_tree":
+        if cmd.params.get("lightweight"):
+            return ResponseEnvelope.success(
+                cmd.id, {"tree": {"name": "Root", "type": "Node2D", "path": ".", "children": []}}
+            )
+        return ResponseEnvelope.success(cmd.id, {"tree": _big_tree()})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", f"unknown {cmd.command}")
+
+
+def _server() -> FastMCP:
+    config = ServerConfig()
+    bridge = Bridge(config.bridge, connector=connector_for(FakeAddonConnection(_responder)))
+    return create_server(config, bridge=bridge)
+
+
+async def test_find_nodes_by_type_paginates() -> None:
+    async with Client(_server()) as client:
+        await client.call_tool("enable_toolset", {"category": "batch"})
+        result = await client.call_tool(
+            "find_nodes_by_type", {"node_type": "Sprite2D", "limit": 3, "offset": 0}
+        )
+    data = result.data
+    assert len(data.nodes) == 3
+    assert data.total == 10
+    assert data.truncated is True
+    assert data.next_offset == 3
+
+
+async def test_list_scripts_paginates_last_page() -> None:
+    async with Client(_server()) as client:
+        await client.call_tool("enable_toolset", {"category": "scripts"})
+        result = await client.call_tool("list_scripts", {"limit": 4, "offset": 8})
+    data = result.data
+    assert len(data.scripts) == 2
+    assert data.total == 10
+    assert data.truncated is False
+    assert data.next_offset is None
+
+
+async def test_scene_tree_resource_is_char_capped() -> None:
+    async with Client(_server()) as client:
+        contents = await client.read_resource("godot://scene/tree")
+    text = contents[0].text
+    assert len(text) <= CHARACTER_LIMIT + 500  # marker, not the giant tree
+    assert json.loads(text)["truncated"] is True
+
+
+async def test_get_scene_tree_tool_marks_truncation() -> None:
+    async with Client(_server()) as client:
+        result = await client.call_tool("get_scene_tree", {})
+    assert result.data.truncated is True
+    assert result.data.hint

--- a/tests/contract/test_output_bounding.py
+++ b/tests/contract/test_output_bounding.py
@@ -94,3 +94,25 @@ async def test_get_scene_tree_tool_marks_truncation() -> None:
         result = await client.call_tool("get_scene_tree", {})
     assert result.data.truncated is True
     assert result.data.hint
+
+
+def _always_big_responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+    """A scene so large that even the lightweight view exceeds the character limit."""
+    base = _default_base_responder(cmd)
+    if base is not None:
+        return base
+    if cmd.command == "cmd_get_scene_tree":
+        return ResponseEnvelope.success(cmd.id, {"tree": _big_tree()})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", f"unknown {cmd.command}")
+
+
+async def test_get_scene_tree_tool_strictly_caps_when_lightweight_still_large() -> None:
+    config = ServerConfig()
+    conn = FakeAddonConnection(_always_big_responder)
+    server = create_server(config, bridge=Bridge(config.bridge, connector=connector_for(conn)))
+    async with Client(server) as client:
+        result = await client.call_tool("get_scene_tree", {})
+    # Even the lightweight fallback is too big → tree dropped, payload bounded.
+    assert result.data.truncated is True
+    assert result.data.tree is None
+    assert len(json.dumps(result.structured_content)) <= CHARACTER_LIMIT


### PR DESCRIPTION
### **User description**
## Summary
Large reads were unbounded — a deep `get_scene_tree` / `godot://scene/tree` could return very large JSON, and list tools had no pagination. This adds a shared bounding helper and applies it:

**`mcp_server/output.py`** — `CHARACTER_LIMIT = 25_000`, `paginate(items, offset, limit)` → `(window, total, truncated, next_offset)`, and `cap_json(text)` (replaces oversized JSON with a truncation marker).

**Pagination** on the genuinely list-shaped tools:
- `find_nodes_by_type` and `list_scripts` gain `offset` / `limit` (bounded, default page 200) and report `total` / `returned` / `truncated` / `next_offset`. Slicing is server-side; `count` (find) still means total matches.

**Character cap** on large reads:
- `godot://...` resources (incl. `scene/tree` and `scene/tree/{max_depth}`) replace an oversized payload with an explicit JSON truncation marker (`truncated: true`, `character_limit`, `actual_length`, `hint`).
- `get_scene_tree` (the tool) re-queries the addon's **lightweight** view when the full tree exceeds the limit and sets `truncated=true` + a `hint` — a real reduction using existing addon capability, one extra round-trip only when needed.

**Behavior note:** list tools now return at most `limit` (default 200) items per call; callers page with `next_offset`. New model fields are additive (defaults preserve existing consumers).

## Acceptance criteria
- [x] Response char cap with an explicit truncation marker
- [x] `limit`/`offset` (with `next_offset` cursor) on list-shaped tools (`find_nodes_by_type`, `list_scripts`)
- [x] `get_scene_tree` bounded

## Test plan
- `tests/contract/test_output_bounding.py`: `find_nodes_by_type`/`list_scripts` pagination (window size, total, truncated, next_offset incl. last-page); `godot://scene/tree` resource capped to a marker; `get_scene_tree` marks truncation and falls back to lightweight.
- Preflight: `ruff` clean, `mypy` clean (210 files), 454 unit+contract tests pass, zero-skip clean.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces character limit and pagination for large read outputs

- Adds `offset`/`limit` parameters to list tools (`find_nodes_by_type`, `list_scripts`)

- Implements truncation marker for oversized JSON payloads in resources

- Modifies `get_scene_tree` to fall back to lightweight view when exceeding limits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["find_nodes_by_type"] -- "offset/limit" --> B["Paginated Results"]
  C["list_scripts"] -- "offset/limit" --> B
  D["get_scene_tree"] -- "lightweight fallback" --> E["Truncated Output"]
  F["godot://scene/tree"] -- "char cap" --> E
  E -- "truncation marker" --> G["Client Handles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>batch.py</strong><dd><code>Add pagination fields to FindNodesResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-b1baa40154eff60bec990fb59268edd52191bbec2b068262d87d13ff8954e51f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspection.py</strong><dd><code>Add truncation fields to SceneTree</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-45806d2c459fe7dbb15e90f53c37192b5e4140ab53ed87ffc293a30f7b33edfa">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scripts.py</strong><dd><code>Add pagination fields to ScriptList</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-dd7d014708fad36bfa6f1e2b7f8a61137c50a0026792a6b3f05f17b7f222f2f3">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output.py</strong><dd><code>Centralize output bounding helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-7fa058179c6b8a6f62cc4de8f0bd4fc6493d3446f1b2be00d12ec996148be96f">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context.py</strong><dd><code>Apply character limit to resource payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-f198a5ea39b3cd033cd62e3fc64cabe2d45635b89aaa54d180894696c54c6d79">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch.py</strong><dd><code>Paginate find_nodes_by_type results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-79a9538ee01520cd22384f6531dc2571d5c387d2a683bf97ad1d3b557405d356">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspection.py</strong><dd><code>Bound get_scene_tree output with lightweight fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-eaaefb58a15b52cc64457889aff9fdfa9a10aadebf62c85b676e43375f167bf0">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scripts.py</strong><dd><code>Paginate list_scripts results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-53b07b1d837dec653317ad780630699d2a4d175c423508a0155d17eab5f99e1c">+23/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_output_bounding.py</strong><dd><code>Contract tests for output bounding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-c091e0cc7f1b2d0aa0dbff7f7ad39bf84d640d66e3832e72e5b92b9a091afe97">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document output bounding behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/240/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

