### PR TITLE
Add delete_resource_file primitive with undo support and safety checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **128 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **129 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -456,6 +456,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `search_files` — by name glob and/or content substring
 - `get_setting`, `set_setting` — project settings
 - `resolve_uid` — path ↔ uid:// resolution
+- `delete_resource_file` — delete a `res://` file (destructive; inverse of file-creating tools)
 
 ### Editor (gated) — `read_only`
 - `capture_editor_screenshot` — returns a PNG image for vision-capable clients

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -346,11 +346,15 @@ Import external files (local paths or HTTP URLs) into a Godot project and assemb
 | `get_setting` | `name` | `SettingValue { name, value, exists }` | `read_only` |
 | `set_setting` | `name, value, dry_run=False` | `SetSettingResult { name, value, set, dry_run }` | `mutating` |
 | `resolve_uid` | `value` (a `res://` path or `uid://…`) | `UidResolution { uid?, path? }` | `read_only` |
+| `delete_resource_file` | `path, confirm=False, dry_run=False` | `DeleteResourceFileResult { path, deleted, had_uid, dry_run }` | `destructive` |
 
 Hidden entries (`.godot`, `.git`, …) are skipped. `search_files` matches `name_glob`
 and/or `content` substring (truncating at `max_results`). `set_setting` coerces to the
 setting's existing type, persists to project settings (not undo-tracked), and accepts
-`dry_run`. `resolve_uid` picks direction by the input prefix.
+`dry_run`. `resolve_uid` picks direction by the input prefix. `delete_resource_file`
+removes a `res://` file (and its `.uid` sidecar) — the inverse of the file-creating tools;
+`destructive` (requires `confirm=True`, `dry_run` previews), `res://` containment enforced,
+undoable in the editor.
 
 #### Editor screenshots (issue #33) — category: `editor` (gated off by default)
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -260,6 +260,19 @@ func _write_file_text(path: String, text: String) -> void:
 	EditorInterface.get_resource_filesystem().update_file(path)
 
 
+## Write raw bytes to a file (creating parent dirs) and re-import it. The UndoRedo
+## undo callback for file deletion (#217), so binary resources round-trip exactly.
+func _write_file_bytes(path: String, bytes: PackedByteArray) -> void:
+	var base_dir := path.get_base_dir()
+	if not DirAccess.dir_exists_absolute(base_dir):
+		DirAccess.make_dir_recursive_absolute(base_dir)
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file != null:
+		file.store_buffer(bytes)
+		file.close()
+	EditorInterface.get_resource_filesystem().update_file(path)
+
+
 func _remove_file(path: String) -> void:
 	if FileAccess.file_exists(path):
 		DirAccess.remove_absolute(path)

--- a/godot/addons/godot_mcp/handlers/project_fs.gd
+++ b/godot/addons/godot_mcp/handlers/project_fs.gd
@@ -89,6 +89,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_search_files"] = _cmd_search_files
 	handlers["cmd_set_setting"] = _cmd_set_setting
 	handlers["cmd_uid_to_path"] = _cmd_uid_to_path
+	handlers["cmd_delete_resource_file"] = _cmd_delete_resource_file
 
 
 # -- handlers ----------------------------------------------------------------
@@ -165,5 +166,29 @@ func _cmd_uid_to_path(params: Dictionary) -> Dictionary:
 	if id == -1 or not ResourceUID.has_id(id):
 		return _router._fail("RESOURCE_NOT_FOUND", "Unknown UID '%s'." % uid)
 	return _router._ok({"uid": uid, "path": ResourceUID.get_id_path(id)})
+
+
+## Delete a res:// file and its .uid sidecar — the inverse of the file-creating
+## handlers (issue #217). res:// containment is enforced server-side; the check here
+## is defense-in-depth. Undoable: the file (and uid) bytes are captured first and
+## restored on undo, so binary resources round-trip exactly.
+func _cmd_delete_resource_file(params: Dictionary) -> Dictionary:
+	var path := str(params.get("path", ""))
+	if not path.begins_with("res://"):
+		return _router._fail("VALIDATION_ERROR", "path must be a res:// file.")
+	if not FileAccess.file_exists(path):
+		return _router._fail("RESOURCE_NOT_FOUND", "No file at '%s'." % path)
+	var bytes := FileAccess.get_file_as_bytes(path)
+	var uid_path := path + ".uid"
+	var had_uid := FileAccess.file_exists(uid_path)
+	var uid_bytes := FileAccess.get_file_as_bytes(uid_path) if had_uid else PackedByteArray()
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Delete file %s" % path)
+	ur.add_do_method(_router, "_remove_file_with_uid", path)
+	ur.add_undo_method(_router, "_write_file_bytes", path, bytes)
+	if had_uid:
+		ur.add_undo_method(_router, "_write_file_bytes", uid_path, uid_bytes)
+	ur.commit_action()
+	return _router._ok({"path": path, "deleted": true, "had_uid": had_uid})
 
 

