### PR TITLE
feat(analysis): expose project structure inventory (list_scenes / project_structure tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **125 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **126 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -507,7 +507,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `find_nodes_by_type`, `batch_set_property`, `cross_scene_set_property`, `get_dependencies`
 
 ### Static Analysis (gated) — `read_only`
-- `find_unused_resources`, `analyze_signal_flow`, `detect_circular_dependencies`, `project_stats`
+- `find_unused_resources`, `analyze_signal_flow`, `detect_circular_dependencies`, `project_stats`, `project_structure`
 
 ### Export (gated) — `read_only` / `runtime`
 - `list_export_presets`, `get_export_info`, `export_project`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -755,6 +755,7 @@ commands). All `read_only`. The project dir is resolved like the runtime loop
 | `analyze_signal_flow` | `scene=""` | `SignalFlowResult { connections[], count }` |
 | `detect_circular_dependencies` | — | `CircularDependenciesResult { cycles[], count }` |
 | `project_stats` | — | `ProjectStatsResult { scenes, scripts, resources, total_nodes, connections, by_extension, busiest_scenes[] }` |
+| `project_structure` | — | `ProjectStructureResult { scenes[], scripts[], resources[], entry_points[] }` |
 | `analyze_dependencies` | `resource_path` | `AnalyzeDependenciesResult { path, type, references[], referencers[] }` |
 | `find_orphaned_resources` | `scan_dir="res://"`, `resource_types` | `FindOrphanedResult { orphaned[]{path, type, estimated_size}, scanned }` |
 | `validate_scene_integrity` | `scene_path` | `ValidateSceneIntegrityResult { valid, errors[]{severity, message, node_path, property}, warnings[] }` |
@@ -765,7 +766,9 @@ entry points — the main scene, autoloads, plugin scripts). `analyze_signal_flo
 `[connection ...]` from scene files (each `{scene, signal, from, to, method}`).
 `detect_circular_dependencies` finds cycles in the `preload`/`load`/`extends` graph among
 `.gd` files. `project_stats` reports counts, total nodes, connections, a per-extension
-breakdown, and the busiest scenes.
+breakdown, and the busiest scenes. `project_structure` returns the raw inventory — the
+actual scene/script/resource `res://` paths (sorted, non-overlapping) plus `entry_points`
+— for an agent to learn what exists before planning edits.
 
 Issue #111 adds **dependency-aware** analysis: `analyze_dependencies` extracts `res://` and
 `uid://` references from a resource file (recursing into sub-dependencies). `find_orphaned_resources`

--- a/mcp_server/analysis.py
+++ b/mcp_server/analysis.py
@@ -234,6 +234,31 @@ def project_stats(index: ProjectIndex) -> dict[str, Any]:
     }
 
 
