### PR TITLE
feat(tilemap): add tilemap_get_used_cells for bulk cell snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **132 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **133 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -483,7 +483,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `add_audio_player`, `get_audio_bus_layout`, `add_audio_bus`, `add_audio_bus_effect`
 
 ### TileMap (gated) — `read_only` / `mutating`
-- `tilemap_set_cell`, `tilemap_fill_rect`, `tilemap_get_cell`, `tilemap_clear`, `tilemap_layers`
+- `tilemap_set_cell`, `tilemap_fill_rect`, `tilemap_get_cell`, `tilemap_get_used_cells`, `tilemap_clear`, `tilemap_layers`
 - **TileSet authoring:** `create_tileset`, `add_tileset_atlas_source`, `create_tile`
 
 ### Theme & UI (gated) — `mutating`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -521,6 +521,7 @@ are `read_only`; edits are `mutating` (UndoRedo-wrapped), `dry_run`.
 | `tilemap_set_cell` | `node_path, coords[x,y], source_id=-1, atlas_coords[x,y]=[0,0], alternative_tile=0, layer=0` | `TileCellResult { node_path, coords, source_id, layer }` |
 | `tilemap_fill_rect` | `node_path, rect[x,y,w,h], source_id=-1, atlas_coords=[0,0], alternative_tile=0, layer=0` | `TileFillResult { node_path, rect, cells, layer }` |
 | `tilemap_get_cell` | `node_path, coords[x,y], layer=0` | `TileGetResult { node_path, coords, source_id, atlas_coords, alternative_tile, empty }` (read_only) |
+| `tilemap_get_used_cells` | `node_path, layer=0` | `TileUsedCellsResult { node_path, layer, count, cells[]{coords, source_id, atlas_coords, alternative_tile} }` (read_only) |
 | `tilemap_clear` | `node_path, layer?` | `TileClearResult { node_path, layer, cleared }` |
 | `tilemap_layers` | `node_path` | `TileLayersResult { node_path, node_type, layers[] }` (read_only) |
 

--- a/godot/addons/godot_mcp/handlers/tilemap.gd
+++ b/godot/addons/godot_mcp/handlers/tilemap.gd
@@ -19,6 +19,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_tilemap_clear"] = _cmd_tilemap_clear
 	handlers["cmd_tilemap_fill_rect"] = _cmd_tilemap_fill_rect
 	handlers["cmd_tilemap_get_cell"] = _cmd_tilemap_get_cell
+	handlers["cmd_tilemap_get_used_cells"] = _cmd_tilemap_get_used_cells
 	handlers["cmd_tilemap_layers"] = _cmd_tilemap_layers
 	handlers["cmd_tilemap_set_cell"] = _cmd_tilemap_set_cell
 
@@ -123,6 +124,32 @@ func _cmd_tilemap_get_cell(params: Dictionary) -> Dictionary:
 		"atlas_coords": [atlas.x, atlas.y],
 		"alternative_tile": cell["alternative_tile"],
 		"empty": cell["source_id"] == -1,
+	})
+
+
+## Bulk snapshot of every painted cell on a layer (issue #219 P3) — the inverse of
+## tilemap_fill_rect / tilemap_clear. Reuses the _used_cells + _read_tile_cell helpers.
+func _cmd_tilemap_get_used_cells(params: Dictionary) -> Dictionary:
+	var found := _resolve_tilemap(params.get("node_path", ""), int(params.get("layer", 0)))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var layer := int(params.get("layer", 0))
+	var cells: Array = []
+	for coords in _used_cells(node, layer):
+		var cell := _read_tile_cell(node, layer, coords)
+		var atlas: Vector2i = cell["atlas_coords"]
+		cells.append({
+			"coords": [coords.x, coords.y],
+			"source_id": cell["source_id"],
+			"atlas_coords": [atlas.x, atlas.y],
+			"alternative_tile": cell["alternative_tile"],
+		})
+	return _router._ok({
+		"node_path": str(params.get("node_path")),
+		"layer": layer,
+		"count": cells.size(),
+		"cells": cells,
 	})
 
 

