### PR TITLE
feat(input): add get_input_action_events for rollback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **136 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **137 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -516,8 +516,8 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 ### Export (gated) — `read_only` / `runtime`
 - `list_export_presets`, `get_export_info`, `export_project`
 
-### Input Map (gated, Godot 4.4+) — `mutating` / `destructive`
-- `add_input_action`, `remove_input_action` (destructive), `add_input_event`, `clear_input_action_events` (destructive)
+### Input Map (gated, Godot 4.4+) — `mutating` / `destructive` / `read_only`
+- `add_input_action`, `remove_input_action` (destructive), `add_input_event`, `clear_input_action_events` (destructive), `get_input_action_events` (read_only)
 
 ### Resources (`godot://` URIs)
 Read-only snapshots refreshed on access:

--- a/godot/addons/godot_mcp/handlers/input_map.gd
+++ b/godot/addons/godot_mcp/handlers/input_map.gd
@@ -6,6 +6,8 @@ extends RefCounted
 ## Registered by the router on _init().  Each handler receives params dict and
 ## returns a response body (without id) via the router's _ok / _fail builders.
 
+const InputActionRead := preload("res://addons/godot_mcp/input_action_read.gd")
+
 var _router: MCPCommandRouter
 
 
@@ -18,9 +20,26 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_add_input_event"] = _cmd_add_input_event
 	handlers["cmd_clear_input_action_events"] = _cmd_clear_input_action_events
 	handlers["cmd_remove_input_action"] = _cmd_remove_input_action
+	handlers["cmd_get_input_action_events"] = _cmd_get_input_action_events
 
 
 # -- handlers ----------------------------------------------------------------
+
+## Read an input action's deadzone + events (issue #219 P2). The inverse of the
+## input_map writers; delegates per-event serialization to MCPInputActionRead. Events
+## come from ProjectSettings (project.godot), the same store the writers persist to.
+func _cmd_get_input_action_events(params: Dictionary) -> Dictionary:
+	var action_name := str(params.get("action", ""))
+	if action_name.is_empty():
+		return _router._fail("VALIDATION_ERROR", "action is required.")
+	var setting_key := "input/" + action_name
+	if not ProjectSettings.has_setting(setting_key):
+		return _router._fail("RESOURCE_NOT_FOUND", "No input action '%s'." % action_name)
+	var action_data: Dictionary = ProjectSettings.get_setting(setting_key)
+	var deadzone := float(action_data.get("deadzone", 0.5))
+	var events: Array = action_data.get("events", [])
+	return _router._ok(InputActionRead.serialize(action_name, deadzone, events))
+
 
 func _cmd_add_input_action(params: Dictionary) -> Dictionary:
 	var action_name := str(params.get("name", ""))

