### PR TITLE
feat(particles): add get_particle_material read tool for rollback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **133 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **134 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -474,7 +474,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - **MeshLibrary authoring:** `create_mesh_library`, `add_mesh_library_item`
 
 ### Particles (gated) — `mutating`
-- `create_particles`, `set_particle_material`, `set_particle_color_gradient`, `apply_particle_preset`
+- `create_particles`, `set_particle_material`, `set_particle_color_gradient`, `apply_particle_preset`, `get_particle_material`
 
 ### Navigation (gated) — `mutating`
 - `setup_navigation_region`, `setup_navigation_agent`, `bake_navigation_mesh`, `set_navigation_layers`

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `add_mesh_instance`, `setup_camera`, `setup_lighting`, `setup_environment`, `gridmap_set_cell`, `gridmap_get_cell`
 - **MeshLibrary authoring:** `create_mesh_library`, `add_mesh_library_item`
 
-### Particles (gated) — `mutating`
+### Particles (gated) — `mutating` / `read_only`
 - `create_particles`, `set_particle_material`, `set_particle_color_gradient`, `apply_particle_preset`, `get_particle_material`
 
 ### Navigation (gated) — `mutating`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -453,7 +453,7 @@ the auto-assigned id.
 #### Particles (issue #42) — category: `particles` (gated off by default)
 
 Create and configure GPU particle systems — generic Godot, pass the node type names.
-All `mutating` (UndoRedo-wrapped), `dry_run`.
+Writes are `mutating` (UndoRedo-wrapped), `dry_run`; `get_particle_material` is `read_only`.
 
 | Tool | Params | Returns |
 |------|--------|---------|

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -461,6 +461,7 @@ All `mutating` (UndoRedo-wrapped), `dry_run`.
 | `set_particle_material` | `node_path, properties` | `ParticleMaterialResult { node_path, properties }` |
 | `set_particle_color_gradient` | `node_path, colors[], offsets?` | `ParticleGradientResult { node_path, stops }` |
 | `apply_particle_preset` | `node_path, preset` | `ParticlePresetResult { node_path, preset }` |
