### PR TITLE
refactor(addon): extract normalize_node_path helper, cover with a test (closes #244)

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -390,15 +390,7 @@ func _resolve(raw_path: Variant) -> Dictionary:
 	var root := EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	var path_str := str(raw_path)
-	# Strip leading slashes ("/Player" -> "Player")
-	if path_str.begins_with("/"):
-		path_str = path_str.substr(1)
-	# Also strip "root/" prefix commonly hallucinated by LLMs ("/root/Player" -> "Player")
-	if path_str.begins_with("root/"):
-		path_str = path_str.substr(5)
-	if path_str.is_empty():
-		path_str = "."
+	var path_str := Inspect.normalize_node_path(str(raw_path))
 	var node: Node = root.get_node_or_null(NodePath(path_str))
 	if node == null:
 		return _fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(raw_path))

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -57,14 +57,7 @@ func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
 	var root: Node = EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	var node_path := str(params["node_path"])
-	if node_path.begins_with("/"):
-		node_path = node_path.substr(1)
-	# Also strip "root/" prefix commonly hallucinated by LLMs
-	if node_path.begins_with("root/"):
-		node_path = node_path.substr(5)
-	if node_path.is_empty():
-		node_path = "."
+	var node_path := Inspect.normalize_node_path(str(params["node_path"]))
 	var node: Node = root.get_node_or_null(NodePath(node_path))
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
@@ -79,14 +72,7 @@ func _cmd_get_node_property(params: Dictionary) -> Dictionary:
 	var root: Node = EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	var node_path := str(params["node_path"])
-	if node_path.begins_with("/"):
-		node_path = node_path.substr(1)
-	# Also strip "root/" prefix commonly hallucinated by LLMs
-	if node_path.begins_with("root/"):
-		node_path = node_path.substr(5)
-	if node_path.is_empty():
-		node_path = "."
+	var node_path := Inspect.normalize_node_path(str(params["node_path"]))
 	var node: Node = root.get_node_or_null(NodePath(node_path))
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
@@ -105,14 +91,7 @@ func _cmd_get_node_groups(params: Dictionary) -> Dictionary:
 	var root: Node = EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	var node_path := str(params["node_path"])
-	if node_path.begins_with("/"):
-		node_path = node_path.substr(1)
-	# Also strip "root/" prefix commonly hallucinated by LLMs
-	if node_path.begins_with("root/"):
-		node_path = node_path.substr(5)
-	if node_path.is_empty():
-		node_path = "."
+	var node_path := Inspect.normalize_node_path(str(params["node_path"]))
 	var node: Node = root.get_node_or_null(NodePath(node_path))
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
@@ -125,14 +104,7 @@ func _cmd_get_node_property_list(params: Dictionary) -> Dictionary:
 	var root: Node = EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	var node_path := str(params["node_path"])
-	if node_path.begins_with("/"):
-		node_path = node_path.substr(1)
-	# Also strip "root/" prefix commonly hallucinated by LLMs
-	if node_path.begins_with("root/"):
-		node_path = node_path.substr(5)
-	if node_path.is_empty():
-		node_path = "."
+	var node_path := Inspect.normalize_node_path(str(params["node_path"]))
 	var node: Node = root.get_node_or_null(NodePath(node_path))
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))

--- a/godot/addons/godot_mcp/handlers/scene_session.gd
+++ b/godot/addons/godot_mcp/handlers/scene_session.gd
@@ -93,14 +93,7 @@ func _cmd_select_nodes(params: Dictionary) -> Dictionary:
 	selection.clear()
 	var selected: Array = []
 	for raw_path in node_paths:
-		var path_str := str(raw_path)
-		if path_str.begins_with("/"):
-			path_str = path_str.substr(1)
-		# Also strip "root/" prefix commonly hallucinated by LLMs
-		if path_str.begins_with("root/"):
-			path_str = path_str.substr(5)
-		if path_str.is_empty():
-			path_str = "."
+		var path_str := Inspect.normalize_node_path(str(raw_path))
 		var node := root.get_node_or_null(NodePath(path_str))
 		if node == null:
 			return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % path_str)