--- a/godot/addons/godot_mcp/input_action_read.gd
+++ b/godot/addons/godot_mcp/input_action_read.gd
@@ -1,0 +1,61 @@
+@tool
+class_name MCPInputActionRead
+extends RefCounted
+## Pure serialization of input-action events (issue #219 P2 — rollback enabler). Takes
+## the events Array + deadzone from a ProjectSettings input/<action> entry (no
+## ProjectSettings / EditorInterface access here), so verifiable headlessly (see
+## godot/tests/input_action_read_smoke.gd). Each event is emitted in the same shape
+## add_input_event accepts, so remove_input_action / clear_input_action_events are
+## invertible.
+
+const _MOUSE_BUTTON_NAMES := {
+	MOUSE_BUTTON_LEFT: "left",
+	MOUSE_BUTTON_RIGHT: "right",
+	MOUSE_BUTTON_MIDDLE: "middle",
+	MOUSE_BUTTON_WHEEL_UP: "wheel_up",
+	MOUSE_BUTTON_WHEEL_DOWN: "wheel_down",
+}
+
+
+## { action, deadzone, events:[{event_type, ...kind-specific keys}] }.
+static func serialize(action: String, deadzone: float, events: Array) -> Dictionary:
+	var out: Array = []
+	for ev in events:
+		var d := _serialize_event(ev)
+		if not d.is_empty():
+			out.append(d)
+	return {"action": action, "deadzone": deadzone, "events": out}
+
+
+## One InputEvent → an add_input_event-shaped dict (empty for unsupported types).
+static func _serialize_event(ev: Variant) -> Dictionary:
+	if ev is InputEventKey:
+		var d := {
+			"event_type": "key",
+			"shift": ev.shift_pressed,
+			"ctrl": ev.ctrl_pressed,
+			"alt": ev.alt_pressed,
+			"meta": ev.meta_pressed,
+		}
+		# Mirror the writer, which sets keycode OR physical_keycode; OS.get_keycode_string
+		# is the inverse of the writer's OS.find_keycode_from_string.
+		if ev.keycode != 0:
+			d["keycode"] = OS.get_keycode_string(ev.keycode)
+		if ev.physical_keycode != 0:
+			d["physical_keycode"] = OS.get_keycode_string(ev.physical_keycode)
+		return d
+	elif ev is InputEventMouseButton:
+		return {
+			"event_type": "mouse",
+			"button": _MOUSE_BUTTON_NAMES.get(ev.button_index, str(ev.button_index)),
+		}
+	elif ev is InputEventJoypadButton:
+		return {"event_type": "joypad_button", "device": ev.device, "joy_button_index": ev.button_index}
+	elif ev is InputEventJoypadMotion:
+		return {
+			"event_type": "joypad_motion",
+			"device": ev.device,
+			"axis": ev.axis,
+			"axis_value": ev.axis_value,
+		}
+	return {}

