### PR TITLE
feat(theme): add get_node_theme_overrides read tool for rollback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **134 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **135 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -486,8 +486,8 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 - `tilemap_set_cell`, `tilemap_fill_rect`, `tilemap_get_cell`, `tilemap_get_used_cells`, `tilemap_clear`, `tilemap_layers`
 - **TileSet authoring:** `create_tileset`, `add_tileset_atlas_source`, `create_tile`
 
-### Theme & UI (gated) — `mutating`
-- `create_theme`, `set_theme_color`, `set_theme_font_size`, `set_theme_stylebox`
+### Theme & UI (gated) — `mutating` / `read_only`
+- `create_theme`, `set_theme_color`, `set_theme_font_size`, `set_theme_stylebox`, `get_node_theme_overrides`
 
 ### Shaders (gated) — `read_only` / `mutating`
 - `create_shader`, `read_shader`, `assign_shader_material`, `set_shader_param`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -556,8 +556,9 @@ not overlapping (`has_room_for_tile`).
 #### Theme & UI (issue #46) — category: `theme_ui` (gated off by default)
 
 Create a Theme for a Control and override theme colors, font sizes, and styleboxes on
-Control nodes. All `mutating` (UndoRedo-wrapped), `dry_run`. Overrides are local to the
-node and take precedence over its assigned theme.
+Control nodes. Writes are `mutating` (UndoRedo-wrapped), `dry_run`;
+`get_node_theme_overrides` is `read_only`. Overrides are local to the node and take
+precedence over its assigned theme.
 
 | Tool | Params | Returns |
 |------|--------|---------|
@@ -565,6 +566,7 @@ node and take precedence over its assigned theme.
 | `set_theme_color` | `node_path, name, color` | `ThemeColorResult { node_path, name }` |
 | `set_theme_font_size` | `node_path, name, size` | `ThemeFontSizeResult { node_path, name, size }` |
 | `set_theme_stylebox` | `node_path, name, stylebox_type="StyleBoxFlat", properties?` | `ThemeStyleboxResult { node_path, name, stylebox_type }` |
+| `get_node_theme_overrides` | `node_path` | `NodeThemeOverrides { node_path, colors{name→rgba}, font_sizes{name→int}, styleboxes[{name, type, properties}] }` (`read_only`) |
 
 `create_theme` makes a Theme and assigns it to the Control (saved to a `res://*.tres`
 when `save_path` is given, else embedded with the scene). `set_theme_color` /
@@ -573,6 +575,10 @@ when `save_path` is given, else embedded with the scene). `set_theme_color` /
 `set_theme_stylebox` builds a `stylebox_type` (StyleBoxFlat/Texture/Empty/Line)
 configured with `properties` (e.g. `bg_color`, `corner_radius_top_left`) and overrides
 the named stylebox. Undo restores the prior override (or removes it).
+`get_node_theme_overrides` is the inverse read — it returns the node's local color,
+font-size, and stylebox overrides (each stylebox with its class + serialized
+`properties`) for rollback. It covers theme items the control's type defines (the same
+set the Inspector exposes — e.g. `font_color` on a Label, the `panel` stylebox on a Panel).
 
 #### Shaders (issue #47) — category: `shader` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/theme_ui.gd
+++ b/godot/addons/godot_mcp/handlers/theme_ui.gd
@@ -2,6 +2,7 @@
 class_name MCPThemeUIHandlers
 extends RefCounted
 const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+const ThemeRead := preload("res://addons/godot_mcp/theme_read.gd")
 ## Domain handler: theme ui.
 ##
 ## Registered by the router on _init().  Each handler receives params dict and
@@ -19,6 +20,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_set_theme_color"] = _cmd_set_theme_color
 	handlers["cmd_set_theme_font_size"] = _cmd_set_theme_font_size
 	handlers["cmd_set_theme_stylebox"] = _cmd_set_theme_stylebox
+	handlers["cmd_get_node_theme_overrides"] = _cmd_get_node_theme_overrides
 
 
 # -- handlers ----------------------------------------------------------------
