### PR TITLE
feat(scene_3d): add gridmap_get_cell read primitive for rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **131 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **132 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -470,7 +470,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `list_animations`, `get_animation` — read tracks/keyframes (for snapshot/rollback)
 
 ### 3D Scene (gated) — `mutating`
-- `add_mesh_instance`, `setup_camera`, `setup_lighting`, `setup_environment`, `gridmap_set_cell`
+- `add_mesh_instance`, `setup_camera`, `setup_lighting`, `setup_environment`, `gridmap_set_cell`, `gridmap_get_cell`
 - **MeshLibrary authoring:** `create_mesh_library`, `add_mesh_library_item`
 
 ### Particles (gated) — `mutating`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -419,6 +419,7 @@ Build 3D scenes — generic Godot, pass the node/resource type names. All `mutat
 | `setup_lighting` | `parent_path, light_type="DirectionalLight3D", name?, properties?` | `LightResult { node_path, light_type, created }` |
 | `setup_environment` | `parent_path, name="WorldEnvironment", properties?` | `EnvironmentResult { node_path, created }` |
 | `gridmap_set_cell` | `node_path, position=[x,y,z], item, orientation=0` | `GridMapCellResult { node_path, position, item }` |
+| `gridmap_get_cell` | `node_path, position=[x,y,z]` | `GridMapCellGet { node_path, position, item, orientation, empty }` (`read_only`) |
 
 `add_mesh_instance` creates a `MeshInstance3D` holding a `mesh_type` primitive mesh
 (BoxMesh/SphereMesh/…) configured with `properties` (size/radius/…). `setup_lighting`

--- a/godot/addons/godot_mcp/handlers/scene_3d.gd
+++ b/godot/addons/godot_mcp/handlers/scene_3d.gd
@@ -16,6 +16,7 @@ func _init(router: MCPCommandRouter) -> void:
 func register(handlers: Dictionary) -> void:
 	handlers["cmd_add_mesh_instance"] = _cmd_add_mesh_instance
 	handlers["cmd_gridmap_set_cell"] = _cmd_gridmap_set_cell
+	handlers["cmd_gridmap_get_cell"] = _cmd_gridmap_get_cell
 	handlers["cmd_setup_camera"] = _cmd_setup_camera
 	handlers["cmd_setup_environment"] = _cmd_setup_environment
 	handlers["cmd_setup_lighting"] = _cmd_setup_lighting
@@ -124,6 +125,31 @@ func _cmd_gridmap_set_cell(params: Dictionary) -> Dictionary:
 		"node_path": str(params.get("node_path")),
 		"position": [position.x, position.y, position.z],
 		"item": item,
+	})
+
+
+## Read a GridMap cell — item + orientation (issue #219 G5). Inverts gridmap_set_cell
+## and is symmetric with tilemap_get_cell. No mesh_library needed: an unset cell reads
+## back as item == GridMap.INVALID_CELL_ITEM (-1) with empty == true.
+func _cmd_gridmap_get_cell(params: Dictionary) -> Dictionary:
+	var found := _router._resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	if not (node is GridMap):
+		return _router._fail("VALIDATION_ERROR", "Node is not a GridMap.")
+	var grid_map: GridMap = node
+	var raw_pos: Variant = params.get("position")
+	if not (raw_pos is Array) or (raw_pos as Array).size() != 3:
+		return _router._fail("VALIDATION_ERROR", "'position' must be a [x, y, z] integer array.")
+	var position := Vector3i(int(raw_pos[0]), int(raw_pos[1]), int(raw_pos[2]))
+	var item := grid_map.get_cell_item(position)
+	return _router._ok({
+		"node_path": str(params.get("node_path")),
+		"position": [position.x, position.y, position.z],
+		"item": item,
+		"orientation": grid_map.get_cell_item_orientation(position),
+		"empty": item == GridMap.INVALID_CELL_ITEM,
 	})
 
 

--- a/mcp_server/models/scene_3d.py
+++ b/mcp_server/models/scene_3d.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MeshInstanceResult(BaseModel):
@@ -37,6 +37,17 @@ class GridMapCellResult(BaseModel):
     position: list[int]
     item: int
     dry_run: bool = False