+def project_structure(index: ProjectIndex) -> dict[str, list[str]]:
+    """The raw project inventory: every indexed ``res://`` path bucketed by kind.
+
+    Buckets are sorted and non-overlapping; their union is every file ``scan`` indexed.
+    ``entry_points`` (main scene + autoloads + plugin scripts) is a labelled cross-cut,
+    not a separate bucket. Exposes data ``scan`` already produces — no new analysis.
+    """
+    scenes: list[str] = []
+    scripts: list[str] = []
+    resources: list[str] = []
+    for res in index.resources:
+        if res.endswith((".tscn", ".scn")):
+            scenes.append(res)
+        elif res.endswith(".gd"):
+            scripts.append(res)
+        else:
+            resources.append(res)
+    return {
+        "scenes": sorted(scenes),
+        "scripts": sorted(scripts),
+        "resources": sorted(resources),
+        "entry_points": sorted(index.entry_points),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Issue #111 — asset dependency, orphan detection, scene integrity
 # ---------------------------------------------------------------------------

--- a/mcp_server/models/analysis.py
+++ b/mcp_server/models/analysis.py
@@ -47,6 +47,18 @@ class ProjectStatsResult(BaseModel):
     busiest_scenes: list[SceneNodeCount] = Field(default_factory=list)
 
 
+class ProjectStructureResult(BaseModel):
+    """Raw project inventory (issue #210): ``res://`` paths bucketed by kind, plus
+    the entry points. ``scenes``/``scripts``/``resources`` are sorted and
+    non-overlapping; ``entry_points`` is a labelled cross-cut (main scene, autoloads,
+    plugins)."""
+
+    scenes: list[str] = Field(default_factory=list)
+    scripts: list[str] = Field(default_factory=list)
+    resources: list[str] = Field(default_factory=list)
+    entry_points: list[str] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Issue #111 — asset dependency, orphan detection, scene integrity
 # ---------------------------------------------------------------------------

--- a/mcp_server/tools/analysis.py
+++ b/mcp_server/tools/analysis.py
@@ -27,6 +27,7 @@ from mcp_server.models.analysis import (
     CrossSceneRefsResult,
     FindOrphanedResult,
     ProjectStatsResult,
+    ProjectStructureResult,
     SignalFlowResult,
     UnusedResourcesResult,
     ValidateSceneIntegrityResult,
@@ -83,6 +84,16 @@ def register_analysis(mcp: FastMCP, bridge: Bridge, config: ServerConfig) -> Non
         connections, a per-extension breakdown, and the busiest scenes by node count.
         """
         return ProjectStatsResult(**analysis.project_stats(await _index()))
+
+    @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
+    @enforce_preconditions
+    async def project_structure() -> ProjectStructureResult:
+        """The project's raw inventory: all scene, script, and resource ``res://`` paths
+        (sorted, non-overlapping buckets) plus ``entry_points`` (main scene, autoloads,
+        plugins). Use it to learn what exists before planning edits — unlike
+        ``project_stats`` (counts only), this returns the actual paths.
+        """
+        return ProjectStructureResult(**analysis.project_structure(await _index()))
 
     @mcp.tool(meta=READ_ONLY, tags=ANALYSIS)
     @enforce_preconditions

--- a/tests/contract/test_analysis.py
+++ b/tests/contract/test_analysis.py
@@ -60,6 +60,7 @@ async def test_gated_read_only_in_analysis_toolset(tmp_path: Path) -> None:
         "analyze_signal_flow",
         "detect_circular_dependencies",
         "project_stats",
+        "project_structure",
         "analyze_dependencies",
         "find_orphaned_resources",
         "validate_scene_integrity",
@@ -67,6 +68,17 @@ async def test_gated_read_only_in_analysis_toolset(tmp_path: Path) -> None:
     }
     assert expected <= set(tools)
     assert all(tools[n].meta["safety_class"] == "read_only" for n in expected)
+
+
+async def test_project_structure_returns_inventory(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    async with Client(_server(tmp_path)) as client:
+        await client.call_tool("enable_toolset", {"category": "analysis"})
+        result = await client.call_tool("project_structure", {})
+    data = result.structured_content
+    assert "res://main.tscn" in data["scenes"]
+    assert "res://unused.png" in data["resources"]
+    assert "res://main.tscn" in data["entry_points"]
 
 
 async def test_find_unused_and_signal_flow(tmp_path: Path) -> None:

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -96,6 +96,23 @@ def test_project_stats(tmp_path: Path) -> None:
     assert stats["busiest_scenes"][0]["scene"] == "res://main.tscn"
 
 
+def test_project_structure(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    index = analysis.scan(tmp_path)
+    structure = analysis.project_structure(index)
+    # Buckets are sorted, non-overlapping, and cover every indexed file.
+    assert structure["scenes"] == ["res://main.tscn"]
+    assert structure["scripts"] == [
+        "res://a.gd",
+        "res://b.gd",
+        "res://game.gd",
+        "res://lonely.gd",
+    ]
+    assert structure["resources"] == ["res://unused.png", "res://used.png"]
+    # main scene + autoload script are entry points.
+    assert set(structure["entry_points"]) == {"res://main.tscn", "res://game.gd"}
+
+
 def test_scan_skips_godot_cache(tmp_path: Path) -> None:
     _make_project(tmp_path)
     (tmp_path / ".godot").mkdir()


### PR DESCRIPTION
### **User description**
## Summary
The static-analysis tools returned only *derived* results — `project_stats` gives counts, `find_unused_resources` gives dead resources, `analyze_*` give relationships. None returned the raw inventory of scene/resource **paths**, even though `analysis.ProjectIndex.scan()` already computes it.

Adds a read-only, `analysis`-gated **`project_structure()`** tool returning the inventory:
- `scenes` / `scripts` / `resources` — sorted, **non-overlapping** `res://` path buckets (their union is every indexed file)
- `entry_points` — labelled cross-cut (main scene, autoloads, plugin scripts)

It's a thin exposure of data `scan()` already produces (`analysis.project_structure(index)`) — no new analysis logic. This unblocks **godot-agents project onboarding**, whose planner needs the actual project map (not just counts) to ground itself.

## Acceptance criteria
- [x] A read-only tool returns all scene paths (+ scripts/resources) for the open project
- [x] Tests over a fixture project assert the inventory

## Test plan
- `tests/unit/test_analysis.py::test_project_structure` — asserts the bucketed inventory + entry points over the synthetic project.
- `tests/contract/test_analysis.py` — `project_structure` is gated in `analysis`, `read_only`, and returns the inventory end-to-end.
- Docs: `docs/tool-contracts.md` analysis table + README updated (126 tools).
- Preflight: CI-parity `ruff` clean, `mypy` clean (218 files), 473 unit+contract tests pass, zero-skip clean.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Introduces `project_structure` tool for raw inventory access

- Exposes scene/script/resource paths and entry points

- Adds new `ProjectStructureResult` model for structured output

- Updates documentation and tests to include new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["project_structure()"] -- "returns" --> B["ProjectStructureResult"]
  A -- "uses" --> C["ProjectIndex.scan() data"]
  B -- "contains" --> D["scenes[], scripts[], resources[]"]
  B -- "contains" --> E["entry_points[]"]
  C -- "internal" --> F["analysis.py"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>analysis.py</strong><dd><code>Add project_structure function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-0012938bd95a1d41eccf4ad66d94e82b00742f4ce51533454a465f3781275b33">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysis.py</strong><dd><code>Define ProjectStructureResult model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-086e2ecb9623fd9f469e771d7efc5c9e88c0e1daee1fb875191a5d39fecf5072">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysis.py</strong><dd><code>Register project_structure tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-f8ff921f4aac5edf75a7b0c3e48e689560a76585dba101161349612b5dd14fdf">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_analysis.py</strong><dd><code>Add contract test for project_structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-e378601f1691d6f00f769d4023bf2c1b616f6edeea6a3d8d0e02db333610f982">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_analysis.py</strong><dd><code>Add unit test for project_structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-4e42ad21fe35e16ab12b565203961d1dddd778dbb8adcaff2ca9f9077c4095d6">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count and list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document project_structure tool contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/241/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