@@ -128,6 +130,19 @@ func _cmd_set_theme_stylebox(params: Dictionary) -> Dictionary:
 		"name": name,
 		"stylebox_type": stylebox_type,
 	})
+
+
+## Read a Control's per-node theme overrides — colors / font_sizes / styleboxes (issue
+## #219 G7). The inverse of set_theme_color / set_theme_font_size / set_theme_stylebox;
+## delegates the pure serialization to MCPThemeRead.
+func _cmd_get_node_theme_overrides(params: Dictionary) -> Dictionary:
+	var found := _resolve_control(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Control = found["node"]
+	var data: Dictionary = ThemeRead.overrides(node)
+	data["node_path"] = str(params.get("node_path"))
+	return _router._ok(data)
 
 
 func _resolve_control(raw_path: Variant) -> Dictionary:

--- a/godot/addons/godot_mcp/theme_read.gd
+++ b/godot/addons/godot_mcp/theme_read.gd
@@ -1,0 +1,48 @@
+@tool
+class_name MCPThemeRead
+extends RefCounted
+## Pure, read-only serialization of a Control's per-node theme overrides (issue #219
+## G7 — rollback enabler). Takes a Control (never EditorInterface), so verifiable
+## headlessly (see godot/tests/theme_read_smoke.gd). Inverts set_theme_color /
+## set_theme_font_size / set_theme_stylebox.
+
+const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+
+
+const _COLOR_PREFIX := "theme_override_colors/"
+const _FONT_SIZE_PREFIX := "theme_override_font_sizes/"
+const _STYLEBOX_PREFIX := "theme_override_styles/"
+
+
+## { colors:{name:{r,g,b,a}}, font_sizes:{name:int}, styleboxes:[{name, type, properties}] }.
+## Styleboxes carry their class + serialized props so they round-trip into set_theme_stylebox.
+##
+## Godot 4.x has no get_theme_*_override_list; overrides surface in the property list as
+## theme_override_colors/<name>, theme_override_font_sizes/<name>, theme_override_styles/
+## <name>. Those entries exist for *every* known theme item, so each is gated on
+## has_theme_*_override to keep only the ones actually set on this node.
+static func overrides(node: Control) -> Dictionary:
+	var colors: Dictionary = {}
+	var font_sizes: Dictionary = {}
+	var styleboxes: Array = []
+	for prop in node.get_property_list():
+		var pname: String = prop.get("name", "")
+		if pname.begins_with(_COLOR_PREFIX):
+			var cname := pname.substr(_COLOR_PREFIX.length())
+			if node.has_theme_color_override(cname):
+				colors[cname] = Coerce.to_json(node.get_theme_color(cname))
+		elif pname.begins_with(_FONT_SIZE_PREFIX):
+			var fname := pname.substr(_FONT_SIZE_PREFIX.length())
+			if node.has_theme_font_size_override(fname):
+				font_sizes[fname] = node.get_theme_font_size(fname)
+		elif pname.begins_with(_STYLEBOX_PREFIX):
+			var sname := pname.substr(_STYLEBOX_PREFIX.length())
+			if node.has_theme_stylebox_override(sname):
+				var sb: StyleBox = node.get_theme_stylebox(sname)
+				styleboxes.append({
+					"name": sname,
+					"type": sb.get_class(),
+					"properties": Inspect.resource_properties(sb),
+				})
+	return {"colors": colors, "font_sizes": font_sizes, "styleboxes": styleboxes}

--- a/godot/tests/theme_read_smoke.gd
+++ b/godot/tests/theme_read_smoke.gd
@@ -1,0 +1,70 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPThemeRead (issue #219 G7).
+##
+## Run via: godot --headless --path godot/ --script res://tests/theme_read_smoke.gd
+## Builds a real Control with color / font-size / stylebox overrides (no EditorInterface)
+## and verifies the pure read serialization against the live Godot theme API.
+
+const ThemeRead := preload("res://addons/godot_mcp/theme_read.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+
+	# A Label with no overrides → all three buckets empty. (A real control type is used
+	# because overrides only surface in get_property_list for items the control defines.)
+	var bare := Label.new()
+	var empty: Dictionary = ThemeRead.overrides(bare)
+	if not (empty["colors"] as Dictionary).is_empty():
+		failures.append("bare colors not empty")
+	if not (empty["font_sizes"] as Dictionary).is_empty():
+		failures.append("bare font_sizes not empty")
+	if not (empty["styleboxes"] as Array).is_empty():
+		failures.append("bare styleboxes not empty")
+	bare.free()
+
+	# A Label carrying one override of each kind (font_color / font_size / the "normal"
+	# stylebox are all real Label theme items).
+	var node := Label.new()
+	node.add_theme_color_override("font_color", Color(1, 0, 0, 1))
+	node.add_theme_font_size_override("font_size", 24)
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(0.1, 0.1, 0.1, 1)
+	node.add_theme_stylebox_override("normal", sb)
+
+	var data: Dictionary = ThemeRead.overrides(node)
+	var colors: Dictionary = data["colors"]
+	_eq(failures, "colors.font_color", colors.get("font_color"), {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0})
+	var font_sizes: Dictionary = data["font_sizes"]
+	_eq(failures, "font_sizes.font_size", font_sizes.get("font_size"), 24)
+	var styleboxes: Array = data["styleboxes"]
+	if styleboxes.size() != 1:
+		failures.append("styleboxes size: %s" % str(styleboxes))
+	else:
+		var entry: Dictionary = styleboxes[0]
+		_eq(failures, "stylebox.name", entry.get("name"), "normal")
+		_eq(failures, "stylebox.type", entry.get("type"), "StyleBoxFlat")
+		var props: Dictionary = entry.get("properties")
+		# bg_color round-trips through type_coerce so the StyleBox can be recreated.
+		if not props.has("bg_color"):
+			failures.append("stylebox properties missing bg_color: %s" % str(props.keys()))
+
+	# Output must be JSON-safe.
+	if JSON.stringify(data) == "":
+		failures.append("serialized overrides are not JSON-safe")
+	node.free()
+
+	if failures.is_empty():
+		print("THEME_READ_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("THEME_READ_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/theme_ui.py
+++ b/mcp_server/models/theme_ui.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class ThemeResult(BaseModel):
@@ -30,3 +32,23 @@ class ThemeStyleboxResult(BaseModel):
     name: str
     stylebox_type: str
     dry_run: bool = False
+
+
+class StyleBoxOverride(BaseModel):
+    """One stylebox override (issue #219 G7): its name, StyleBox ``type``, and the
+    serialized ``properties`` — enough to recreate it via ``set_theme_stylebox``."""
+
+    name: str
+    type: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class NodeThemeOverrides(BaseModel):
+    """A Control's per-node theme overrides (issue #219 G7) — the inverse of
+    ``set_theme_color`` / ``set_theme_font_size`` / ``set_theme_stylebox``. ``colors``
+    map override name → ``{r,g,b,a}``; ``font_sizes`` map name → int."""
+
+    node_path: str
+    colors: dict[str, Any] = Field(default_factory=dict)
+    font_sizes: dict[str, int] = Field(default_factory=dict)
+    styleboxes: list[StyleBoxOverride] = Field(default_factory=list)

--- a/mcp_server/tools/theme_ui.py
+++ b/mcp_server/tools/theme_ui.py
@@ -18,13 +18,14 @@ from mcp_server.defaults import (
     DEFAULT_STYLEBOX_TYPE,
 )
 from mcp_server.models.theme_ui import (
+    NodeThemeOverrides,
     ThemeColorResult,
     ThemeFontSizeResult,
     ThemeResult,
     ThemeStyleboxResult,
 )
-from mcp_server.safety import MUTATING, enforce_preconditions, require_node_exists
-from mcp_server.tools._route import run_or_preview
+from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_node_exists
+from mcp_server.tools._route import route, run_or_preview
 
 THEME_UI = {THEME_UI_TAG}
 
@@ -103,4 +104,18 @@ def register_theme_ui(mcp: FastMCP, bridge: Bridge) -> None:
         preview = {"node_path": node_path, "name": name, "stylebox_type": stylebox_type}
         return await run_or_preview(
             dry_run, ThemeStyleboxResult, preview, bridge, "cmd_set_theme_stylebox", params
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=THEME_UI)
+    async def get_node_theme_overrides(node_path: str) -> NodeThemeOverrides:
+        """Read the per-node theme overrides on the Control at ``node_path``: ``colors``
+        (name → {r,g,b,a}), ``font_sizes`` (name → int), and ``styleboxes``
+        ({name, type, properties}). The inverse of ``set_theme_color`` /
+        ``set_theme_font_size`` / ``set_theme_stylebox`` — snapshot a node's overrides
+        before editing them for rollback. Covers theme items the control's type defines
+        (the same set Godot's Inspector exposes — e.g. ``font_color`` on a Label, the
+        ``panel`` stylebox on a Panel). Errors if the node isn't a Control.
+        """
+        return NodeThemeOverrides(
+            **await route(bridge, "cmd_get_node_theme_overrides", {"node_path": node_path})
         )

--- a/tests/contract/test_theme_ui.py
+++ b/tests/contract/test_theme_ui.py
@@ -41,6 +41,22 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "stylebox_type": p["stylebox_type"],
                 },
             )
+        case "cmd_get_node_theme_overrides":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "colors": {"font_color": {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0}},
+                    "font_sizes": {"font_size": 24},
+                    "styleboxes": [
+                        {
+                            "name": "panel",
+                            "type": "StyleBoxFlat",
+                            "properties": {"bg_color": {"r": 0.1, "g": 0.1, "b": 0.1, "a": 1.0}},
+                        }
+                    ],
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -104,3 +120,21 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_set_theme_color" not in _commands(conn)
+
+
+async def test_get_node_theme_overrides_reads_all_kinds() -> None:
+    # #219 G7: read color/font-size/stylebox overrides — inverts the set_theme_* writers.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "theme_ui"})
+        result = await client.call_tool("get_node_theme_overrides", {"node_path": "Panel"})
+        tools = {t.name: t for t in await client.list_tools()}
+    data = result.structured_content
+    assert data["colors"]["font_color"] == {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0}
+    assert data["font_sizes"]["font_size"] == 24
+    sb = data["styleboxes"][0]
+    assert sb["name"] == "panel" and sb["type"] == "StyleBoxFlat"
+    assert sb["properties"]["bg_color"]["r"] == 0.1
+    assert tools["get_node_theme_overrides"].meta["safety_class"] == "read_only"
+    cmds = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+    assert "cmd_get_node_theme_overrides" in cmds

--- a/tests/integration/test_theme_ui_e2e.py
+++ b/tests/integration/test_theme_ui_e2e.py
@@ -92,6 +92,27 @@ async def _run() -> None:
         )
         assert box["stylebox_type"] == "StyleBoxFlat"
 
+        # G7 (#219): the panel stylebox override reads back on the Panel (its native item).
+        panel_ov = await _ok(bridge, "cmd_get_node_theme_overrides", {"node_path": "Panel"})
+        panel_sb = next(s for s in panel_ov["styleboxes"] if s["name"] == "panel")
+        assert panel_sb["type"] == "StyleBoxFlat"
+        assert panel_sb["properties"]["corner_radius_top_left"] == 8
+        # color + font-size overrides read back on a Label (their native theme items).
+        await _create(bridge, "Label", "Label")
+        await _ok(
+            bridge,
+            "cmd_set_theme_color",
+            {"node_path": "Label", "name": "font_color", "color": "#ff8800"},
+        )
+        await _ok(
+            bridge,
+            "cmd_set_theme_font_size",
+            {"node_path": "Label", "name": "font_size", "size": 18},
+        )
+        label_ov = await _ok(bridge, "cmd_get_node_theme_overrides", {"node_path": "Label"})
+        assert "font_color" in label_ov["colors"]
+        assert label_ov["font_sizes"]["font_size"] == 18
+
         # validation: non-Control target, bad stylebox type, non-positive size, bad save path
         await _create(bridge, "Plain", "Node2D")
         not_control = await bridge.send("cmd_create_theme", {"node_path": "Plain"})


### PR DESCRIPTION
### **User description**
## Summary
`set_theme_color` / `set_theme_font_size` / `set_theme_stylebox` had no matching read, so none could be inverted (rollback enabler **G7** of the #219 umbrella, found by audit #212).

Adds **`get_node_theme_overrides(node_path)`** → `{node_path, colors{name→rgba}, font_sizes{name→int}, styleboxes[{name, type, properties}]}`:
- `read_only` `[Both]`, the inverse of the three theme-override writers.
- Each stylebox carries its StyleBox **class** + serialized `properties`, so it round-trips back into `set_theme_stylebox`.
- Pure serialization in a new **`MCPThemeRead`** lib (Control + theme APIs, no `EditorInterface`) → verified headlessly against the real Godot API.

### Godot API note
Godot 4.x has **no** `get_theme_*_override_list`, so the lib enumerates overrides via the property list (`theme_override_colors/` · `theme_override_font_sizes/` · `theme_override_styles/`), each gated on `has_theme_*_override`. This covers theme items the control's **type** defines — the same set the Inspector exposes (e.g. `font_color` on a Label, the `panel` stylebox on a Panel). Documented in the tool docstring + contracts.

## Acceptance criteria (#219 G7)
- [x] `get_node_theme_overrides(node_path)` → `{colors, font_sizes, styleboxes}`; inverts `set_theme_color` / `set_theme_font_size` / `set_theme_stylebox`

## Test plan
- **Contract** (`tests/contract/test_theme_ui.py`): all three override kinds + `read_only` meta.
- **Addon (headless)**: `theme_read_smoke.gd` builds a real `Label` with color/font-size/stylebox overrides and verifies the read (incl. the empty-overrides case) → `THEME_READ_TEST_OK`. Both addon scripts pass `--check-only`.
- **E2E** (`tests/integration/test_theme_ui_e2e.py`): the `panel` stylebox reads back on a Panel; `font_color`/`font_size` read back on a Label (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 490 unit+contract pass, zero-skip clean. Docs + README (135 tools).

Part of #219 (G7). Remaining: G6 (visual-shader read), P2 (input-action events), G8 (audio-bus removers).
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds read-only tool for theme overrides

- Enables rollback support for theme modifications

- Expands tool contract documentation

- Updates README with new tool listing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set_theme_color"] -- "rollback enabler" --> B["get_node_theme_overrides"]
  A -- "rollback enabler" --> C["set_theme_font_size"]
  A -- "rollback enabler" --> D["set_theme_stylebox"]
  B -- "read-only" --> E["MCPThemeRead lib"]
  E -- "serializes" --> F["NodeThemeOverrides"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>theme_ui.py</strong><dd><code>Add theme override data models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-c1fe535f0b62cb68216575b2de61767e628477409d00b0417e2b8824a3e64d64">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme_ui.py</strong><dd><code>Implement get_node_theme_overrides tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-1b8b29f3591a4b62b44f5b6f038e6a418600e2c621b6e2ae9ec20a2ef31077df">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme_ui.gd</strong><dd><code>Register new theme override handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-3df63a637864b4734a280d31cdd59e0ec3e6565aa9b686d900e6fe52ba3f16ba">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme_read.gd</strong><dd><code>Add pure read-only theme override serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-350ef76cef40fa3637e691b083cf3d3f8b1be9490cf9863439b04097c822ea81">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_theme_ui.py</strong><dd><code>Add contract test for theme overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-f91816214519320a0d6202ecb9fbdaa82c6af38389def58c36a8ddf26ba2c507">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_theme_ui_e2e.py</strong><dd><code>Add end-to-end test for theme overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-c10407aa9bc3c1616c95c3cd641f59cc84829ddb587320e6a64e18f3264025ba">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme_read_smoke.gd</strong><dd><code>Add headless smoke test for theme reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-93cecb74fdb52bb85e4808fda3db5a04ff06aa89596e44e506fff9f4954ace4e">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count and add new tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document new read-only theme override tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/251/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

