### PR TITLE
feat(animation): add list_animations and get_animation read tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **129 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **131 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -464,9 +464,10 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 ### Physics (gated) — `mutating`
 - `setup_physics_body`, `setup_collision`, `set_physics_layers`, `add_raycast`
 
-### Animation (gated) — `mutating`
+### Animation (gated) — `mutating` / `read_only`
 - `create_animation`, `add_animation_track`, `insert_keyframe`
 - `create_animation_tree`, `add_state_machine_state`, `set_blend_tree_node`
+- `list_animations`, `get_animation` — read tracks/keyframes (for snapshot/rollback)
 
 ### 3D Scene (gated) — `mutating`
 - `add_mesh_instance`, `setup_camera`, `setup_lighting`, `setup_environment`, `gridmap_set_cell`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -395,13 +395,17 @@ Author AnimationPlayer animations and AnimationTree graphs. All `mutating`
 | `create_animation_tree` | `parent_path, name="AnimationTree", anim_player?, root_type="AnimationNodeStateMachine"` | `AnimationTreeResult { node_path, root_type }` |
 | `add_state_machine_state` | `tree_path, state_name, animation?` | `StateMachineStateResult { tree_path, state }` |
 | `set_blend_tree_node` | `tree_path, node_name, node_type` | `BlendTreeNodeResult { tree_path, node, node_type }` |
+| `list_animations` | `node_path` | `AnimationList { player_path, animations[] }` (`read_only`) |
+| `get_animation` | `node_path, animation_name` | `AnimationDetail { name, length, tracks[]{type, path, keys[]{time, value}} }` (`read_only`) |
 
 `create_animation` adds a default `AnimationLibrary` ("") if absent and rejects a
 duplicate name. `add_animation_track` returns the new track index; `track_type` is one
 of value/position_3d/rotation_3d/scale_3d/method/bezier/audio/animation. `insert_keyframe`
 accepts Godot string forms for `value` (e.g. `"Vector2(10, 20)"`, coerced via `str_to_var`).
 `add_state_machine_state` requires an `AnimationNodeStateMachine` root; `set_blend_tree_node`