--- a/godot/tests/input_action_read_smoke.gd
+++ b/godot/tests/input_action_read_smoke.gd
@@ -1,0 +1,60 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPInputActionRead (issue #219 P2).
+##
+## Run via: godot --headless --path godot/ --script res://tests/input_action_read_smoke.gd
+## Builds real InputEvent objects (no ProjectSettings) and verifies the pure event
+## serialization round-trips into the add_input_event shape against the live Godot API.
+
+const InputActionRead := preload("res://addons/godot_mcp/input_action_read.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+
+	# A Ctrl+Space key event, a left mouse button, and a joypad motion.
+	var key := InputEventKey.new()
+	key.keycode = OS.find_keycode_from_string("Space")
+	key.ctrl_pressed = true
+	var mouse := InputEventMouseButton.new()
+	mouse.button_index = MOUSE_BUTTON_LEFT
+	var motion := InputEventJoypadMotion.new()
+	motion.device = 0
+	motion.axis = JOY_AXIS_LEFT_X
+	motion.axis_value = 1.0
+
+	var data: Dictionary = InputActionRead.serialize("jump", 0.25, [key, mouse, motion])
+	_eq(failures, "action", data.get("action"), "jump")
+	_eq(failures, "deadzone", data.get("deadzone"), 0.25)
+
+	var events: Array = data["events"]
+	if events.size() != 3:
+		failures.append("expected 3 events, got %s" % str(events))
+	else:
+		var k: Dictionary = events[0]
+		_eq(failures, "key.event_type", k.get("event_type"), "key")
+		# keycode round-trips through OS.find_keycode_from_string (the writer's inverse).
+		_eq(failures, "key.keycode", OS.find_keycode_from_string(k.get("keycode", "")), key.keycode)
+		_eq(failures, "key.ctrl", k.get("ctrl"), true)
+		_eq(failures, "key.shift", k.get("shift"), false)
+		_eq(failures, "mouse.button", events[1].get("button"), "left")
+		_eq(failures, "motion.event_type", events[2].get("event_type"), "joypad_motion")
+		_eq(failures, "motion.axis_value", events[2].get("axis_value"), 1.0)
+
+	# Output must be JSON-safe.
+	if JSON.stringify(data) == "":
+		failures.append("serialized events are not JSON-safe")
+
+	if failures.is_empty():
+		print("INPUT_ACTION_READ_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("INPUT_ACTION_READ_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/input_action_read_smoke.gd
+++ b/godot/tests/input_action_read_smoke.gd
@@ -12,24 +12,30 @@ const InputActionRead := preload("res://addons/godot_mcp/input_action_read.gd")
 func _initialize() -> void:
 	var failures: Array[String] = []
 
-	# A Ctrl+Space key event, a left mouse button, and a joypad motion.
+	# One of each kind: a Ctrl+Space key, a physical-keycode key, a left mouse button,
+	# a joypad button, and a joypad motion — covering every branch of _serialize_event.
 	var key := InputEventKey.new()
 	key.keycode = OS.find_keycode_from_string("Space")
 	key.ctrl_pressed = true
+	var phys := InputEventKey.new()
+	phys.physical_keycode = OS.find_keycode_from_string("A")
 	var mouse := InputEventMouseButton.new()
 	mouse.button_index = MOUSE_BUTTON_LEFT
+	var joy_button := InputEventJoypadButton.new()
+	joy_button.device = 1
+	joy_button.button_index = JOY_BUTTON_A
 	var motion := InputEventJoypadMotion.new()
 	motion.device = 0
 	motion.axis = JOY_AXIS_LEFT_X
 	motion.axis_value = 1.0
 
-	var data: Dictionary = InputActionRead.serialize("jump", 0.25, [key, mouse, motion])
+	var data: Dictionary = InputActionRead.serialize("jump", 0.25, [key, phys, mouse, joy_button, motion])
 	_eq(failures, "action", data.get("action"), "jump")
 	_eq(failures, "deadzone", data.get("deadzone"), 0.25)
 
 	var events: Array = data["events"]
-	if events.size() != 3:
-		failures.append("expected 3 events, got %s" % str(events))
+	if events.size() != 5:
+		failures.append("expected 5 events, got %s" % str(events))
 	else:
 		var k: Dictionary = events[0]
 		_eq(failures, "key.event_type", k.get("event_type"), "key")
@@ -37,9 +43,19 @@ func _initialize() -> void:
 		_eq(failures, "key.keycode", OS.find_keycode_from_string(k.get("keycode", "")), key.keycode)
 		_eq(failures, "key.ctrl", k.get("ctrl"), true)
 		_eq(failures, "key.shift", k.get("shift"), false)
-		_eq(failures, "mouse.button", events[1].get("button"), "left")
-		_eq(failures, "motion.event_type", events[2].get("event_type"), "joypad_motion")
-		_eq(failures, "motion.axis_value", events[2].get("axis_value"), 1.0)
+		# physical-keycode key: physical_keycode is serialized, keycode is omitted (was 0).
+		var pk: Dictionary = events[1]
+		_eq(failures, "phys.physical_keycode", OS.find_keycode_from_string(pk.get("physical_keycode", "")), phys.physical_keycode)
+		if pk.has("keycode"):
+			failures.append("physical key leaked an (unset) keycode: %s" % str(pk))
+		_eq(failures, "mouse.button", events[2].get("button"), "left")
+		# joypad button: device + joy_button_index round-trip into add_input_event.
+		var jb: Dictionary = events[3]
+		_eq(failures, "joy_button.event_type", jb.get("event_type"), "joypad_button")
+		_eq(failures, "joy_button.device", jb.get("device"), 1)
+		_eq(failures, "joy_button.index", jb.get("joy_button_index"), joy_button.button_index)
+		_eq(failures, "motion.event_type", events[4].get("event_type"), "joypad_motion")
+		_eq(failures, "motion.axis_value", events[4].get("axis_value"), 1.0)
 
 	# Output must be JSON-safe.
 	if JSON.stringify(data) == "":

--- a/mcp_server/models/input_map.py
+++ b/mcp_server/models/input_map.py
@@ -5,7 +5,9 @@ Editing the project's Input Map actions and events (project.godot).
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class AddInputActionResult(BaseModel):
@@ -32,3 +34,16 @@ class ClearInputActionEventsResult(BaseModel):
     action: str
     cleared: bool
     dry_run: bool = False
+
+
+class InputActionEvents(BaseModel):
+    """An input action's deadzone + its events (issue #219 P2) — the inverse of
+    ``add_input_event`` / ``clear_input_action_events`` / ``remove_input_action``. Each
+    event is a dict in the same shape ``add_input_event`` accepts (``event_type`` plus
+    its kind-specific keys: ``keycode``/modifiers for key, ``button`` for mouse,
+    ``device``/``joy_button_index`` or ``axis``/``axis_value`` for joypad), so the action
+    can be rebuilt for rollback."""
+
+    action: str
+    deadzone: float = 0.5
+    events: list[dict[str, Any]] = Field(default_factory=list)

--- a/mcp_server/tools/input_map.py
+++ b/mcp_server/tools/input_map.py
@@ -19,17 +19,19 @@ from mcp_server.models.input_map import (
     AddInputActionResult,
     AddInputEventResult,
     ClearInputActionEventsResult,
+    InputActionEvents,
     RemoveInputActionResult,
 )
 from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
+    READ_ONLY,
     ApprovalGate,
     enforce_preconditions,
     require_bridge_connected,
     require_confirmation,
 )
-from mcp_server.tools._route import run_or_preview
+from mcp_server.tools._route import route, run_or_preview
 
 INPUT_MAP = {INPUT_MAP_TAG}
 
@@ -148,4 +150,19 @@ def register_input_map(
             bridge,
             "cmd_clear_input_action_events",
             params,
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=INPUT_MAP)
+    async def get_input_action_events(action: str) -> InputActionEvents:
+        """Read an input action's ``deadzone`` and full event list. Each event is a dict
+        in the same shape ``add_input_event`` accepts (``event_type`` plus its
+        kind-specific keys — ``keycode``/``physical_keycode``/modifiers for key,
+        ``button`` for mouse, ``device``/``joy_button_index`` or ``axis``/``axis_value``
+        for joypad). The inverse of ``add_input_event`` / ``clear_input_action_events`` /
+        ``remove_input_action`` — snapshot an action before editing it so it can be
+        rebuilt. Errors (RESOURCE_NOT_FOUND) if no such action exists.
+        """
+        require_bridge_connected(bridge)
+        return InputActionEvents(
+            **await route(bridge, "cmd_get_input_action_events", {"action": action})
         )

--- a/tests/contract/test_input_map.py
+++ b/tests/contract/test_input_map.py
@@ -33,6 +33,25 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             )
         case "cmd_clear_input_action_events":
             return ResponseEnvelope.success(cmd.id, {"action": p["action"], "cleared": True})
+        case "cmd_get_input_action_events":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "action": p["action"],
+                    "deadzone": 0.5,
+                    "events": [
+                        {
+                            "event_type": "key",
+                            "keycode": "Space",
+                            "shift": False,
+                            "ctrl": True,
+                            "alt": False,
+                            "meta": False,
+                        },
+                        {"event_type": "mouse", "button": "left"},
+                    ],
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 
 
@@ -149,3 +168,20 @@ async def test_clear_input_action_events_with_confirm_proceeds() -> None:
         )
     assert result.structured_content["cleared"] is True
     assert "cmd_clear_input_action_events" in _commands(conn)