--- a/mcp_server/models/tilemap.py
+++ b/mcp_server/models/tilemap.py
@@ -30,6 +30,25 @@ class TileGetResult(BaseModel):
     empty: bool = True
 
 
+class TileCellSnapshot(BaseModel):
+    """One painted cell in a used-cells snapshot (issue #219 P3)."""
+
+    coords: list[int]
+    source_id: int = -1
+    atlas_coords: list[int] = Field(default_factory=lambda: [-1, -1])
+    alternative_tile: int = -1
+
+
+class TileUsedCellsResult(BaseModel):
+    """Bulk snapshot of a TileMap layer's painted cells (issue #219 P3) — the inverse
+    of ``tilemap_fill_rect`` / ``tilemap_clear`` without per-cell reads."""
+
+    node_path: str
+    layer: int = 0
+    count: int = 0
+    cells: list[TileCellSnapshot] = Field(default_factory=list)
+
+
 class TileClearResult(BaseModel):
     node_path: str
     layer: int | None = None

--- a/mcp_server/tools/tilemap.py
+++ b/mcp_server/tools/tilemap.py
@@ -29,6 +29,7 @@ from mcp_server.models.tilemap import (
     TileLayersResult,
     TileSetResult,
     TileSetSourceResult,
+    TileUsedCellsResult,
 )
 from mcp_server.safety import (
     MUTATING,
@@ -140,6 +141,17 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
         """
         params = {"node_path": node_path, "coords": coords, "layer": layer}
         return TileGetResult(**await route(bridge, "cmd_tilemap_get_cell", params))
+
+    @mcp.tool(meta=READ_ONLY, tags=TILEMAP)
+    async def tilemap_get_used_cells(node_path: str, layer: TileLayer = 0) -> TileUsedCellsResult:
+        """Snapshot every painted cell on the TileMap/TileMapLayer at ``node_path`` in
+        one call: each cell's ``coords`` plus ``source_id``/``atlas_coords``/
+        ``alternative_tile``. The bulk inverse of ``tilemap_fill_rect`` / ``tilemap_clear``
+        — capture a layer before editing so the change can be rolled back without an
+        O(n) sweep of ``tilemap_get_cell``. ``layer`` applies to multi-layer TileMap only.
+        """
+        params = {"node_path": node_path, "layer": layer}
+        return TileUsedCellsResult(**await route(bridge, "cmd_tilemap_get_used_cells", params))
 
     @mcp.tool(meta=MUTATING, tags=TILEMAP)
     @enforce_preconditions

--- a/tests/contract/test_tilemap.py
+++ b/tests/contract/test_tilemap.py
@@ -54,6 +54,21 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "empty": True,
                 },
             )
+        case "cmd_tilemap_get_used_cells":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "layer": p["layer"],
+                    "count": 2,
+                    "cells": [
+                        {"coords": [0, 0], "source_id": 1, "atlas_coords": [2, 3],
+                         "alternative_tile": 0},
+                        {"coords": [1, 0], "source_id": 1, "atlas_coords": [4, 5],
+                         "alternative_tile": 1},
+                    ],
+                },
+            )
         case "cmd_tilemap_clear":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "layer": p["layer"], "cleared": 4}
@@ -276,3 +291,25 @@ async def test_clear_and_dry_run() -> None:
     assert cleared.structured_content["cleared"] == 4
     assert dry.structured_content["dry_run"] is True
     assert "cmd_tilemap_set_cell" not in _commands(conn)
+
+
+async def test_tilemap_get_used_cells_snapshot() -> None:
+    # #219 P3: bulk snapshot of used cells — inverts tilemap_fill_rect / tilemap_clear.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "tilemap"})
+        result = await client.call_tool(
+            "tilemap_get_used_cells", {"node_path": "TileMapLayer", "layer": 0}
+        )
+        tools = {t.name: t for t in await client.list_tools()}
+    data = result.structured_content
+    assert data["count"] == 2 and len(data["cells"]) == 2
+    assert data["cells"][0] == {
+        "coords": [0, 0],
+        "source_id": 1,
+        "atlas_coords": [2, 3],
+        "alternative_tile": 0,
+    }
+    assert tools["tilemap_get_used_cells"].meta["safety_class"] == "read_only"
+    cmds = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+    assert "cmd_tilemap_get_used_cells" in cmds

--- a/tests/integration/test_tilemap_e2e.py
+++ b/tests/integration/test_tilemap_e2e.py
@@ -86,6 +86,10 @@ async def _run() -> None:
         cell = await _ok(bridge, "cmd_tilemap_get_cell", {"node_path": "Ground", "coords": [0, 0]})
         assert cell["empty"] is True and cell["source_id"] == -1
 
+        # P3 (#219): a fresh layer has no used cells — the snapshot is empty.
+        used = await _ok(bridge, "cmd_tilemap_get_used_cells", {"node_path": "Ground", "layer": 0})
+        assert used["count"] == 0 and used["cells"] == []
+
         # erase set_cell + erase fill are valid without a TileSet and are undoable
         erased = await _ok(
             bridge,


### PR DESCRIPTION
### **User description**
## Summary
`tilemap_fill_rect` / `tilemap_clear` had no bulk read, so they couldn't be inverted without an O(n) sweep of `tilemap_get_cell` (rollback enabler **P3** of the #219 umbrella, found by audit #212).

Adds **`tilemap_get_used_cells(node_path, layer=0)`** → `{node_path, layer, count, cells: [{coords, source_id, atlas_coords, alternative_tile}]}`:
- `read_only` `[Both]`, the bulk inverse of `tilemap_fill_rect` / `tilemap_clear` — snapshot a whole layer before editing for rollback.
- Addon handler **reuses the existing `_used_cells` + `_read_tile_cell` helpers** (the same ones `tilemap_clear` already uses to enumerate cells), so it works on both `TileMapLayer` and the deprecated multi-layer `TileMap` with no new Godot API surface.

## Acceptance criteria (#219 P3)
- [x] `tilemap_get_used_cells(node_path, layer=0)` → bulk cell snapshot; inverts `tilemap_fill_rect` / `tilemap_clear`

## Test plan
- **Contract** (`tests/contract/test_tilemap.py`): populated snapshot (count + per-cell shape), `read_only` meta.
- **Addon**: `--check-only` parse passes.
- **E2E** (`tests/integration/test_tilemap_e2e.py`): a fresh `TileMapLayer` has no used cells → `count=0`, `cells=[]` (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 488 unit+contract pass, zero-skip clean. Docs + README (133 tools).

Part of #219 (P3). Remaining: G6 (visual-shader read), G7 (theme overrides), G8 (audio-bus removers), P2 (input-action events), P4 (`get_particle_material`).
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds bulk read primitive for TileMap layers

- Enables rollback for tilemap_fill_rect / tilemap_clear operations

- Supports efficient state capture before mutations

- Expands toolset coverage for agent-driven development


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tilemap_get_used_cells"] -- "bulk snapshot" --> B["tilemap_fill_rect"]
  A -- "bulk snapshot" --> C["tilemap_clear"]
  B -- "inverse" --> D["rollback enabler"]
  C -- "inverse" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>tilemap.py</strong><dd><code>Add data models for tile cell snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-4015d0919c18e261b07fcdcb7726a48cbf9c920095790748962462bdafbbf309">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tilemap.py</strong><dd><code>Implement tilemap_get_used_cells tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-35e6aaf5902029283267d1e40814fb097eee14a34683f10e21099f82de522199">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tilemap.gd</strong><dd><code>Add addon handler for get_used_cells</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-2f1bc359086cbbf7b0dd3a1033054065b823c7e34cbb4e79a1c37b9df4b2997c">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_tilemap.py</strong><dd><code>Add contract test for get_used_cells</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-0b82b4bb7835cbd79a2805fe6ea6dad331766785e71a5a66f8b66946ab90cdda">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tilemap_e2e.py</strong><dd><code>Verify empty layer snapshot behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-7c689cc30d471cbab50c26fbca8e34bd8163f576cf1c7b49efd0c302c70fecdb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update toolset documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document new tilemap_get_used_cells contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/249/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