+
+
+class GridMapCellGet(BaseModel):
+    """A read of a GridMap cell (issue #219 G5) — inverts ``gridmap_set_cell``.
+    ``item`` is the MeshLibrary index (-1 when empty); ``empty`` flags an unset cell."""
+
+    node_path: str
+    position: list[int] = Field(default_factory=list)
+    item: int = -1
+    orientation: int = 0
+    empty: bool = True
 
 
 class MeshLibraryResult(BaseModel):

--- a/mcp_server/tools/scene_3d.py
+++ b/mcp_server/tools/scene_3d.py
@@ -25,6 +25,7 @@ from mcp_server.defaults import (
 from mcp_server.models.scene_3d import (
     CameraResult,
     EnvironmentResult,
+    GridMapCellGet,
     GridMapCellResult,
     LightResult,
     MeshInstanceResult,
@@ -33,11 +34,12 @@ from mcp_server.models.scene_3d import (
 )
 from mcp_server.safety import (
     MUTATING,
+    READ_ONLY,
     PreconditionError,
     enforce_preconditions,
     require_node_exists,
 )
-from mcp_server.tools._route import run_or_preview
+from mcp_server.tools._route import route, run_or_preview
 
 SCENE_3D = {SCENE_3D_TAG}
 
@@ -196,6 +198,17 @@ def register_scene_3d(mcp: FastMCP, bridge: Bridge) -> None:
         return await run_or_preview(
             dry_run, GridMapCellResult, preview, bridge, "cmd_gridmap_set_cell", params
         )
+
+    @mcp.tool(meta=READ_ONLY, tags=SCENE_3D)
+    async def gridmap_get_cell(node_path: str, position: list[int]) -> GridMapCellGet:
+        """Read the GridMap cell at the integer grid ``position`` ``[x, y, z]``: its
+        ``item`` (MeshLibrary index, -1 when empty), ``orientation``, and ``empty``.
+        Symmetric with ``tilemap_get_cell`` and the inverse of ``gridmap_set_cell`` —
+        snapshot a cell before changing it for rollback. Errors if the node isn't a
+        GridMap or doesn't resolve.
+        """
+        params = {"node_path": node_path, "position": position}
+        return GridMapCellGet(**await route(bridge, "cmd_gridmap_get_cell", params))
 
     @mcp.tool(meta=MUTATING, tags=SCENE_3D)
     @enforce_preconditions

--- a/tests/contract/test_scene_3d.py
+++ b/tests/contract/test_scene_3d.py
@@ -55,6 +55,18 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 cmd.id,
                 {"node_path": p["node_path"], "position": p["position"], "item": p["item"]},
             )
+        case "cmd_gridmap_get_cell":
+            empty = p["position"] == [9, 9, 9]
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "position": p["position"],
+                    "item": -1 if empty else 3,
+                    "orientation": 0 if empty else 22,
+                    "empty": empty,
+                },
+            )
         case "cmd_create_mesh_library":
             return ResponseEnvelope.success(
                 cmd.id,
@@ -231,3 +243,23 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_add_mesh_instance" not in _commands(conn)
+
+
+async def test_gridmap_get_cell_reads_cell() -> None:
+    # #219 G5: read a GridMap cell (item + orientation) — inverts gridmap_set_cell.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "scene_3d"})
+        filled = await client.call_tool(
+            "gridmap_get_cell", {"node_path": "GridMap", "position": [1, 0, 2]}
+        )
+        empty = await client.call_tool(
+            "gridmap_get_cell", {"node_path": "GridMap", "position": [9, 9, 9]}
+        )
+        tools = {t.name: t for t in await client.list_tools()}
+    f = filled.structured_content
+    assert f["position"] == [1, 0, 2] and f["item"] == 3 and f["orientation"] == 22
+    assert f["empty"] is False
+    assert empty.structured_content["item"] == -1 and empty.structured_content["empty"] is True
+    assert tools["gridmap_get_cell"].meta["safety_class"] == "read_only"
+    assert "cmd_gridmap_get_cell" in _commands(conn)

--- a/tests/integration/test_scene_3d_e2e.py
+++ b/tests/integration/test_scene_3d_e2e.py
@@ -125,6 +125,13 @@ async def _run() -> None:
         assert no_lib.ok is False and no_lib.error == "VALIDATION_ERROR"
         assert no_lib.required == "mesh_library"
 
+        # G5 (#219): reading a cell needs no mesh_library — an unset cell is empty/-1.
+        empty_cell = await _ok(
+            bridge, "cmd_gridmap_get_cell", {"node_path": "Grid", "position": [0, 0, 0]}
+        )
+        assert empty_cell["item"] == -1 and empty_cell["empty"] is True
+        assert empty_cell["position"] == [0, 0, 0]
+
         # validation: bad mesh/light types, non-GridMap target, malformed position
         bad_mesh = await bridge.send(
             "cmd_add_mesh_instance", {"parent_path": ".", "mesh_type": "Node"}


### PR DESCRIPTION
### **User description**
## Summary
No tool read a GridMap cell, so `gridmap_set_cell` couldn't be inverted (rollback enabler **G5**, the first item of the #219 umbrella, found by audit #212).

Adds **`gridmap_get_cell(node_path, position)`** → `{node_path, position, item, orientation, empty}`:
- `read_only` `[Both]`, symmetric with the existing `tilemap_get_cell` and the inverse of `gridmap_set_cell`.
- Reading needs **no** `mesh_library` — an unset cell reads back as `item == -1` / `empty == true`.
- Addon handler reuses `get_cell_item` / `get_cell_item_orientation` (the same API the set handler already uses to capture the previous cell for undo), so the API is proven.

## Acceptance criteria (#219 G5)
- [x] `gridmap_get_cell(node_path, position[x,y,z])` → `{position, item, orientation}` (+ `empty`); inverts `gridmap_set_cell`

## Test plan
- **Contract** (`tests/contract/test_scene_3d.py`): filled cell (item/orientation), empty cell (`item=-1`, `empty=true`), `read_only` meta.
- **Addon**: `--check-only` parse passes.
- **E2E** (`tests/integration/test_scene_3d_e2e.py`): read an unset cell on a library-less GridMap → `item=-1`, `empty=true` (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 487 unit+contract pass, zero-skip clean. Docs + README (132 tools).

Part of #219 (G5). Remaining umbrella items: G6 (visual-shader read), G7 (theme overrides), G8 (audio-bus removers), P2 (input-action events), P3 (`tilemap_get_used_cells`), P4 (`get_particle_material`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `gridmap_get_cell` read primitive for rollback support

- Enables inversion of `gridmap_set_cell` operations

- Provides symmetric cell data access with `tilemap_get_cell`

- Updates tool contracts and documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gridmap_set_cell"] -- "inverts" --> B["gridmap_get_cell"]
  C["tilemap_get_cell"] -- "symmetric with" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>scene_3d.py</strong><dd><code>Add GridMapCellGet model for read result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-d23b4af9dc635ce90affbe8faa2b9b71fbe363a82333ff5ef900b94096fe14f8">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_3d.py</strong><dd><code>Implement gridmap_get_cell tool with READ_ONLY meta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-7383994ab0c2d0e17ee84307df07c0b522c0768f4f946911118a0df5b92b5c66">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_3d.gd</strong><dd><code>Implement cmd_gridmap_get_cell handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-bbd16a8ac83263bcd8132ae87e049973d377c01943182eab985760b9f6917b9f">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_scene_3d.py</strong><dd><code>Add contract test for gridmap_get_cell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-ef9f48900c610cb5331eed17136b6c82a8b9ca06e8cbe741b5b21fc6ae8491d2">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scene_3d_e2e.py</strong><dd><code>Add E2E test for empty cell reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-7447d40d08569cf33a1ed2962f889d133540cbb9f29959a736c9d0f6894e6e0c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count and list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document gridmap_get_cell contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/248/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