+| `get_particle_material` | `node_path` | `ParticleMaterialDetail { node_path, has_material, properties, color_ramp{colors, offsets}? }` (`read_only`) |
 
 `create_particles` adds a GPUParticles2D/3D with a fresh ParticleProcessMaterial.
 `set_particle_material` applies process-material properties (`gravity`,

--- a/godot/addons/godot_mcp/handlers/particles.gd
+++ b/godot/addons/godot_mcp/handlers/particles.gd
@@ -2,6 +2,7 @@
 class_name MCPParticlesHandlers
 extends RefCounted
 const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+const ParticleRead := preload("res://addons/godot_mcp/particle_read.gd")
 ## Domain handler: particles.
 ##
 ## Registered by the router on _init().  Each handler receives params dict and
@@ -61,6 +62,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_create_particles"] = _cmd_create_particles
 	handlers["cmd_set_particle_color_gradient"] = _cmd_set_particle_color_gradient
 	handlers["cmd_set_particle_material"] = _cmd_set_particle_material
+	handlers["cmd_get_particle_material"] = _cmd_get_particle_material
 
 
 # -- handlers ----------------------------------------------------------------
@@ -153,6 +155,19 @@ func _cmd_apply_particle_preset(params: Dictionary) -> Dictionary:
 			ur.add_undo_property(node, str(key), node.get(str(key)))
 	ur.commit_action()
 	return _router._ok({"node_path": str(params.get("node_path")), "preset": preset_name})
+
+
+## Read a particle node's ProcessMaterial — props + color ramp (issue #219 P4). The
+## inverse of set_particle_material / set_particle_color_gradient; delegates the pure
+## serialization to MCPParticleRead.
+func _cmd_get_particle_material(params: Dictionary) -> Dictionary:
+	var found := _resolve_particles(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var data: Dictionary = ParticleRead.serialize(node.process_material)
+	data["node_path"] = str(params.get("node_path"))
+	return _router._ok(data)
 
 
 func _resolve_particles(raw_path: Variant) -> Dictionary:

--- a/godot/addons/godot_mcp/particle_read.gd
+++ b/godot/addons/godot_mcp/particle_read.gd
@@ -1,0 +1,42 @@
+@tool
+class_name MCPParticleRead
+extends RefCounted
+## Pure, read-only serialization of a ParticleProcessMaterial (issue #219 P4 — rollback
+## enabler). Takes the material resource (never EditorInterface), so it is verifiable
+## headlessly (see godot/tests/particle_read_smoke.gd). Inverts set_particle_material /
+## set_particle_color_gradient: ``properties`` are the JSON-coerced material fields and
+## ``color_ramp`` is the gradient's stops (not a sub-resource ref) so it round-trips.
+
+const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+
+
+## { has_material, properties:{...}, color_ramp:{colors:[{r,g,b,a}], offsets:[float]}|null }.
+static func serialize(material: Variant) -> Dictionary:
+	if not (material is ParticleProcessMaterial):
+		return {"has_material": false, "properties": {}, "color_ramp": null}
+	# All editable/stored material props, JSON-coerced. color_ramp is a sub-resource
+	# (GradientTexture) that resource_properties would flatten to a class name, so drop
+	# it here and serialize the gradient detail separately.
+	var props: Dictionary = Inspect.resource_properties(material)
+	props.erase("color_ramp")
+	return {
+		"has_material": true,
+		"properties": props,
+		"color_ramp": _serialize_ramp(material.color_ramp),
+	}
+
+
+## A GradientTexture1D's gradient as parallel { colors, offsets }, or null.
+static func _serialize_ramp(tex: Variant) -> Variant:
+	if tex == null:
+		return null
+	var gradient: Variant = tex.get("gradient")
+	if not (gradient is Gradient):
+		return null
+	var colors: Array = []
+	var offsets: Array = []
+	for i in gradient.get_point_count():
+		var c: Color = gradient.get_color(i)
+		colors.append({"r": c.r, "g": c.g, "b": c.b, "a": c.a})
+		offsets.append(gradient.get_offset(i))
+	return {"colors": colors, "offsets": offsets}

--- a/godot/tests/particle_read_smoke.gd
+++ b/godot/tests/particle_read_smoke.gd
@@ -1,0 +1,62 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPParticleRead (issue #219 P4).
+##
+## Run via: godot --headless --path godot/ --script res://tests/particle_read_smoke.gd
+## Builds a real ParticleProcessMaterial + GradientTexture1D (no EditorInterface) and
+## verifies the pure read serialization against the live Godot API.
+
+const ParticleRead := preload("res://addons/godot_mcp/particle_read.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+
+	# No material → has_material false, empty props, null ramp.
+	var none: Dictionary = ParticleRead.serialize(null)
+	_eq(failures, "none.has_material", none.get("has_material"), false)
+	_eq(failures, "none.color_ramp", none.get("color_ramp"), null)
+
+	# A real material with a couple of props + a color ramp.
+	var mat := ParticleProcessMaterial.new()
+	mat.spread = 45.0
+	var gradient := Gradient.new()
+	gradient.offsets = PackedFloat32Array([0.0, 1.0])
+	gradient.colors = PackedColorArray([Color(1, 1, 1, 1), Color(1, 0, 0, 0)])
+	var tex := GradientTexture1D.new()
+	tex.gradient = gradient
+	mat.color_ramp = tex
+
+	var data: Dictionary = ParticleRead.serialize(mat)
+	_eq(failures, "has_material", data.get("has_material"), true)
+	var props: Dictionary = data.get("properties")
+	_eq(failures, "props.spread", props.get("spread"), 45.0)
+	# color_ramp is serialized as gradient stops, never as a sub-resource ref.
+	if props.has("color_ramp"):
+		failures.append("color_ramp leaked into properties")
+	var ramp: Dictionary = data.get("color_ramp")
+	_eq(failures, "ramp.offsets", ramp.get("offsets"), [0.0, 1.0])
+	var colors: Array = ramp.get("colors")
+	if colors.size() != 2:
+		failures.append("ramp colors size: %s" % str(colors))
+	else:
+		_eq(failures, "ramp.color0", colors[0], {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0})
+		_eq(failures, "ramp.color1.a", colors[1].get("a"), 0.0)
+
+	# Output must be JSON-safe.
+	if JSON.stringify(data) == "":
+		failures.append("serialized material is not JSON-safe")
+
+	if failures.is_empty():
+		print("PARTICLE_READ_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("PARTICLE_READ_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/particles.py
+++ b/mcp_server/models/particles.py
@@ -30,3 +30,22 @@ class ParticlePresetResult(BaseModel):
     node_path: str
     preset: str
     dry_run: bool = False
+
+
+class ParticleColorRamp(BaseModel):
+    """A color ramp's gradient stops (issue #219 P4): parallel ``colors`` ({r,g,b,a})
+    and ``offsets`` (0..1). Round-trips into ``set_particle_color_gradient``."""
+
+    colors: list[dict[str, float]] = Field(default_factory=list)
+    offsets: list[float] = Field(default_factory=list)
+
+
+class ParticleMaterialDetail(BaseModel):
+    """A read of a GPUParticles node's ParticleProcessMaterial (issue #219 P4) — the
+    inverse of ``set_particle_material`` / ``set_particle_color_gradient``. ``properties``
+    are JSON-coerced material fields; ``color_ramp`` is the gradient (null when none)."""
+
+    node_path: str
+    has_material: bool = False
+    properties: dict[str, Any] = Field(default_factory=dict)
+    color_ramp: ParticleColorRamp | None = None

--- a/mcp_server/tools/particles.py
+++ b/mcp_server/tools/particles.py
@@ -23,11 +23,12 @@ from mcp_server.defaults import (
 from mcp_server.models.particles import (
     CreateParticlesResult,
     ParticleGradientResult,
+    ParticleMaterialDetail,
     ParticleMaterialResult,
     ParticlePresetResult,
 )
-from mcp_server.safety import MUTATING, enforce_preconditions, require_node_exists
-from mcp_server.tools._route import run_or_preview
+from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_node_exists
+from mcp_server.tools._route import route, run_or_preview
 
 PARTICLES = {PARTICLES_TAG}
 
@@ -124,4 +125,16 @@ def register_particles(mcp: FastMCP, bridge: Bridge) -> None:
         preview = {"node_path": node_path, "preset": preset}
         return await run_or_preview(
             dry_run, ParticlePresetResult, preview, bridge, "cmd_apply_particle_preset", params
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=PARTICLES)
+    async def get_particle_material(node_path: str) -> ParticleMaterialDetail:
+        """Read the ProcessMaterial of the GPUParticles2D/3D at ``node_path``: its
+        ``properties`` (JSON-coerced material fields) and ``color_ramp`` (gradient stops,
+        null when none). ``has_material`` is false when no ProcessMaterial is set. The
+        inverse of ``set_particle_material`` / ``set_particle_color_gradient`` — snapshot
+        a material before editing it for rollback.
+        """
+        return ParticleMaterialDetail(
+            **await route(bridge, "cmd_get_particle_material", {"node_path": node_path})
         )

--- a/tests/contract/test_particles.py
+++ b/tests/contract/test_particles.py
@@ -40,6 +40,22 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "preset": p["preset"]}
             )
+        case "cmd_get_particle_material":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "has_material": True,
+                    "properties": {"gravity": {"x": 0.0, "y": -98.0, "z": 0.0}, "spread": 45.0},
+                    "color_ramp": {
+                        "colors": [
+                            {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0},
+                            {"r": 1.0, "g": 0.0, "b": 0.0, "a": 0.0},
+                        ],
+                        "offsets": [0.0, 1.0],
+                    },
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -111,3 +127,21 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_apply_particle_preset" not in _commands(conn)
+
+
+async def test_get_particle_material_reads_props_and_ramp() -> None:
+    # #219 P4: read the process_material props + color ramp — inverts the writers.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "particles"})
+        result = await client.call_tool("get_particle_material", {"node_path": "GPUParticles2D"})
+        tools = {t.name: t for t in await client.list_tools()}
+    data = result.structured_content
+    assert data["has_material"] is True
+    assert data["properties"]["spread"] == 45.0
+    assert data["properties"]["gravity"] == {"x": 0.0, "y": -98.0, "z": 0.0}
+    assert data["color_ramp"]["offsets"] == [0.0, 1.0]
+    assert data["color_ramp"]["colors"][0] == {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0}
+    assert tools["get_particle_material"].meta["safety_class"] == "read_only"
+    cmds = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+    assert "cmd_get_particle_material" in cmds

--- a/tests/integration/test_particles_e2e.py
+++ b/tests/integration/test_particles_e2e.py
@@ -88,6 +88,14 @@ async def _run() -> None:
         )
         assert grad["stops"] == 3
 
+        # P4 (#219): read the material back — the props + the 3-stop ramp just set.
+        read = await _ok(bridge, "cmd_get_particle_material", {"node_path": "FX"})
+        assert read["has_material"] is True
+        assert read["properties"]["spread"] == 33.0
+        assert read["properties"]["initial_velocity_min"] == 25.0
+        assert read["color_ramp"] is not None
+        assert len(read["color_ramp"]["offsets"]) == 3 and len(read["color_ramp"]["colors"]) == 3
+
         preset = await _ok(
             bridge, "cmd_apply_particle_preset", {"node_path": "FX", "preset": "explosion"}
         )


### PR DESCRIPTION
### **User description**
## Summary
`set_particle_material` / `set_particle_color_gradient` had no matching read, so neither could be inverted (rollback enabler **P4** of the #219 umbrella, found by audit #212).

Adds **`get_particle_material(node_path)`** → `{node_path, has_material, properties, color_ramp{colors, offsets}?}`:
- `read_only` `[Both]`, the inverse of the particle material writers.
- `properties` reuses `Inspect.resource_properties` (the same EDITOR|STORAGE fields the setter writes), JSON-coerced.
- `color_ramp` is serialized as the gradient **stops** (`colors` `{r,g,b,a}` + `offsets`), not a sub-resource ref, so it round-trips back into `set_particle_color_gradient`.
- Pure serialization in a new **`MCPParticleRead`** lib (no `EditorInterface`) → verified headlessly against the real Godot API.

## Acceptance criteria (#219 P4)
- [x] `get_particle_material(node_path)` → serialized `process_material` / `color_ramp`; inverts `set_particle_material` / `set_particle_color_gradient`

## Test plan
- **Contract** (`tests/contract/test_particles.py`): props + color ramp, `read_only` meta.
- **Addon (headless)**: `particle_read_smoke.gd` builds a real `ParticleProcessMaterial` + `GradientTexture1D` and verifies the serialization (incl. `color_ramp` not leaking into `properties`) → `PARTICLE_READ_TEST_OK`. Both addon scripts pass `--check-only`.
- **E2E** (`tests/integration/test_particles_e2e.py`): set material + a 3-stop gradient → `get_particle_material` reads them back (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 489 unit+contract pass, zero-skip clean. Docs + README (134 tools).

Part of #219 (P4). Remaining: G6 (visual-shader read), G7 (theme overrides), P2 (input-action events), G8 (audio-bus removers).
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds read-only tool for particle material inspection

- Enables rollback support for particle material changes

- Expands particle toolset with `get_particle_material`

- Includes contract and integration tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_particle_material"] -- "reads material" --> B["ParticleMaterialDetail"]
  C["set_particle_material"] -- "writes material" --> D["ParticleProcessMaterial"]
  E["set_particle_color_gradient"] -- "writes gradient" --> F["GradientTexture1D"]
  G["ParticleRead.serialize"] -- "serializes props + ramp" --> H["MCPParticleRead lib"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>particles.py</strong><dd><code>Add data models for particle material read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-58a68af1a78b8b755a747a30a94b0ea747f784075ed802de341b10e789d81c26">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particles.py</strong><dd><code>Implement get_particle_material tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-a38f7e81286d0e7bc3ab0a8a7090f15827b73ea80c02b5c00bafb0934d764c47">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particles.gd</strong><dd><code>Register cmd_get_particle_material handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-9dca22317704334a24c4a981dadb1af8669927658eadcb453ccab8f7855968ca">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particle_read.gd</strong><dd><code>Add pure serialization lib for particle materials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-f6433d4803703d38f7e5b7b505b882c829775e096346d8371f911f8140198ed4">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_particles.py</strong><dd><code>Add contract test for get_particle_material</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-4b9ba42d59c718f6cdc0618386d600c3e3d467a57cb47ecd9449d7437dbb9dba">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_particles_e2e.py</strong><dd><code>Add E2E test for particle material read-back</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-39e9c9e2eae4c813cc06842d1d9dd6403067890c4df3b124e2bf9fba52d810d5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particle_read_smoke.gd</strong><dd><code>Add headless smoke test for particle read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-8faf1bd3e32032b5386423eade0b8b029252390d4236149f8dd0090d79022911">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update toolset documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document get_particle_material contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/250/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