--- a/mcp_server/models/project_fs.py
+++ b/mcp_server/models/project_fs.py
@@ -41,3 +41,13 @@ class SetSettingResult(BaseModel):
 class UidResolution(BaseModel):
     uid: str | None = None
     path: str | None = None
+
+
+class DeleteResourceFileResult(BaseModel):
+    """Result of deleting a ``res://`` file (issue #217). ``had_uid`` is true when a
+    ``.uid`` sidecar was removed alongside it."""
+
+    path: str
+    deleted: bool = False
+    had_uid: bool = False
+    dry_run: bool = False

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -123,7 +123,7 @@ def create_server(
     register_scene_session(mcp, bridge, approval)
     register_node_ops(mcp, bridge)
     register_resource_files(mcp, bridge)
-    register_project_fs(mcp, bridge)
+    register_project_fs(mcp, bridge, approval)
     register_physics(mcp, bridge)
     register_animation(mcp, bridge)
     register_scene_3d(mcp, bridge)

--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -84,9 +84,34 @@ async def _validate_script_path(
     return None
 
 
+async def _validate_delete_resource_path(
+    bridge: Bridge, command: str, params: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Fail a resource-file deletion whose ``path`` isn't a contained ``res://`` path
+    (issue #217) — mirrors the script-write containment hardening (#205)."""
+    if command != "cmd_delete_resource_file":
+        return None
+    path = params.get("path", "")
+    if not path.startswith("res://"):
+        return {
+            "ok": False,
+            "error": "PARAM_ERROR",
+            "hint": f"path must start with 'res://'. Got: '{path}'",
+            "required": "path",
+        }
+    if _escapes_res_root(path):
+        return {
+            "ok": False,
+            "error": "PARAM_ERROR",
+            "hint": f"path escapes the project root (res://). Got: '{path}'",
+            "required": "path",
+        }
+    return None
+
+
 # Each validator returns a PARAM_ERROR dict on failure, else None. Property
 # names are deliberately not validated server-side — the addon has better context.
-_VALIDATORS = (_validate_script_path,)
+_VALIDATORS = (_validate_script_path, _validate_delete_resource_path)
 
 
 async def _preflight_validate(

--- a/mcp_server/tools/project_fs.py
+++ b/mcp_server/tools/project_fs.py
@@ -2,7 +2,7 @@
 
 Explore the project on disk, search files, read/write project settings, and resolve
 resource UIDs. Gated `project` toolset. Reads are `read_only`; `set_setting` is
-`mutating` (persists to project settings).
+`mutating` (persists to project settings); `delete_resource_file` is `destructive`.
 """
 
 from __future__ import annotations
@@ -18,19 +18,28 @@ from mcp_server.defaults import (
     DEFAULT_SEARCH_MAX_RESULTS,
 )
 from mcp_server.models.project_fs import (
+    DeleteResourceFileResult,
     FilesystemTree,
     SearchResult,
     SetSettingResult,
     SettingValue,
     UidResolution,
 )
-from mcp_server.safety import MUTATING, READ_ONLY
-from mcp_server.tools._route import route, run_or_preview
+from mcp_server.safety import (
+    DESTRUCTIVE,
+    MUTATING,
+    READ_ONLY,
+    ApprovalGate,
+    enforce_preconditions,
+    require_bridge_connected,
+    require_confirmation,
+)
+from mcp_server.tools._route import route, run_or_preview, validate_or_raise
 
 PROJECT = {PROJECT_TAG}
 
 
-def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
+def register_project_fs(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate) -> None:
     """Register the project & filesystem tools."""
 
     @mcp.tool(meta=READ_ONLY, tags=PROJECT)
@@ -95,3 +104,30 @@ def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
         else:
             result = await route(bridge, "cmd_path_to_uid", {"path": value})
         return UidResolution(uid=result.get("uid"), path=result.get("path"))
+
+    @mcp.tool(meta=DESTRUCTIVE, tags=PROJECT)
+    @enforce_preconditions
+    async def delete_resource_file(
+        path: str, confirm: bool = False, dry_run: bool = False
+    ) -> DeleteResourceFileResult:
+        """Delete the ``res://`` file at ``path`` (and its ``.uid`` sidecar). The inverse
+        of the file-creating tools (create_scene, create_resource, create_tileset,
+        import_asset, …) — use it to roll back a file you just generated.
+
+        DESTRUCTIVE: requires ``confirm=True`` to actually delete; ``dry_run=True``
+        previews without confirming or deleting. ``res://`` containment is enforced (a
+        traversal or non-``res://`` path is rejected). Undoable in the editor (the file
+        bytes are restored on undo). Errors RESOURCE_NOT_FOUND if no file is at ``path``.
+        """
+        require_bridge_connected(bridge)
+        params = {"path": path}
+        if dry_run:
+            # Validate containment even on a dry_run so it can't preview an escaping
+            # path (parity with the script-write hardening, #205).
+            await validate_or_raise(bridge, "cmd_delete_resource_file", params)
+            return DeleteResourceFileResult(path=path, deleted=False, dry_run=True)
+        require_confirmation(confirm, "delete_resource_file")
+        await approval.require("delete_resource_file", "destructive", params)
+        return DeleteResourceFileResult(
+            **await route(bridge, "cmd_delete_resource_file", params)
+        )

--- a/tests/contract/test_project_fs.py
+++ b/tests/contract/test_project_fs.py
@@ -47,6 +47,14 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             return ResponseEnvelope.success(cmd.id, {"path": p["path"], "uid": "uid://abc123"})
         case "cmd_uid_to_path":
             return ResponseEnvelope.success(cmd.id, {"uid": p["uid"], "path": "res://a.gd"})
+        case "cmd_delete_resource_file":
+            if p["path"] == "res://missing.tres":
+                return ResponseEnvelope.failure(
+                    cmd.id, "RESOURCE_NOT_FOUND", "No file at 'res://missing.tres'."
+                )
+            return ResponseEnvelope.success(
+                cmd.id, {"path": p["path"], "deleted": True, "had_uid": True}
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -116,3 +124,67 @@ async def test_resolve_uid_both_directions() -> None:
     assert from_path.structured_content["uid"] == "uid://abc123"
     assert from_uid.structured_content["path"] == "res://a.gd"
     assert "cmd_path_to_uid" in _commands(conn) and "cmd_uid_to_path" in _commands(conn)
+
+
+async def test_delete_resource_file_requires_confirm() -> None:
+    # Destructive: without confirm (and not a dry_run) it must refuse, not delete.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "project"})
+        result = await client.call_tool(
+            "delete_resource_file", {"path": "res://gen.tres"}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "confirm" in str(result.content)
+    assert "cmd_delete_resource_file" not in _commands(conn)
+
+
+async def test_delete_resource_file_dry_run_previews() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "project"})
+        dry = await client.call_tool(
+            "delete_resource_file", {"path": "res://gen.tres", "dry_run": True}
+        )
+    assert dry.structured_content["deleted"] is False
+    assert dry.structured_content["dry_run"] is True
+    assert "cmd_delete_resource_file" not in _commands(conn)
+
+
+async def test_delete_resource_file_confirmed_deletes() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "project"})
+        done = await client.call_tool(
+            "delete_resource_file", {"path": "res://gen.tres", "confirm": True}
+        )
+    data = done.structured_content
+    assert data["deleted"] is True and data["had_uid"] is True
+    assert "cmd_delete_resource_file" in _commands(conn)
+
+
+async def test_delete_resource_file_rejects_escape() -> None:
+    # res:// containment (#205): a traversal/non-res path is rejected before the bridge.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "project"})
+        escape = await client.call_tool(
+            "delete_resource_file",
+            {"path": "res://../secret.tres", "confirm": True},
+            raise_on_error=False,
+        )
+        absolute = await client.call_tool(
+            "delete_resource_file",
+            {"path": "/etc/passwd", "confirm": True},
+            raise_on_error=False,
+        )
+    assert escape.is_error and absolute.is_error
+    assert "cmd_delete_resource_file" not in _commands(conn)
+
+
+async def test_delete_resource_file_is_destructive() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "project"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["delete_resource_file"].meta["safety_class"] == "destructive"

--- a/tests/integration/test_project_fs_e2e.py
+++ b/tests/integration/test_project_fs_e2e.py
@@ -85,6 +85,17 @@ async def _run() -> None:
         # Sandbox: paths outside the project (res://) are rejected.
         outside = await bridge.send("cmd_get_filesystem_tree", {"directory": "/etc"})
         assert outside.ok is False and outside.error == "VALIDATION_ERROR"
+
+        # delete_resource_file round-trip (#217): create a throwaway file, delete it,
+        # confirm it's gone, and that a second delete + a non-res:// path are rejected.
+        tmp = "res://tmp_e2e_delete.gd"
+        await _ok(bridge, "cmd_write_script", {"script_path": tmp, "content": "extends Node\n"})
+        deleted = await _ok(bridge, "cmd_delete_resource_file", {"path": tmp})
+        assert deleted["deleted"] is True and deleted["path"] == tmp
+        gone = await bridge.send("cmd_delete_resource_file", {"path": tmp})
+        assert gone.ok is False and gone.error == "RESOURCE_NOT_FOUND"
+        bad = await bridge.send("cmd_delete_resource_file", {"path": "/etc/passwd"})
+        assert bad.ok is False and bad.error == "VALIDATION_ERROR"
     finally:
         await bridge.close()
 
@@ -106,3 +117,6 @@ def test_live_project_fs() -> None:
         except subprocess.TimeoutExpired:
             editor.kill()
         PROJECT_GODOT.write_text(snapshot)  # undo the set_setting write
+        # Clean up the delete round-trip's throwaway file if the test bailed early.
+        for leftover in ("tmp_e2e_delete.gd", "tmp_e2e_delete.gd.uid"):
+            (GODOT_PROJECT / leftover).unlink(missing_ok=True)


### PR DESCRIPTION
### **User description**
## Summary
No MCP tool could delete a `res://` file, so every file-creating tool (`create_scene`, `create_resource`, `create_tileset`, `create_visual_shader`, `import_asset`, `create_material_from_textures`, `create_mesh_library`, `scaffold_project`) was **one-way** — the agent couldn't roll back a file it generated (rollback enabler **G3**, found by audit #212).

The issue posed a decision (add a delete primitive vs. rely on git). This takes **Option 1** — the in-MCP inverse, consistent with the rollback arc (#146):

**`delete_resource_file(path, confirm=False, dry_run=False)`** → `{path, deleted, had_uid, dry_run}`:
- **`destructive`** safety class — requires `confirm=True`; `dry_run=True` previews without confirming or deleting; routed through the optional `ApprovalGate` (project_fs now receives `approval`).
- **`res://` containment** enforced server-side via a new `_route.py` validator (`PARAM_ERROR` on a non-`res://` or traversal/absolute path) — mirrors the #205 write hardening; validated even on `dry_run`.
- **Addon** (`[Both]`): `cmd_delete_resource_file` removes the file **and its `.uid` sidecar** via `EditorUndoRedoManager`, capturing the bytes first so the delete is **undoable** and **binary resources round-trip exactly** (new `_write_file_bytes` router helper). Defense-in-depth `res://` check addon-side.

## Acceptance criteria
- [x] `delete_resource_file(path, confirm)` — destructive (`confirm=True`), `res://` containment, `.uid` parity, EditorFileSystem rescan, `[Both]`

## Test plan
- **Contract** (`tests/contract/test_project_fs.py`): requires confirm; `dry_run` previews without sending; confirmed delete routes; containment rejects `res://../…` and `/etc/…` before the bridge; `destructive` meta.
- **Addon**: `--check-only` parse passes; inspect-smoke regression `INSPECT_TEST_OK`.
- **E2E** (`tests/integration/test_project_fs_e2e.py`): create → delete → confirm gone; second delete → `RESOURCE_NOT_FOUND`; non-`res://` → `VALIDATION_ERROR` (runs in CI; locally a pre-existing editor occupies the bridge port).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 483 unit+contract pass, zero-skip clean. Docs + README (129 tools).

Closes #217
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds file deletion primitive for `res://` files

- Enforces `res://` containment and undo support

- Requires confirmation for destructive operations

- Updates tool contracts and documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["delete_resource_file tool"] -- "requires confirm" --> B["DESTRUCTIVE safety class"]
  A -- "res:// containment" --> C["_validate_delete_resource_path"]
  A -- "undoable via EditorUndoRedoManager" --> D["_remove_file_with_uid"]
  B -- "dry_run previews" --> E["validate_or_raise"]
  C -- "rejects escapes" --> F["PARAM_ERROR"]
  D -- "captures bytes" --> G["_write_file_bytes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>project_fs.py</strong><dd><code>Add result model for delete operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-68da4d3660c562e509c4dca6cd09b83be83cf0890d7f0dcccac08fa67b6227ee">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>project_fs.py</strong><dd><code>Implement delete_resource_file tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-57f51063bdf8edff1bc3223daba69188202b052640f5b7eff8a1886e12cbffec">+40/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_router.gd</strong><dd><code>Add helper for byte-level file writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>project_fs.gd</strong><dd><code>Implement delete handler with undo support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-653cd125f6ff6497196d75a226fbc31b22b3b6154cd75e8c503761906f98e7fb">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server.py</strong><dd><code>Pass approval gate to project FS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-f24be50e829d65c1c3626dad15c1b306dd882fc305e41024df58c9a7649f07b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>_route.py</strong><dd><code>Add path validation for delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-01da951849455fe4b33f27e100cc270a20348263d7d674dbab63428dd369baf4">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_project_fs.py</strong><dd><code>Add contract tests for delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-15c5df54468608cd7b6e11537b94cdc9a4bc1ad0874f7919658a5631c008124a">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_project_fs_e2e.py</strong><dd><code>Add end-to-end tests for delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-dfb643a848d87f3824a661f7fe4355b6ba35f035f11ffe120df04dc1578ff47f">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document new delete tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Update tool contracts for delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/246/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