+
+
+async def test_get_input_action_events_returns_detail() -> None:
+    # #219 P2: read each event's full detail so remove/clear are invertible.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "input_map"})
+        result = await client.call_tool("get_input_action_events", {"action": "jump"})
+        tools = {t.name: t for t in await client.list_tools()}
+    data = result.structured_content
+    assert data["action"] == "jump"
+    assert data["deadzone"] == 0.5
+    key = data["events"][0]
+    assert key["event_type"] == "key" and key["keycode"] == "Space" and key["ctrl"] is True
+    assert data["events"][1] == {"event_type": "mouse", "button": "left"}
+    assert tools["get_input_action_events"].meta["safety_class"] == "read_only"
+    assert "cmd_get_input_action_events" in _commands(conn)


### PR DESCRIPTION
### **User description**
## Summary
`get_project_info` exposed no input-action event detail, so `add_input_event` / `clear_input_action_events` / `remove_input_action` couldn't be inverted (rollback enabler **P2** of the #219 umbrella, found by audit #212).

Adds **`get_input_action_events(action)`** → `{action, deadzone, events[]}`:
- `read_only` `[Both]`. Each event is a dict in the **same shape `add_input_event` accepts** — `event_type` plus its kind-specific keys (`keycode`/`physical_keycode`/modifiers for key, `button` for mouse, `device`/`joy_button_index` or `axis`/`axis_value` for joypad) — so an action can be rebuilt for rollback.
- Pure per-event serialization in a new **`MCPInputActionRead`** lib (operates on `InputEvent` objects, no ProjectSettings access) → verified headlessly against the real Godot API. The handler reads `ProjectSettings` `input/<action>` (the same store the writers persist to) and delegates.
- `keycode` round-trips via `OS.get_keycode_string` — the inverse of the writer's `OS.find_keycode_from_string`.

