### PR TITLE
feat(shader): add read_visual_shader for rollback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **135 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **136 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -611,6 +611,7 @@ to the text-shader `shader` toolset (issue #47). All mutating tools support `dry
 | `connect_shader_nodes` | `shader_path, from_node, from_port, to_node, to_port` | `ConnectShaderNodesResult { connected }` | `mutating` |
 | `set_shader_node_param` | `shader_path, node_id, property, value` | `SetShaderNodeParamResult { node_id, property, value, set }` | `mutating` |
 | `list_shader_node_types` | — | `ListShaderNodeTypesResult { types[] }` | `read_only` |
+| `read_visual_shader` | `shader_path` | `VisualShaderGraph { shader_path, mode, nodes[{id, type, position, parameters}], connections[{from_node, from_port, to_node, to_port}] }` | `read_only` |
 
 `create_visual_shader` creates a `VisualShader` resource with `shader_type` set from
 `type` (`"2d"` → canvas_item, `"3d"` → spatial, `"particles"` | `"sky"` | `"fog"`).
@@ -618,7 +619,9 @@ to the text-shader `shader` toolset (issue #47). All mutating tools support `dry
 `position`. `connect_shader_nodes` wires an output port to an input port by
 integer ids. `set_shader_node_param` sets a property on the node (values coerced via
 `type_coerce`). `list_shader_node_types` scans ClassDB for instantiable
-`VisualShaderNode*` classes so agents know what's available.
+`VisualShaderNode*` classes so agents know what's available. `read_visual_shader` is the
+inverse read — it serializes the whole graph (mode, every node with its class/position/
+parameters, and the connections) for rollback before edits.
 
 #### Project scaffold (issue #112) — category: `project_scaffold` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/visual_shader.gd
+++ b/godot/addons/godot_mcp/handlers/visual_shader.gd
@@ -2,6 +2,7 @@
 class_name MCPVisualShaderHandlers
 extends RefCounted
 const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+const VisualShaderRead := preload("res://addons/godot_mcp/visual_shader_read.gd")
 ## Domain handler: visual shader node graphs (issue #107).
 ##
 ## Registered by the router on _init(). Each handler receives a params dict and
@@ -20,6 +21,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_connect_shader_nodes"] = _cmd_connect_shader_nodes
 	handlers["cmd_set_shader_node_param"] = _cmd_set_shader_node_param
 	handlers["cmd_list_shader_node_types"] = _cmd_list_shader_node_types
+	handlers["cmd_read_visual_shader"] = _cmd_read_visual_shader
 
 
 # -- helpers -----------------------------------------------------------------
@@ -195,3 +197,19 @@ func _cmd_list_shader_node_types(_params: Dictionary) -> Dictionary:
 		if str(cls).begins_with("VisualShaderNode") and ClassDB.can_instantiate(str(cls)):
 			types.append(str(cls))
 	return _router._ok({"types": types})
+
+
+## Read a VisualShader graph — mode + nodes + connections (issue #219 G6). The inverse of
+## the visual-shader writers; delegates the pure serialization to MCPVisualShaderRead.
+func _cmd_read_visual_shader(params: Dictionary) -> Dictionary:
+	var path := str(params.get("shader_path", ""))
+	if not path.begins_with("res://"):
+		return _router._fail("VALIDATION_ERROR", "shader_path must start with res://.")
+	if not ResourceLoader.exists(path):
+		return _router._fail("RESOURCE_NOT_FOUND", "No shader at '%s'." % path)
+	var resource: Resource = ResourceLoader.load(path)
+	if not (resource is VisualShader):
+		return _router._fail("VALIDATION_ERROR", "'%s' is not a VisualShader." % path)
+	var data: Dictionary = VisualShaderRead.serialize(resource)
+	data["shader_path"] = path
+	return _router._ok(data)

--- a/godot/addons/godot_mcp/visual_shader_read.gd
+++ b/godot/addons/godot_mcp/visual_shader_read.gd
@@ -1,0 +1,49 @@
+@tool
+class_name MCPVisualShaderRead
+extends RefCounted
+## Pure, read-only serialization of a VisualShader node graph (issue #219 G6 — rollback
+## enabler). Takes a VisualShader resource (never EditorInterface), so verifiable
+## headlessly (see godot/tests/visual_shader_read_smoke.gd). Inverts
+## create_visual_shader / add_shader_node / connect_shader_nodes / set_shader_node_param.
+
+const Inspect := preload("res://addons/godot_mcp/scene_inspect.gd")
+const Coerce := preload("res://addons/godot_mcp/type_coerce.gd")
+
+const _MODE_NAMES := {
+	VisualShader.MODE_SPATIAL: "spatial",
+	VisualShader.MODE_CANVAS_ITEM: "canvas_item",
+	VisualShader.MODE_PARTICLES: "particles",
+	VisualShader.MODE_SKY: "sky",
+	VisualShader.MODE_FOG: "fog",
+}
+
+
+## { mode, nodes:[{id, type, position:{x,y}, parameters:{...}}],
+##   connections:[{from_node, from_port, to_node, to_port}] }.
+##
+## The writers add nodes under int(shader.get_mode()) as the VisualShader.Type arg, so the
+## read enumerates against that same value to round-trip (see handlers/visual_shader.gd).
+static func serialize(shader: VisualShader) -> Dictionary:
+	var type := int(shader.get_mode())
+	var nodes: Array = []
+	for id in shader.get_node_list(type):
+		var node: VisualShaderNode = shader.get_node(type, id)
+		nodes.append({
+			"id": int(id),
+			"type": node.get_class(),
+			"position": Coerce.to_json(shader.get_node_position(type, id)),
+			"parameters": Inspect.resource_properties(node),
+		})
+	var connections: Array = []
+	for c in shader.get_node_connections(type):
+		connections.append({
+			"from_node": int(c["from_node"]),
+			"from_port": int(c["from_port"]),
+			"to_node": int(c["to_node"]),
+			"to_port": int(c["to_port"]),
+		})
+	return {
+		"mode": _MODE_NAMES.get(int(shader.get_mode()), "spatial"),
+		"nodes": nodes,
+		"connections": connections,
+	}

--- a/godot/tests/visual_shader_read_smoke.gd
+++ b/godot/tests/visual_shader_read_smoke.gd
@@ -1,0 +1,69 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPVisualShaderRead (issue #219 G6).
+##
+## Run via: godot --headless --path godot/ --script res://tests/visual_shader_read_smoke.gd
+## Builds a real VisualShader graph (no EditorInterface) the same way the writers do —
+## add_node(int(mode), ...) + connect_nodes — and verifies the pure read serialization
+## against the live Godot API.
+
+const VisualShaderRead := preload("res://addons/godot_mcp/visual_shader_read.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+
+	var shader := VisualShader.new()
+	shader.set_mode(VisualShader.MODE_CANVAS_ITEM)
+	var type := int(shader.get_mode())  # mirror the writers' Type-from-Mode convention
+
+	# Add a color-constant node (id 2) and wire it to the output node (id 0, port 0).
+	var color := VisualShaderNodeColorConstant.new()
+	color.constant = Color(1, 0, 0, 1)
+	shader.add_node(type, color, Vector2(-200, 40), 2)
+	shader.connect_nodes(type, 2, 0, 0, 0)
+
+	var data: Dictionary = VisualShaderRead.serialize(shader)
+	_eq(failures, "mode", data.get("mode"), "canvas_item")
+
+	var nodes: Array = data["nodes"]
+	var ids: Array = []
+	for n in nodes:
+		ids.append(n["id"])
+	if not (ids.has(0) and ids.has(2)):
+		failures.append("expected node ids 0 and 2, got %s" % str(ids))
+	var color_node: Dictionary = {}
+	for n in nodes:
+		if n["id"] == 2:
+			color_node = n
+	_eq(failures, "color.type", color_node.get("type"), "VisualShaderNodeColorConstant")
+	_eq(failures, "color.position", color_node.get("position"), {"x": -200.0, "y": 40.0})
+	var params: Dictionary = color_node.get("parameters", {})
+	if not params.has("constant"):
+		failures.append("color node parameters missing 'constant': %s" % str(params.keys()))
+
+	var connections: Array = data["connections"]
+	if connections.size() != 1:
+		failures.append("expected 1 connection, got %s" % str(connections))
+	else:
+		var edge: Dictionary = connections[0]
+		_eq(failures, "edge.from_node", edge.get("from_node"), 2)
+		_eq(failures, "edge.to_node", edge.get("to_node"), 0)
+
+	# Output must be JSON-safe.
+	if JSON.stringify(data) == "":
+		failures.append("serialized graph is not JSON-safe")
+
+	if failures.is_empty():
+		print("VISUAL_SHADER_READ_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("VISUAL_SHADER_READ_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/visual_shader.py
+++ b/mcp_server/models/visual_shader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class CreateVisualShaderResult(BaseModel):
@@ -35,3 +35,36 @@ class SetShaderNodeParamResult(BaseModel):
 
 class ListShaderNodeTypesResult(BaseModel):
     types: list[str]
+
+
+class VisualShaderNodeInfo(BaseModel):
+    """One node in a VisualShader graph (issue #219 G6): its ``id``, ``type`` (the
+    VisualShaderNode class), editor ``position``, and serialized ``parameters`` — enough
+    to recreate it via ``add_shader_node`` + ``set_shader_node_param``."""
+
+    id: int
+    type: str
+    position: dict[str, float] = Field(default_factory=dict)
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class VisualShaderConnection(BaseModel):
+    """One edge in a VisualShader graph (issue #219 G6) — the inverse of
+    ``connect_shader_nodes``."""
+
+    from_node: int
+    from_port: int
+    to_node: int
+    to_port: int
+
+
+class VisualShaderGraph(BaseModel):
+    """A serialized VisualShader graph (issue #219 G6) — the inverse of
+    ``create_visual_shader`` / ``add_shader_node`` / ``connect_shader_nodes`` /
+    ``set_shader_node_param``. ``mode`` is the shader mode (spatial / canvas_item /
+    particles / sky / fog)."""
+
+    shader_path: str
+    mode: str
+    nodes: list[VisualShaderNodeInfo] = Field(default_factory=list)
+    connections: list[VisualShaderConnection] = Field(default_factory=list)

--- a/mcp_server/tools/visual_shader.py
+++ b/mcp_server/tools/visual_shader.py
@@ -20,6 +20,7 @@ from mcp_server.models.visual_shader import (
     CreateVisualShaderResult,
     ListShaderNodeTypesResult,
     SetShaderNodeParamResult,
+    VisualShaderGraph,
 )
 from mcp_server.safety import MUTATING, READ_ONLY
 from mcp_server.tools._route import route, run_or_preview
@@ -162,4 +163,17 @@ def register_visual_shader(mcp: FastMCP, bridge: Bridge) -> None:
         """
         return ListShaderNodeTypesResult(
             **await route(bridge, "cmd_list_shader_node_types")
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=VISUAL_SHADER)
+    async def read_visual_shader(shader_path: str) -> VisualShaderGraph:
+        """Read the VisualShader graph at ``shader_path`` (a ``res://*.tres``): its
+        ``mode`` plus every ``node`` ({id, type, position, parameters}) and
+        ``connection`` ({from_node, from_port, to_node, to_port}). The inverse of
+        ``create_visual_shader`` / ``add_shader_node`` / ``connect_shader_nodes`` /
+        ``set_shader_node_param`` — snapshot a shader graph before editing it for
+        rollback. Errors if the path isn't a VisualShader resource.
+        """
+        return VisualShaderGraph(
+            **await route(bridge, "cmd_read_visual_shader", {"shader_path": shader_path})
         )

--- a/tests/contract/test_visual_shader.py
+++ b/tests/contract/test_visual_shader.py
@@ -62,6 +62,31 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     ]
                 },
             )
+        case "cmd_read_visual_shader":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "shader_path": p["shader_path"],
+                    "mode": "spatial",
+                    "nodes": [
+                        {
+                            "id": 0,
+                            "type": "VisualShaderNodeOutput",
+                            "position": {"x": 0.0, "y": 0.0},
+                            "parameters": {},
+                        },
+                        {
+                            "id": 2,
+                            "type": "VisualShaderNodeColorConstant",
+                            "position": {"x": -200.0, "y": 40.0},
+                            "parameters": {"constant": {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0}},
+                        },
+                    ],
+                    "connections": [
+                        {"from_node": 2, "from_port": 0, "to_node": 0, "to_port": 0}
+                    ],
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -194,3 +219,24 @@ async def test_mutating_tools_have_dry_run() -> None:
     assert dry.structured_content["dry_run"] is True
     assert dry.structured_content["added"] is False
     assert "cmd_add_shader_node" not in _commands(conn)
+
+
+async def test_read_visual_shader_returns_graph() -> None:
+    # #219 G6: read the VisualShader graph (nodes + connections) — inverts the writers.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "visual_shader"})
+        result = await client.call_tool(
+            "read_visual_shader", {"shader_path": "res://shaders/fx.tres"}
+        )
+        tools = {t.name: t for t in await client.list_tools()}
+    data = result.structured_content
+    assert data["mode"] == "spatial"
+    assert {n["id"] for n in data["nodes"]} == {0, 2}
+    color = next(n for n in data["nodes"] if n["id"] == 2)
+    assert color["type"] == "VisualShaderNodeColorConstant"
+    assert color["parameters"]["constant"]["r"] == 1.0
+    conn_edge = data["connections"][0]
+    assert conn_edge["from_node"] == 2 and conn_edge["to_node"] == 0
+    assert tools["read_visual_shader"].meta["safety_class"] == "read_only"
+    assert "cmd_read_visual_shader" in _commands(conn)

--- a/tests/integration/test_visual_shader_e2e.py
+++ b/tests/integration/test_visual_shader_e2e.py
@@ -77,8 +77,20 @@ async def _run() -> None:
         )
         assert connected["connected"] is True
 
+        # G6 (#219): read the graph back — mode, the added node, and the connection.
+        graph = await _ok(bridge, "cmd_read_visual_shader", {"shader_path": SHADER})
+        assert graph["mode"] == "canvas_item"
+        node1 = next(n for n in graph["nodes"] if n["id"] == 1)
+        assert node1["type"] == "VisualShaderNodeColorConstant"
+        assert node1["position"] == {"x": 100.0, "y": 200.0}
+        assert {"from_node": 1, "from_port": 0, "to_node": 0, "to_port": 0} in graph["connections"]
+
         types = await _ok(bridge, "cmd_list_shader_node_types", {})
         assert any(t.startswith("VisualShaderNode") for t in types["types"])
+
+        # validation: not a VisualShader resource path
+        bad = await bridge.send("cmd_read_visual_shader", {"shader_path": "res://nope.tres"})
+        assert bad.ok is False and bad.error == "RESOURCE_NOT_FOUND"
     finally:
         await bridge.close()
 


### PR DESCRIPTION
### **User description**
## Summary
`create_visual_shader` / `add_shader_node` / `connect_shader_nodes` / `set_shader_node_param` had no matching read, so none could be inverted (rollback enabler **G6** of the #219 umbrella, found by audit #212).

Adds **`read_visual_shader(shader_path)`** → `{shader_path, mode, nodes[{id, type, position, parameters}], connections[{from_node, from_port, to_node, to_port}]}`:
- `read_only` `[Both]`, the inverse of the four visual-shader writers.
- Each node carries its `VisualShaderNode` class, editor `position`, and serialized `parameters`, so it round-trips into `add_shader_node` + `set_shader_node_param`.
- Pure serialization in a new **`MCPVisualShaderRead`** lib (VisualShader resource only, no `EditorInterface`) → verified headlessly against the real Godot API.

### API note
The read enumerates nodes/connections under `int(shader.get_mode())` as the `VisualShader.Type` arg — the **exact** convention the writers use in `add_node` (see `handlers/visual_shader.gd`) — so the graph round-trips with the writers.

## Acceptance criteria (#219 G6)
- [x] `read_visual_shader(...)` → serialized VisualShader graph (nodes + connections); inverts the visual-shader writers

## Test plan
- **Contract** (`tests/contract/test_visual_shader.py`): graph nodes + connections + `read_only` meta.
- **Addon (headless)**: `visual_shader_read_smoke.gd` builds a real `VisualShader` (a ColorConstant wired to the output, the writers' way) and verifies the read → `VISUAL_SHADER_READ_TEST_OK`. Both addon scripts pass `--check-only`.
- **E2E** (`tests/integration/test_visual_shader_e2e.py`): read back mode + the added node + the connection, plus a not-found path (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 491 unit+contract pass, zero-skip clean. Docs + README (136 tools).

Part of #219 (G6). Remaining: P2 (input-action events), G8 (audio-bus removers).
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds read-only primitive for VisualShader graphs

- Enables rollback for visual shader editing

- Supports full inversion of shader mutation tools

- Extends tool contract documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["create_visual_shader"] -- "inverse" --> B["read_visual_shader"]
  C["add_shader_node"] -- "inverse" --> B
  D["connect_shader_nodes"] -- "inverse" --> B
  E["set_shader_node_param"] -- "inverse" --> B
  B -- "serializes graph" --> F["VisualShaderGraph"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>visual_shader.py</strong><dd><code>Add VisualShader graph data models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-33b225343d9f04e9bf3df354d3cd23a99aa8e9dc2627eeba568b2a22680e3a0d">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visual_shader.py</strong><dd><code>Implement read_visual_shader tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-efada8cfdde063fcbd62db55f8edcb6faf51c715a3e8b3aa7a33ac2fcd14a455">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visual_shader.gd</strong><dd><code>Register cmd_read_visual_shader handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-1a15b4e5dbf86dbc670b36feff984bd20e39675dd6e101d58c72c293985afc07">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visual_shader_read.gd</strong><dd><code>Implement pure VisualShader graph serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-32dec349351af0a8ba58b0a1496506f90040281d4ba6599148ddaad98c9a8d30">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_visual_shader.py</strong><dd><code>Add contract test for read_visual_shader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-89076c9096ff808cf76ce6fc9a3ed87f1fa75f69e1d0620efd9e7f8170f7b27b">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_visual_shader_e2e.py</strong><dd><code>Add E2E test for shader graph reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-c63c164c4e0b39b3b9e26b9cf99ae8745e93a2a49fcd39e39edf1e0ee58a68eb">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visual_shader_read_smoke.gd</strong><dd><code>Add headless smoke test for graph reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-d74756ca45b0117a17eb37bfb9709cc8f04a82fec6040af6739c603d8ed04726">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document read_visual_shader contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/252/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