-requires an `AnimationNodeBlendTree` root and an `AnimationNode` `node_type`.
+requires an `AnimationNodeBlendTree` root and an `AnimationNode` `node_type`. `list_animations`
+and `get_animation` (#218) are the `read_only` inverses of the writers — `get_animation`
+returns each track's keyframes (values JSON-coerced) for snapshot/rollback.
 
 #### 3D scene (issue #40) — category: `scene_3d` (gated off by default)
 

--- a/godot/addons/godot_mcp/animation_read.gd
+++ b/godot/addons/godot_mcp/animation_read.gd
@@ -3,7 +3,7 @@ class_name MCPAnimationRead
 extends RefCounted
 ## Pure, read-only serialization of Animation resources (issue #218 — rollback
 ## enabler G4). Takes Animation/AnimationPlayer resources (never EditorInterface),
-## so it is verifiable headlessly (see godot/tests/animation_smoke.gd). Keyframe
+## so it is verifiable headlessly (see godot/tests/animation_read_smoke.gd). Keyframe
 ## values are JSON-safe via MCPTypeCoerce. Inverts the animation writers
 ## (create_animation / add_animation_track / insert_keyframe).
 

--- a/godot/addons/godot_mcp/animation_read.gd
+++ b/godot/addons/godot_mcp/animation_read.gd
@@ -1,0 +1,49 @@
+@tool
+class_name MCPAnimationRead
+extends RefCounted
+## Pure, read-only serialization of Animation resources (issue #218 — rollback
+## enabler G4). Takes Animation/AnimationPlayer resources (never EditorInterface),
+## so it is verifiable headlessly (see godot/tests/animation_smoke.gd). Keyframe
+## values are JSON-safe via MCPTypeCoerce. Inverts the animation writers
+## (create_animation / add_animation_track / insert_keyframe).
+
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+
+# Animation.TrackType enum → the names the writer accepts (mirror of the handler's
+# _TRACK_TYPES), so a read round-trips back into add_animation_track.
+const _TYPE_NAMES := {
+	Animation.TYPE_VALUE: "value",
+	Animation.TYPE_POSITION_3D: "position_3d",
+	Animation.TYPE_ROTATION_3D: "rotation_3d",
+	Animation.TYPE_SCALE_3D: "scale_3d",
+	Animation.TYPE_METHOD: "method",
+	Animation.TYPE_BEZIER: "bezier",
+	Animation.TYPE_AUDIO: "audio",
+	Animation.TYPE_ANIMATION: "animation",
+}
+
+
+## All animation names on a player (across its libraries), as plain strings.
+static func names(player: AnimationPlayer) -> Array:
+	var out: Array = []
+	for n in player.get_animation_list():
+		out.append(String(n))
+	return out
+
+
+## { name, length, tracks:[{type, path, keys:[{time, value}]}] }, JSON-coerced.
+static func serialize(anim_name: String, animation: Animation) -> Dictionary:
+	var tracks: Array = []
+	for i in animation.get_track_count():
+		var keys: Array = []
+		for k in animation.track_get_key_count(i):
+			keys.append({
+				"time": animation.track_get_key_time(i, k),
+				"value": Coerce.to_json(animation.track_get_key_value(i, k)),
+			})
+		tracks.append({
+			"type": _TYPE_NAMES.get(animation.track_get_type(i), "unknown"),
+			"path": String(animation.track_get_path(i)),
+			"keys": keys,
+		})
+	return {"name": anim_name, "length": animation.length, "tracks": tracks}

--- a/godot/addons/godot_mcp/handlers/animation.gd
+++ b/godot/addons/godot_mcp/handlers/animation.gd
@@ -7,6 +7,7 @@ extends RefCounted
 ## returns a response body (without id) via the router's _ok / _fail builders.
 
 const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+const AnimRead := preload("res://addons/godot_mcp/animation_read.gd")
 
 var _router: MCPCommandRouter
 
@@ -22,6 +23,8 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_create_animation_tree"] = _cmd_create_animation_tree
 	handlers["cmd_insert_keyframe"] = _cmd_insert_keyframe
 	handlers["cmd_set_blend_tree_node"] = _cmd_set_blend_tree_node
+	handlers["cmd_list_animations"] = _cmd_list_animations
+	handlers["cmd_get_animation"] = _cmd_get_animation
 
 
 # -- handlers ----------------------------------------------------------------
@@ -215,3 +218,31 @@ func _resolve_player_animation(params: Dictionary) -> Dictionary:
 	if not player.has_animation(anim_name):
 		return _router._fail("RESOURCE_NOT_FOUND", "No animation '%s' on the AnimationPlayer." % anim_name)
 	return {"ok": true, "animation": player.get_animation(anim_name)}
+
+
+# -- read tools (rollback enabler G4, issue #218) ----------------------------
+
+func _cmd_list_animations(params: Dictionary) -> Dictionary:
+	var found := _router._resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var player: Node = found["node"]
+	if not (player is AnimationPlayer):
+		return _router._fail("VALIDATION_ERROR", "Node is not an AnimationPlayer.")
+	return _router._ok({
+		"player_path": str(params.get("node_path")),
+		"animations": AnimRead.names(player),
+	})
+
+
+func _cmd_get_animation(params: Dictionary) -> Dictionary:
+	var found := _router._resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var player: Node = found["node"]
+	if not (player is AnimationPlayer):
+		return _router._fail("VALIDATION_ERROR", "Node is not an AnimationPlayer.")
+	var anim_name := str(params.get("animation_name", ""))
+	if not player.has_animation(anim_name):
+		return _router._fail("RESOURCE_NOT_FOUND", "No animation '%s' on the AnimationPlayer." % anim_name)
+	return _router._ok(AnimRead.serialize(anim_name, player.get_animation(anim_name)))

--- a/godot/tests/animation_read_smoke.gd
+++ b/godot/tests/animation_read_smoke.gd
@@ -1,0 +1,66 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPAnimationRead (issue #218).
+##
+## Run via: godot --headless --path godot/ --script res://tests/animation_read_smoke.gd
+## Builds a real AnimationPlayer + Animation (no EditorInterface) and verifies the
+## pure read serialization round-trips against the live Godot Animation API.
+
+const AnimRead := preload("res://addons/godot_mcp/animation_read.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+	var player := AnimationPlayer.new()
+	var lib := AnimationLibrary.new()
+	player.add_animation_library("", lib)
+
+	var anim := Animation.new()
+	anim.length = 2.0
+	var ti := anim.add_track(Animation.TYPE_VALUE)
+	anim.track_set_path(ti, NodePath("Sprite2D:position"))
+	anim.track_insert_key(ti, 0.5, Vector2(10, 20))
+	lib.add_animation("walk", anim)
+	lib.add_animation("idle", Animation.new())
+
+	# names: all animations on the player (sorted by Godot's own order).
+	var names: Array = AnimRead.names(player)
+	if not ("walk" in names and "idle" in names and names.size() == 2):
+		failures.append("names wrong: %s" % str(names))
+
+	# serialize: length, track type/path, and a JSON-coerced keyframe value.
+	var detail: Dictionary = AnimRead.serialize("walk", anim)
+	_eq(failures, "name", detail.get("name"), "walk")
+	_eq(failures, "length", detail.get("length"), 2.0)
+	var tracks: Array = detail.get("tracks")
+	if tracks.size() != 1:
+		failures.append("track count: %s" % str(tracks))
+	else:
+		var t: Dictionary = tracks[0]
+		_eq(failures, "type", t.get("type"), "value")
+		_eq(failures, "path", t.get("path"), "Sprite2D:position")
+		var keys: Array = t.get("keys")
+		if keys.size() != 1:
+			failures.append("key count: %s" % str(keys))
+		else:
+			_eq(failures, "key.time", keys[0].get("time"), 0.5)
+			_eq(failures, "key.value", keys[0].get("value"), {"x": 10.0, "y": 20.0})
+
+	# Output must be JSON-safe.
+	if JSON.stringify(detail) == "":
+		failures.append("serialized animation is not JSON-safe")
+
+	player.free()
+	if failures.is_empty():
+		print("ANIM_READ_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("ANIM_READ_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/animation.py
+++ b/mcp_server/models/animation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class CreateAnimationResult(BaseModel):
@@ -10,6 +12,34 @@ class CreateAnimationResult(BaseModel):
     animation: str
     length: float = 0.0
     dry_run: bool = False
+
+
+class AnimationList(BaseModel):
+    """The animations on an AnimationPlayer (issue #218)."""
+
+    player_path: str
+    animations: list[str] = Field(default_factory=list)
+
+
+class AnimationKey(BaseModel):
+    """One keyframe: ``time`` and its JSON-coerced ``value``."""
+
+    time: float
+    value: Any = None
+
+
+class AnimationTrack(BaseModel):
+    type: str
+    path: str
+    keys: list[AnimationKey] = Field(default_factory=list)
+
+
+class AnimationDetail(BaseModel):
+    """An animation's tracks and keyframes (issue #218) — inverts the animation writers."""
+
+    name: str
+    length: float = 0.0
+    tracks: list[AnimationTrack] = Field(default_factory=list)
 
 
 class AnimationTrackResult(BaseModel):

--- a/mcp_server/tools/animation.py
+++ b/mcp_server/tools/animation.py
@@ -21,6 +21,8 @@ from mcp_server.defaults import (
     DEFAULT_ANIMATION_TREE_ROOT_TYPE,
 )
 from mcp_server.models.animation import (
+    AnimationDetail,
+    AnimationList,
     AnimationTrackResult,
     AnimationTreeResult,
     BlendTreeNodeResult,
@@ -28,8 +30,8 @@ from mcp_server.models.animation import (
     KeyframeResult,
     StateMachineStateResult,
 )
-from mcp_server.safety import MUTATING, enforce_preconditions, require_node_exists
-from mcp_server.tools._route import run_or_preview
+from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_node_exists
+from mcp_server.tools._route import route, run_or_preview
 
 ANIMATION = {ANIMATION_TAG}
 
@@ -167,3 +169,22 @@ def register_animation(mcp: FastMCP, bridge: Bridge) -> None:
         return await run_or_preview(
             dry_run, BlendTreeNodeResult, preview, bridge, "cmd_set_blend_tree_node", params
         )
+
+    @mcp.tool(meta=READ_ONLY, tags=ANIMATION)
+    async def list_animations(node_path: str) -> AnimationList:
+        """List the animation names on the AnimationPlayer at ``node_path``. Pair with
+        ``get_animation`` to snapshot an animation before editing it — for rollback.
+        Errors if the node isn't an AnimationPlayer or doesn't resolve.
+        """
+        return AnimationList(**await route(bridge, "cmd_list_animations", {"node_path": node_path}))
+
+    @mcp.tool(meta=READ_ONLY, tags=ANIMATION)
+    async def get_animation(node_path: str, animation_name: str) -> AnimationDetail:
+        """Read an animation on the AnimationPlayer at ``node_path``: its ``length`` and
+        each ``track`` ({type, path, keys:[{time, value}]}), with keyframe values
+        JSON-coerced (Vector2 as {"x","y"}, …). The inverse of the animation writers
+        (create_animation / add_animation_track / insert_keyframe) — capture this before
+        a change to roll it back. Errors RESOURCE_NOT_FOUND if the animation is absent.
+        """
+        params = {"node_path": node_path, "animation_name": animation_name}
+        return AnimationDetail(**await route(bridge, "cmd_get_animation", params))

--- a/tests/contract/test_animation.py
+++ b/tests/contract/test_animation.py
@@ -46,6 +46,27 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 cmd.id,
                 {"tree_path": p["tree_path"], "node": p["node_name"], "node_type": p["node_type"]},
             )
+        case "cmd_list_animations":
+            return ResponseEnvelope.success(
+                cmd.id, {"player_path": p["node_path"], "animations": ["idle", "walk"]}
+            )
+        case "cmd_get_animation":
+            if p["animation_name"] == "missing":
+                return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No animation.")
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "name": p["animation_name"],
+                    "length": 2.0,
+                    "tracks": [
+                        {
+                            "type": "value",
+                            "path": "Sprite2D:position",
+                            "keys": [{"time": 0.5, "value": {"x": 10.0, "y": 20.0}}],
+                        }
+                    ],
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -154,3 +175,42 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_create_animation" not in _commands(conn)
+
+
+async def test_list_and_get_animation_reads() -> None:
+    # #218: read tools so animation writers become invertible (G4).
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "animation"})
+        listed = await client.call_tool("list_animations", {"node_path": "AnimationPlayer"})
+        detail = await client.call_tool(
+            "get_animation", {"node_path": "AnimationPlayer", "animation_name": "walk"}
+        )
+    assert listed.structured_content["animations"] == ["idle", "walk"]
+    data = detail.structured_content
+    assert data["name"] == "walk" and data["length"] == 2.0
+    track = data["tracks"][0]
+    assert track["type"] == "value" and track["path"] == "Sprite2D:position"
+    assert track["keys"][0] == {"time": 0.5, "value": {"x": 10.0, "y": 20.0}}
+    assert "cmd_list_animations" in _commands(conn) and "cmd_get_animation" in _commands(conn)
+
+
+async def test_get_animation_missing_is_structured_error() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "animation"})
+        result = await client.call_tool(
+            "get_animation",
+            {"node_path": "AnimationPlayer", "animation_name": "missing"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+
+
+async def test_animation_reads_are_read_only() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "animation"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["list_animations"].meta["safety_class"] == "read_only"
+    assert tools["get_animation"].meta["safety_class"] == "read_only"

--- a/tests/integration/test_animation_e2e.py
+++ b/tests/integration/test_animation_e2e.py
@@ -89,6 +89,21 @@ async def _run() -> None:
         )
         assert key["time"] == 0.5
 
+        # Read it back (#218): list + get_animation invert the writers above.
+        listed = await _ok(bridge, "cmd_list_animations", {"node_path": "AnimationPlayer"})
+        assert "walk" in listed["animations"]
+        detail = await _ok(
+            bridge, "cmd_get_animation", {"node_path": "AnimationPlayer", "animation_name": "walk"}
+        )
+        assert detail["name"] == "walk" and detail["length"] == 2.0
+        rt = detail["tracks"][0]
+        assert rt["type"] == "value" and rt["path"] == "Sprite2D:position"
+        assert rt["keys"][0]["time"] == 0.5 and rt["keys"][0]["value"] == {"x": 10.0, "y": 20.0}
+        missing = await bridge.send(
+            "cmd_get_animation", {"node_path": "AnimationPlayer", "animation_name": "nope"}
+        )
+        assert missing.ok is False and missing.error == "RESOURCE_NOT_FOUND"
+
         # AnimationTree with a state-machine root + a state
         tree = await _ok(
             bridge,


### PR DESCRIPTION
### **User description**
## Summary
The animation toolset was **write-only** from the agent's view — `create_animation`, `add_animation_track`, `insert_keyframe` had no matching reads, so none could be inverted (rollback enabler **G4**, found by audit #212).

Adds two `read_only` `[Both]` tools:
- **`list_animations(node_path)`** → `{player_path, animations: [name]}`
- **`get_animation(node_path, animation_name)`** → `{name, length, tracks: [{type, path, keys: [{time, value}]}]}` — keyframe values JSON-coerced (Vector2 as `{"x","y"}`, …)

These are the inverse of the animation writers — capture an animation before editing it to roll the change back (enables #146 for the animation domain). The pure serialization lives in a new **`MCPAnimationRead`** lib (takes `Animation`/`AnimationPlayer`, no `EditorInterface`), so it's verifiable headlessly; the handlers just resolve the node and delegate. (State-machine / blend-tree readers, listed as optional in the issue, are left for a follow-up.)

## Acceptance criteria
- [x] `list_animations` → `{player_path, animations[]}`
- [x] `get_animation` → tracks + keyframes, values type-coerced; `read_only`, `[Both]`

## Test plan
- **Contract** (`tests/contract/test_animation.py`): list + get round-trip, RESOURCE_NOT_FOUND for a missing animation, `read_only` meta.
- **Addon (headless)**: `godot/tests/animation_read_smoke.gd` builds a real `AnimationPlayer`+`Animation` and verifies `names`/`serialize` against the live Godot API → `ANIM_READ_TEST_OK`. Both addon scripts pass `--check-only`.
- **E2E** (`tests/integration/test_animation_e2e.py`): create animation+track+key → `list_animations`/`get_animation` read them back (incl. the coerced `{"x":10,"y":20}` key); missing animation → `RESOURCE_NOT_FOUND` (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 486 unit+contract pass, zero-skip clean. Docs + README (131 tools).

Closes #218
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds read-only animation tools for rollback support

- Enables inversion of animation writers via list/get tools

- Introduces JSON-coerced keyframe values for consistency

- Updates tool contracts and documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["create_animation"] -- "read-only inverse" --> B["list_animations"]
  C["add_animation_track"] -- "read-only inverse" --> D["get_animation"]
  E["insert_keyframe"] -- "read-only inverse" --> F["get_animation"]
  G["AnimationPlayer"] -- "read tools" --> H["MCPAnimationRead lib"]
  I["MCPAnimationRead"] -- "JSON-coerced values" --> J["type_coerce.gd"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>animation.py</strong><dd><code>Add animation read models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-57933167c5858afe350457f3a404436daf98e4d6bb5c695ac3f49f4d7bec0263">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation.py</strong><dd><code>Implement list_animations and get_animation tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-7b51cf8a89aa105d09d4fba22148b0d8bba9b180d51c08e7ddcbd71c66d08428">+23/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation_read.gd</strong><dd><code>Create pure read-only animation serialization lib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-ac41871bd0f9fba5d09efd1cf0543584c5ea9ba7b9374611c62be9527e332148">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation.gd</strong><dd><code>Add command handlers for animation reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-ef1d446b5f0e07598f9f0ea1fadeda7bce2f606c5ee4dd7d62e5937ed2641655">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_animation.py</strong><dd><code>Add contract tests for animation reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-e510b4fc9c27d39080ae483d156210eb4469e46ef9d762bebc46cbc05a13341c">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_animation_e2e.py</strong><dd><code>Add E2E tests for animation read tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-c8aa2cf3558736d1fc410fada1386c803c35cc6a7760550d33e203f917680ada">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation_read_smoke.gd</strong><dd><code>Add headless smoke test for animation read lib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-f8b44220e9fa7dd173d5b40884ee81a4c406ccb4c7c8a2b5df2f17ed5776ae64">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count and animation section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document new animation read tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/247/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

