### PR TITLE
Add get_node_property tool and enhance JSON schema descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **126 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **127 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -429,6 +429,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `get_scene_tree` — full node hierarchy with `max_depth` control
 - `get_selected_node` — the currently selected node in the editor
 - `get_node_properties` — type, script, properties, children for any node path
+- `get_node_property` — read a single property by name, including built-in Godot properties
 
 ### Scene Edit (gated) — `mutating` / `destructive`
 - **Node creation:** `create_node`, `instance_scene`, `duplicate_node`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -198,6 +198,7 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 | `get_scene_tree` | `max_depth: int = -1, lightweight: bool = False` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
 | `get_selected_node` | — | `SelectedNode { selected: NodeInfo? }` | `cmd_get_selected_node` |
 | `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
+| `get_node_property` | `node_path: str, property: str` | `NodeProperty { node_path, property, value, exists }` | `cmd_get_node_property` |
 | `get_node_property_list` | `node_path: str` | `NodePropertyList { node_path, type, properties[] }` | `cmd_get_node_property_list` |
 
 `SceneNode = { name, type, path, script?, children: [SceneNode] }`. Each node's `path` (#180)
@@ -208,7 +209,10 @@ by the path-taking tools (`set_node_property`, `create_node` parent, `attach_scr
 discovery payload (pair with `max_depth`). `get_node_properties` errors
 with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
 `get_node_property_list` returns every valid property name for a node (useful before calling
-`set_node_property`).
+`set_node_property`). `get_node_property` reads a single property by name — **including
+built-in Godot properties** (`position`, `modulate`, `collision_layer`, …) that
+`get_node_properties` omits (it returns only script vars) — as `{ value, exists }`
+(`exists=false`, value null when absent), for snapshotting a value before a set (#215).
 
 #### Mutation (issue #6) — `mutating` (except `delete_node`)
 

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -20,6 +20,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
 	handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
+	handlers["cmd_get_node_property"] = _cmd_get_node_property
 	handlers["cmd_get_node_property_list"] = _cmd_get_node_property_list
 
 
@@ -67,6 +68,34 @@ func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
 	return _router._ok(Inspect.node_info(node, root))
+
+
+func _cmd_get_node_property(params: Dictionary) -> Dictionary:
+	if not params.has("node_path"):
+		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	if not params.has("property"):
+		return _router._fail("VALIDATION_ERROR", "'property' is required.")
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node_path := str(params["node_path"])
+	if node_path.begins_with("/"):
+		node_path = node_path.substr(1)
+	# Also strip "root/" prefix commonly hallucinated by LLMs
+	if node_path.begins_with("root/"):
+		node_path = node_path.substr(5)
+	if node_path.is_empty():
+		node_path = "."
+	var node: Node = root.get_node_or_null(NodePath(node_path))
+	if node == null:
+		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
+	var read: Dictionary = Inspect.read_property(node, str(params["property"]))
+	return _router._ok({
+		"node_path": str(params["node_path"]),
+		"property": str(params["property"]),
+		"value": read["value"],
+		"exists": read["exists"],
+	})
 
 
 func _cmd_get_node_property_list(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -64,6 +64,16 @@ static func node_properties(node: Node) -> Dictionary:
 	return props
 
 
+## Read one property by name — built-in OR script var, no usage filter (issue #215).
+## { value, exists }: exists=false (value=null) when the node has no such property,
+## so a real null value is distinguishable from "absent". JSON-coerced via type_coerce.
+static func read_property(node: Node, property: String) -> Dictionary:
+	for entry in node.get_property_list():
+		if String(entry.get("name", "")) == property:
+			return {"value": Coerce.to_json(node.get(property)), "exists": true}
+	return {"value": null, "exists": false}
+
+
 ## A resource's editable+stored properties, JSON-coerced (issue #34). Unlike nodes
 ## (script vars), built-in resource fields are EDITOR|STORAGE, so filter on those and
 ## drop the base Resource bookkeeping fields.

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -19,6 +19,7 @@ func _initialize() -> void:
 	_test_from_json(failures)
 	_test_serialize_tree(failures)
 	_test_node_properties(failures)
+	_test_read_property(failures)
 	_test_node_info(failures)
 
 	if failures.is_empty():
@@ -137,6 +138,24 @@ func _test_node_properties(failures: Array[String]) -> void:
 	var props: Dictionary = Inspect.node_properties(node)
 	_eq(failures, "props.speed", props.get("speed"), 200.0)
 	_eq(failures, "props.health", props.get("health"), 100)
+	node.free()
+
+
+func _test_read_property(failures: Array[String]) -> void:
+	# read_property reads built-ins the script-var filter hides, plus script vars,
+	# and reports exists=false for absent names (issue #215).
+	var node := Node2D.new()
+	node.set_script(Probe)
+	node.position = Vector2(10, 20)
+	var pos: Dictionary = Inspect.read_property(node, "position")
+	_eq(failures, "read.builtin.exists", pos.get("exists"), true)
+	_eq(failures, "read.builtin.value", pos.get("value"), {"x": 10.0, "y": 20.0})
+	var speed: Dictionary = Inspect.read_property(node, "speed")
+	_eq(failures, "read.script.exists", speed.get("exists"), true)
+	_eq(failures, "read.script.value", speed.get("value"), 200.0)
+	var absent: Dictionary = Inspect.read_property(node, "no_such_prop")
+	_eq(failures, "read.absent.exists", absent.get("exists"), false)
+	_eq(failures, "read.absent.value", absent.get("value"), null)
 	node.free()
 
 

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -72,6 +72,19 @@ class NodePropertyList(BaseModel):
     properties: list[str] = Field(default_factory=list)
 
 
+class NodeProperty(BaseModel):
+    """A single node property read (issue #215), including built-in Godot properties.
+
+    ``value`` is JSON-coerced (see type_coerce.gd); ``exists`` is false (and ``value``
+    null) when the node has no such property.
+    """
+
+    node_path: str
+    property: str
+    value: Any = None
+    exists: bool = False
+
+
 class SelectedNode(BaseModel):
     """The selected node, or ``selected=None`` when nothing is selected."""
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -15,6 +15,7 @@ from mcp_server.constraints import MaxDepth
 from mcp_server.models.inspection import (
     ActiveScene,
     NodeInfo,
+    NodeProperty,
     NodePropertyList,
     ProjectInfo,
     SceneTree,
@@ -102,6 +103,24 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         if no scene is open.
         """
         return NodeInfo(**await route(bridge, "cmd_get_node_properties", {"node_path": node_path}))
+
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
+    async def get_node_property(node_path: str, property: str) -> NodeProperty:
+        """Read a single ``property`` by name from the node at ``node_path`` — including
+        **built-in** Godot properties (position, scale, modulate, collision_layer,
+        material, theme, …) that ``get_node_properties`` omits (it returns only
+        script-declared variables). Returns ``{value, exists}``; ``exists=false``
+        (value null) when the node has no such property. The value is JSON-coerced
+        (Vector2 as {"x","y"}, Color, NodePath as string). Use it to snapshot a value
+        before ``set_node_property`` — for verification or rollback. Errors with
+        RESOURCE_NOT_FOUND if the path doesn't resolve, or PRECONDITION_FAILED if no
+        scene is open.
+        """
+        return NodeProperty(
+            **await route(
+                bridge, "cmd_get_node_property", {"node_path": node_path, "property": property}
+            )
+        )
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_node_property_list(node_path: str) -> NodePropertyList:

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -86,6 +86,31 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "children": [],
                 },
             )
+        case "cmd_get_node_property":
+            if cmd.params.get("node_path") == "Missing":
+                return ResponseEnvelope.failure(
+                    cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Missing'."
+                )
+            # A built-in property the script-var filter would have hidden.
+            if cmd.params.get("property") == "position":
+                return ResponseEnvelope.success(
+                    cmd.id,
+                    {
+                        "node_path": cmd.params["node_path"],
+                        "property": "position",
+                        "value": {"x": 10.0, "y": 20.0},
+                        "exists": True,
+                    },
+                )
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "property": cmd.params["property"],
+                    "value": None,
+                    "exists": False,
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 
 
@@ -186,6 +211,41 @@ async def test_get_node_properties_missing_is_structured_error() -> None:
     assert "RESOURCE_NOT_FOUND" in str(result.content)
 
 
+async def test_get_node_property_reads_builtin() -> None:
+    # #215: reads a built-in property (position) the script-var filter would hide.
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool(
+            "get_node_property", {"node_path": "Player", "property": "position"}
+        )
+    data = result.structured_content
+    assert data["node_path"] == "Player"
+    assert data["property"] == "position"
+    assert data["exists"] is True
+    assert data["value"] == {"x": 10.0, "y": 20.0}
+    assert conn.last_command().params["property"] == "position"
+
+
+async def test_get_node_property_absent_reports_exists_false() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool(
+            "get_node_property", {"node_path": "Player", "property": "nope"}
+        )
+    data = result.structured_content
+    assert data["exists"] is False
+    assert data["value"] is None
+
+
+async def test_get_node_property_missing_node_is_structured_error() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool(
+            "get_node_property",
+            {"node_path": "Missing", "property": "position"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+
+
 async def test_inspection_tools_are_read_only() -> None:
     async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
         tools = await client.list_tools()
@@ -196,6 +256,7 @@ async def test_inspection_tools_are_read_only() -> None:
         "get_scene_tree",
         "get_selected_node",
         "get_node_properties",
+        "get_node_property",
     ):
         assert by_name[name].meta is not None
         assert by_name[name].meta.get("safety_class") == "read_only"

--- a/tests/integration/test_inspection_e2e.py
+++ b/tests/integration/test_inspection_e2e.py
@@ -53,6 +53,14 @@ async def _run_checks() -> None:
         assert props.ok is False
         assert props.error == "PRECONDITION_FAILED"
         assert props.required == "active_scene"
+
+        # The new single-property read handler is registered and routes the same way (#215).
+        prop = await bridge.send(
+            "cmd_get_node_property", {"node_path": "Anything", "property": "position"}
+        )
+        assert prop.ok is False
+        assert prop.error == "PRECONDITION_FAILED"
+        assert prop.required == "active_scene"
     finally:
         await bridge.close()
 


### PR DESCRIPTION
### **User description**
## Summary
`get_node_properties` / `node_info` only return `PROPERTY_USAGE_SCRIPT_VARIABLE` properties, so **built-in** Godot node properties (`position`, `scale`, `modulate`, `collision_layer`, `material`, `theme`, …) can't be captured. This is the **most pervasive read-before-write gap** (rollback enabler **G1**, found by audit #212): it blocks faithful rollback of `set_node_property`, `set_physics_layers`, `set_navigation_layers`, `setup_physics_body`, shader/theme/particle setters, `batch_set_property`, and more.

Adds **`get_node_property(node_path, property)`** → `{node_path, property, value, exists}`:
- **Addon** (`[Both]`): `cmd_get_node_property` handler + `Inspect.read_property()` lib helper — reads `node.get(property)` with **no usage filter**, JSON-coerced via `type_coerce.gd`; `exists=false` (value null) distinguishes an absent property from a real null.
- **MCP**: `read_only`, `inspection`-gated tool + `NodeProperty` model.

Use it to snapshot a value before `set_node_property` — for verification or rollback (enables #146).

## Acceptance criteria
- [x] Reads built-in node properties without the script-var filter
- [x] `{value, exists}`, JSON type-coerced; `read_only`, `[Both]`

## Test plan
- **Addon (headless):** `godot/tests/inspect_smoke.gd::_test_read_property` — built-in (`position`), script var (`speed`), and absent name → `INSPECT_TEST_OK`. Handler file passes `--check-only`.
- **Contract:** `tests/contract/test_inspection.py` — built-in read, `exists=false` for absent, RESOURCE_NOT_FOUND for missing node, read-only meta.
- **E2E:** `test_inspection_e2e.py` — new handler registered + precondition path (runs in CI; locally a pre-existing editor occupies the bridge port).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 476 unit+contract pass, zero-skip clean. Docs + README updated (127 tools).

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds `get_node_property` tool for reading built-in node properties

- Enables rollback by capturing pre-mutation state

- Extends JSON schema tool descriptions to reduce hallucination

- Updates documentation and tests for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_node_properties"] -- "reads script vars only" --> B["get_node_property"]
  B -- "reads built-in + script vars" --> C["rollback enabler"]
  D["JSON Schema tools"] -- "reduced hallucination" --> E["evals"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>inspection.py</strong><dd><code>Add NodeProperty model for single property reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-45806d2c459fe7dbb15e90f53c37192b5e4140ab53ed87ffc293a30f7b33edfa">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspection.py</strong><dd><code>Implement get_node_property MCP tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-eaaefb58a15b52cc64457889aff9fdfa9a10aadebf62c85b676e43375f167bf0">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_inspect.gd</strong><dd><code>Register cmd_get_node_property handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-93f640e48d1dd80cc0c6e5b70a9d2a9f3102ed5b878c2d99d5f78fc7698a7f42">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_inspect.gd</strong><dd><code>Add read_property helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-f46999a59ce9b8f6f5042f77e6b0f9c181037b948b691f6e06d4c7b02efeb8e7">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_inspection.py</strong><dd><code>Add contract tests for get_node_property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-f52b5e8ce780e310798b29270e857c1ade095a13a2af6ff9c76176e54a5e24b9">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inspection_e2e.py</strong><dd><code>Verify new handler registration in E2E tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-a84a985289e336df9fe93d7e929526a441b7ff299413f024e49f05cf2314b90f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspect_smoke.gd</strong><dd><code>Add smoke test for read_property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-a046752542cde07fc09ed46ac7b1541937a79a2a282322efcc4711ca346621dd">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document new get_node_property tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Update tool contracts with get_node_property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/242/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