## Acceptance criteria (#219 P2)
- [x] full event detail available for an action (keycode/modifiers/type) so `remove_input_action` / `clear_input_action_events` are invertible — added as `get_input_action_events(action)` (the issue's "else" path, since `get_project_info` carried no event detail)

## Test plan
- **Contract** (`tests/contract/test_input_map.py`): key (with modifiers) + mouse event detail, `deadzone`, `read_only` meta.
- **Addon (headless)**: `input_action_read_smoke.gd` builds real `InputEventKey`/`InputEventMouseButton`/`InputEventJoypadMotion` and verifies the serialization round-trips → `INPUT_ACTION_READ_TEST_OK`. Both addon scripts pass `--check-only`.
- Preflight: CI-parity `ruff` clean, `mypy` clean, 492 unit+contract pass, zero-skip clean. README (137 tools).

### Skipped step (per workflow.md)
- **E2E**: the `input_map` toolset (#81) ships **no** e2e harness (it mutates `project.godot` `ProjectSettings`, which an e2e would dirty), and the writers have none either. The headless smoke already covers the real-`InputEvent`-API serialization that's unique to this read; the contract covers the envelope round-trip.

Part of #219 (P2). Remaining: **G8** audio-bus removers (destructive) — the final item, after which #219 closes complete.
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds read-only input action event detail

- Enables rollback for input map edits

- Expands input map toolset with new read primitive

- Updates documentation and tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_input_action_events"] -- "read-only" --> B["InputActionEvents"]
  C["cmd_get_input_action_events"] -- "delegates to" --> D["MCPInputActionRead"]
  E["MCPInputActionRead"] -- "serializes events" --> F["add_input_event shape"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>input_map.py</strong><dd><code>Add InputActionEvents model for event detail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-1047a4df7a5753dce284143fc107a69125c06ca34727664c605b0a7f46bfe0f6">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_map.py</strong><dd><code>Implement get_input_action_events tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-a8a7ee26afeb2b59bd098fcd465c62c09e8b2413388dfdd575ea678afa565436">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_map.gd</strong><dd><code>Register cmd_get_input_action_events handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-75a9cc4be204cd422fd179331492212e8f7c8026a09d812eeff9fe6008f73a92">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_action_read.gd</strong><dd><code>New pure event serialization lib</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-91040e5e05312f2956c03df1bfdeaaf3e8f5769f6764ac2a2956ae570aa825bf">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_input_map.py</strong><dd><code>Add contract test for new read tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-44dc8e1afc8dadfffaa2ab9ebf0364168138912a53e57d22c54ac2ae9bbdc524">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_action_read_smoke.gd</strong><dd><code>Headless smoke test for event reader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-fc4f041d8d004c2713f431635736e93e45e699340f4bf3d3508639b262fd719f">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update toolset documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/253/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

