### PR TITLE
feat(inspection): get_node_groups — read a node's group memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **127 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **128 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -430,6 +430,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `get_selected_node` — the currently selected node in the editor
 - `get_node_properties` — type, script, properties, children for any node path
 - `get_node_property` — read a single property by name, including built-in Godot properties
+- `get_node_groups` — a node's group memberships (for snapshot/rollback)
 
 ### Scene Edit (gated) — `mutating` / `destructive`
 - **Node creation:** `create_node`, `instance_scene`, `duplicate_node`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -200,6 +200,7 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 | `get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |
 | `get_node_property` | `node_path: str, property: str` | `NodeProperty { node_path, property, value, exists }` | `cmd_get_node_property` |
 | `get_node_property_list` | `node_path: str` | `NodePropertyList { node_path, type, properties[] }` | `cmd_get_node_property_list` |
+| `get_node_groups` | `node_path: str` | `NodeGroups { node_path, groups[] }` | `cmd_get_node_groups` |
 
 `SceneNode = { name, type, path, script?, children: [SceneNode] }`. Each node's `path` (#180)
 is scene-relative (`"."` for the root, e.g. `Player/Weapon` below it) and is accepted verbatim
@@ -213,6 +214,8 @@ with `RESOURCE_NOT_FOUND` (bad path) or `PRECONDITION_FAILED` (no scene open).
 built-in Godot properties** (`position`, `modulate`, `collision_layer`, …) that
 `get_node_properties` omits (it returns only script vars) — as `{ value, exists }`
 (`exists=false`, value null when absent), for snapshotting a value before a set (#215).
+`get_node_groups` returns a node's group memberships (editor-internal `_`-prefixed groups
+excluded) for snapshotting before `add_to_group`/`remove_from_group` (#216).
 
 #### Mutation (issue #6) — `mutating` (except `delete_node`)
 

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -22,6 +22,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
 	handlers["cmd_get_node_property"] = _cmd_get_node_property
 	handlers["cmd_get_node_property_list"] = _cmd_get_node_property_list
+	handlers["cmd_get_node_groups"] = _cmd_get_node_groups
 
 
 # -- handlers ----------------------------------------------------------------
@@ -96,6 +97,26 @@ func _cmd_get_node_property(params: Dictionary) -> Dictionary:
 		"value": read["value"],
 		"exists": read["exists"],
 	})
+
+
+func _cmd_get_node_groups(params: Dictionary) -> Dictionary:
+	if not params.has("node_path"):
+		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node_path := str(params["node_path"])
+	if node_path.begins_with("/"):
+		node_path = node_path.substr(1)
+	# Also strip "root/" prefix commonly hallucinated by LLMs
+	if node_path.begins_with("root/"):
+		node_path = node_path.substr(5)
+	if node_path.is_empty():
+		node_path = "."
+	var node: Node = root.get_node_or_null(NodePath(node_path))
+	if node == null:
+		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
+	return _router._ok({"node_path": str(params["node_path"]), "groups": Inspect.node_groups(node)})
 
 
 func _cmd_get_node_property_list(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -74,6 +74,18 @@ static func read_property(node: Node, property: String) -> Dictionary:
 	return {"value": null, "exists": false}
 
 
+## A node's group memberships as plain strings, sorted, excluding editor-internal
+## groups (names beginning with "_") — issue #216. Inverts add/remove_from_group.
+static func node_groups(node: Node) -> Array:
+	var out: Array = []
+	for g in node.get_groups():
+		var name := String(g)
+		if not name.begins_with("_"):
+			out.append(name)
+	out.sort()
+	return out
+
+
 ## A resource's editable+stored properties, JSON-coerced (issue #34). Unlike nodes
 ## (script vars), built-in resource fields are EDITOR|STORAGE, so filter on those and
 ## drop the base Resource bookkeeping fields.

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -20,6 +20,7 @@ func _initialize() -> void:
 	_test_serialize_tree(failures)
 	_test_node_properties(failures)
 	_test_read_property(failures)
+	_test_node_groups(failures)
 	_test_node_info(failures)
 
 	if failures.is_empty():
@@ -157,6 +158,19 @@ func _test_read_property(failures: Array[String]) -> void:
 	_eq(failures, "read.absent.exists", absent.get("exists"), false)
 	_eq(failures, "read.absent.value", absent.get("value"), null)
 	node.free()
+
+
+func _test_node_groups(failures: Array[String]) -> void:
+	# node_groups returns sorted plain-string memberships, excluding internal "_" groups (#216).
+	var node := Node2D.new()
+	node.add_to_group("spawnable")
+	node.add_to_group("enemies")
+	node.add_to_group("_internal")  # editor-internal — must be filtered out
+	_eq(failures, "groups", Inspect.node_groups(node), ["enemies", "spawnable"])
+	var bare := Node.new()
+	_eq(failures, "groups.empty", Inspect.node_groups(bare), [])
+	node.free()
+	bare.free()
 
 
 func _test_node_info(failures: Array[String]) -> void:

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -85,6 +85,17 @@ class NodeProperty(BaseModel):
     exists: bool = False
 
 
+class NodeGroups(BaseModel):
+    """A node's group memberships (issue #216), editor-internal groups excluded.
+
+    Inverts ``add_to_group`` / ``remove_from_group`` and lets ``delete_node`` restore
+    membership.
+    """
+
+    node_path: str
+    groups: list[str] = Field(default_factory=list)
+
+
 class SelectedNode(BaseModel):
     """The selected node, or ``selected=None`` when nothing is selected."""
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -14,6 +14,7 @@ from mcp_server.categories import INSPECTION_TAG
 from mcp_server.constraints import MaxDepth
 from mcp_server.models.inspection import (
     ActiveScene,
+    NodeGroups,
     NodeInfo,
     NodeProperty,
     NodePropertyList,
@@ -131,3 +132,13 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         return NodePropertyList(
             **await route(bridge, "cmd_get_node_property_list", {"node_path": node_path})
         )
+
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
+    async def get_node_groups(node_path: str) -> NodeGroups:
+        """List the groups the node at ``node_path`` belongs to (``{groups: [name]}``),
+        excluding editor-internal groups (names beginning with "_"). Use it to snapshot
+        membership before ``add_to_group`` / ``remove_from_group`` (or a delete) so the
+        change is reversible. Errors with RESOURCE_NOT_FOUND if the path doesn't resolve,
+        or PRECONDITION_FAILED if no scene is open.
+        """
+        return NodeGroups(**await route(bridge, "cmd_get_node_groups", {"node_path": node_path}))

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -111,6 +111,15 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "exists": False,
                 },
             )
+        case "cmd_get_node_groups":
+            if cmd.params.get("node_path") == "Missing":
+                return ResponseEnvelope.failure(
+                    cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Missing'."
+                )
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"node_path": cmd.params["node_path"], "groups": ["enemies", "spawnable"]},
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 
 
@@ -246,6 +255,24 @@ async def test_get_node_property_missing_node_is_structured_error() -> None:
     assert result.is_error
 
 
+async def test_get_node_groups_success() -> None:
+    # #216: returns the node's group memberships (so add/remove_from_group is invertible).
+    conn = FakeAddonConnection(responder=_populated)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("get_node_groups", {"node_path": "Player"})
+    data = result.structured_content
+    assert data["node_path"] == "Player"
+    assert data["groups"] == ["enemies", "spawnable"]
+
+
+async def test_get_node_groups_missing_is_structured_error() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool(
+            "get_node_groups", {"node_path": "Missing"}, raise_on_error=False
+        )
+    assert result.is_error
+
+
 async def test_inspection_tools_are_read_only() -> None:
     async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
         tools = await client.list_tools()
@@ -257,6 +284,7 @@ async def test_inspection_tools_are_read_only() -> None:
         "get_selected_node",
         "get_node_properties",
         "get_node_property",
+        "get_node_groups",
     ):
         assert by_name[name].meta is not None
         assert by_name[name].meta.get("safety_class") == "read_only"

--- a/tests/integration/test_inspection_e2e.py
+++ b/tests/integration/test_inspection_e2e.py
@@ -61,6 +61,12 @@ async def _run_checks() -> None:
         assert prop.ok is False
         assert prop.error == "PRECONDITION_FAILED"
         assert prop.required == "active_scene"
+
+        # The new group-read handler is registered and routes the same way (#216).
+        groups = await bridge.send("cmd_get_node_groups", {"node_path": "Anything"})
+        assert groups.ok is False
+        assert groups.error == "PRECONDITION_FAILED"
+        assert groups.required == "active_scene"
     finally:
         await bridge.close()
 


### PR DESCRIPTION
### **User description**
## Summary
No MCP tool returned a node's groups, so `add_to_group` / `remove_from_group` can't be inverted and `delete_node` can't faithfully restore group membership (rollback enabler **G2**, found by audit #212).

Adds **`get_node_groups(node_path)`** → `{node_path, groups: [str]}`:
- **Addon** (`[Both]`): `cmd_get_node_groups` handler + `Inspect.node_groups()` lib helper — `node.get_groups()`, sorted, with editor-internal (`_`-prefixed) groups excluded.
- **MCP**: `read_only`, `inspection`-gated tool + `NodeGroups` model.

## Acceptance criteria
- [x] Returns a node's group memberships (`{groups: [str]}`)
- [x] Editor-internal groups filtered; `read_only`, `[Both]`

## Test plan
- **Addon (headless):** `inspect_smoke.gd::_test_node_groups` — sorted memberships, `_internal` excluded, empty case → `INSPECT_TEST_OK`. Handler passes `--check-only`.
- **Contract:** `test_inspection.py` — success, RESOURCE_NOT_FOUND for missing node, read-only meta.
- **E2E:** `test_inspection_e2e.py` — handler registered + precondition path (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 475 unit+contract pass, zero-skip clean. Docs + README updated (127 tools).

## Note
Shares files with #215 (also open) — both add to `inspection.py` / `scene_inspect.gd` / docs, so a trivial additive conflict is expected on whichever merges second. No functional dependency between them.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds `get_node_groups` MCP tool for rollback enabler G2

- Enables inversion of `add_to_group`/`remove_from_group`

- Filters editor-internal groups (prefixed with "_")

- Supports `delete_node` faithful group restoration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCP Server"] -- "get_node_groups" --> B["Addon Handler"]
  B -- "cmd_get_node_groups" --> C["scene_inspect.gd"]
  C -- "Inspect.node_groups()" --> D["Node groups"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>inspection.py</strong><dd><code>Add NodeGroups model for group memberships</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-45806d2c459fe7dbb15e90f53c37192b5e4140ab53ed87ffc293a30f7b33edfa">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspection.py</strong><dd><code>Register get_node_groups MCP tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-eaaefb58a15b52cc64457889aff9fdfa9a10aadebf62c85b676e43375f167bf0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_inspect.gd</strong><dd><code>Implement cmd_get_node_groups handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-93f640e48d1dd80cc0c6e5b70a9d2a9f3102ed5b878c2d99d5f78fc7698a7f42">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_inspect.gd</strong><dd><code>Add node_groups() helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-f46999a59ce9b8f6f5042f77e6b0f9c181037b948b691f6e06d4c7b02efeb8e7">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_inspection.py</strong><dd><code>Add contract tests for get_node_groups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-f52b5e8ce780e310798b29270e857c1ade095a13a2af6ff9c76176e54a5e24b9">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_inspection_e2e.py</strong><dd><code>Verify handler registration and precondition checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-a84a985289e336df9fe93d7e929526a441b7ff299413f024e49f05cf2314b90f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspect_smoke.gd</strong><dd><code>Add smoke test for node groups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-a046752542cde07fc09ed46ac7b1541937a79a2a282322efcc4711ca346621dd">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document new get_node_groups tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Update tool contracts with get_node_groups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/243/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