--- a/godot/addons/godot_mcp/scene_inspect.gd
+++ b/godot/addons/godot_mcp/scene_inspect.gd
@@ -86,6 +86,21 @@ static func node_groups(node: Node) -> Array:
 	return out
 
 
+## Normalize an agent-supplied node path before resolving it (issue #244): tolerate a
+## leading "/" and a "root/" prefix (both commonly hallucinated by LLMs), and map an
+## empty path to "." (the scene root). Pure string transform — the single source used
+## by every path-taking handler. "/root/Player" → "Player"; "" → ".".
+static func normalize_node_path(raw: String) -> String:
+	var path := raw
+	if path.begins_with("/"):
+		path = path.substr(1)
+	if path.begins_with("root/"):
+		path = path.substr(5)
+	if path.is_empty():
+		path = "."
+	return path
+
+
 ## A resource's editable+stored properties, JSON-coerced (issue #34). Unlike nodes
 ## (script vars), built-in resource fields are EDITOR|STORAGE, so filter on those and
 ## drop the base Resource bookkeeping fields.

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -21,6 +21,7 @@ func _initialize() -> void:
 	_test_node_properties(failures)
 	_test_read_property(failures)
 	_test_node_groups(failures)
+	_test_normalize_node_path(failures)
 	_test_node_info(failures)
 
 	if failures.is_empty():
@@ -171,6 +172,15 @@ func _test_node_groups(failures: Array[String]) -> void:
 	_eq(failures, "groups.empty", Inspect.node_groups(bare), [])
 	node.free()
 	bare.free()
+
+
+func _test_normalize_node_path(failures: Array[String]) -> void:
+	# Tolerates LLM-hallucinated absolute/`root/` prefixes; empty → "." (#244).
+	_eq(failures, "norm.root_abs", Inspect.normalize_node_path("/root/Player"), "Player")
+	_eq(failures, "norm.root_rel", Inspect.normalize_node_path("root/Player"), "Player")
+	_eq(failures, "norm.abs", Inspect.normalize_node_path("/Player"), "Player")
+	_eq(failures, "norm.empty", Inspect.normalize_node_path(""), ".")
+	_eq(failures, "norm.plain", Inspect.normalize_node_path("Player/Gun"), "Player/Gun")
 
 
 func _test_node_info(failures: Array[String]) -> void:


### PR DESCRIPTION
## Summary
Surfaced by the Qodo review of #242: the agent node-path normalization — strip a leading `/`, strip a `root/` prefix (both commonly hallucinated by LLMs), map empty → `"."` — was **duplicated across 6 call sites in 3 files** and **untested** (the contract tests use a fake bridge that echoes the path; the headless smoke tests covered lib serializers, not this transform). A refactor could silently break the primary LLM-path use case.

This extracts it into a single pure helper **`Inspect.normalize_node_path(raw) -> String`** and routes every call site through it:
- `handlers/scene_inspect.gd` — `get_node_properties` / `get_node_property` / `get_node_property_list` / `get_node_groups` (4 copies)
- `command_router.gd` — `_resolve` (the shared node resolver)
- `handlers/scene_session.gd` — `select_nodes` loop

Addon-only; no MCP surface change.

## Test plan
- `godot/tests/inspect_smoke.gd::_test_normalize_node_path` (headless) — `"/root/Player"→"Player"`, `"root/Player"→"Player"`, `"/Player"→"Player"`, `""→"."`, `"Player/Gun"` unchanged → `INSPECT_TEST_OK`.
- `--check-only` parse passes for all 4 changed scripts.
- The only remaining `begins_with("root/")` is inside the helper itself (single source).
- Python suite unaffected (no `.py` changed): 478 unit+contract pass.

Closes #244
🤖 Generated with [Claude Code](https://claude.com/claude-code)