### PR TITLE
feat(audio): add destructive audio bus removers for rollback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for **AI-driven Godot development**. An AI agent (Claude Code, OpenCode, Cursor, or any stdio MCP client) connects to a live Godot 4.4+ editor and controls it programmatically — inspecting scenes, editing nodes, writing scripts, running the game, and exporting builds — all through a typed, structured API with no built-in game vocabulary.
 
-> **Status:** feature-complete across the planned ecosystem. **137 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
+> **Status:** feature-complete across the planned ecosystem. **139 tools** across **23 gated toolsets** (plus always-on `core`). Every capability is documented, tested, and ready for agent use.
 
 ---
 
@@ -479,8 +479,8 @@ The full surface is 121 tools across 23 categories. Below is a summary; the auth
 ### Navigation (gated) — `mutating`
 - `setup_navigation_region`, `setup_navigation_agent`, `bake_navigation_mesh`, `set_navigation_layers`
 
-### Audio (gated) — `read_only` / `mutating`
-- `add_audio_player`, `get_audio_bus_layout`, `add_audio_bus`, `add_audio_bus_effect`
+### Audio (gated) — `read_only` / `mutating` / `destructive`
+- `add_audio_player`, `get_audio_bus_layout`, `add_audio_bus`, `add_audio_bus_effect`, `remove_audio_bus` (destructive), `remove_audio_bus_effect` (destructive)
 
 ### TileMap (gated) — `read_only` / `mutating`
 - `tilemap_set_cell`, `tilemap_fill_rect`, `tilemap_get_cell`, `tilemap_get_used_cells`, `tilemap_clear`, `tilemap_layers`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -495,8 +495,9 @@ turns `[1,3]` into the bitmask `5` on any node with a `navigation_layers` proper
 #### Audio (issue #44) — category: `audio` (gated off by default)
 
 Set up audio — stream players, the AudioServer bus layout, and bus effects.
-`get_audio_bus_layout` is `read_only`; the others are `mutating` (UndoRedo-wrapped),
-`dry_run`. The bus layout is **global** AudioServer/editor state (not per-scene).
+`get_audio_bus_layout` is `read_only`; the adders are `mutating` (UndoRedo-wrapped),
+`dry_run`; the removers are `destructive` (`confirm`, `dry_run`). The bus layout is
+**global** AudioServer/editor state (not per-scene).
 
 | Tool | Params | Returns |
 |------|--------|---------|
@@ -504,12 +505,16 @@ Set up audio — stream players, the AudioServer bus layout, and bus effects.
 | `get_audio_bus_layout` | — | `AudioBusLayoutResult { buses[] }` (read_only) |
 | `add_audio_bus` | `name, volume_db=0.0` | `AudioBusResult { index, name }` |
 | `add_audio_bus_effect` | `bus, effect_type, properties?` | `AudioBusEffectResult { bus, bus_index, effect_type, effect_index }` |
+| `remove_audio_bus` | `bus, confirm` | `AudioBusRemoveResult { name, index, removed }` (destructive) |
+| `remove_audio_bus_effect` | `bus, effect_index, confirm` | `AudioBusEffectRemoveResult { bus, bus_index, effect_index, removed }` (destructive) |
 
 `add_audio_player` creates an AudioStreamPlayer/2D/3D, optionally loading a `res://`
 AudioStream (`stream_path`) and applying `properties` (volume_db, bus, autoplay, …).
 `get_audio_bus_layout` returns each bus's index/name/volume_db, mute/solo/bypass, and
 its effect stack. `add_audio_bus` appends a uniquely-named bus; `add_audio_bus_effect`
-appends an AudioEffect (e.g. AudioEffectReverb) to the named bus.
+appends an AudioEffect (e.g. AudioEffectReverb) to the named bus. `remove_audio_bus`
+(the Master bus is never removable) and `remove_audio_bus_effect` are the inverses —
+both undoable (the bus/effect, with its state, is restored on undo).
 
 #### TileMap (issue #45) — category: `tilemap` (gated off by default)
 

--- a/godot/addons/godot_mcp/audio_bus_capture.gd
+++ b/godot/addons/godot_mcp/audio_bus_capture.gd
@@ -1,0 +1,44 @@
+@tool
+class_name MCPAudioBusCapture
+extends RefCounted
+## Capture / restore an AudioServer bus for undoable removal (issue #219 G8). Operates on
+## the live AudioServer (available headlessly) — no EditorInterface — so it is verifiable
+## in a headless smoke (see godot/tests/audio_bus_capture_smoke.gd). The remove handler
+## captures a bus before AudioServer.remove_bus and registers restore() as the UndoRedo
+## undo step, so undo rebuilds the bus with all its properties and effects.
+
+
+## Snapshot a bus's name/routing/flags and its full effect stack (effect objects + enabled
+## flags). The effects are kept as live AudioEffect references, not serialized — this dict
+## feeds restore(), it never crosses the bridge.
+static func capture(index: int) -> Dictionary:
+	var effects: Array = []
+	for e in AudioServer.get_bus_effect_count(index):
+		effects.append({
+			"effect": AudioServer.get_bus_effect(index, e),
+			"enabled": AudioServer.is_bus_effect_enabled(index, e),
+		})
+	return {
+		"name": String(AudioServer.get_bus_name(index)),
+		"volume_db": AudioServer.get_bus_volume_db(index),
+		"send": String(AudioServer.get_bus_send(index)),
+		"mute": AudioServer.is_bus_mute(index),
+		"solo": AudioServer.is_bus_solo(index),
+		"bypass": AudioServer.is_bus_bypassing_effects(index),
+		"effects": effects,
+	}
+
+
+## Re-create a captured bus at ``index`` with its properties and effect stack.
+static func restore(index: int, state: Dictionary) -> void:
+	AudioServer.add_bus(index)
+	AudioServer.set_bus_name(index, state["name"])
+	AudioServer.set_bus_volume_db(index, state["volume_db"])
+	AudioServer.set_bus_send(index, state["send"])
+	AudioServer.set_bus_mute(index, state["mute"])
+	AudioServer.set_bus_solo(index, state["solo"])
+	AudioServer.set_bus_bypass_effects(index, state["bypass"])
+	var effects: Array = state["effects"]
+	for i in effects.size():
+		AudioServer.add_bus_effect(index, effects[i]["effect"], i)
+		AudioServer.set_bus_effect_enabled(index, i, effects[i]["enabled"])

--- a/godot/addons/godot_mcp/handlers/audio.gd
+++ b/godot/addons/godot_mcp/handlers/audio.gd
@@ -6,6 +6,8 @@ extends RefCounted
 ## Registered by the router on _init().  Each handler receives params dict and
 ## returns a response body (without id) via the router's _ok / _fail builders.
 
+const AudioBusCapture := preload("res://addons/godot_mcp/audio_bus_capture.gd")
+
 var _router: MCPCommandRouter
 
 
@@ -18,6 +20,8 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_add_audio_bus_effect"] = _cmd_add_audio_bus_effect
 	handlers["cmd_add_audio_player"] = _cmd_add_audio_player
 	handlers["cmd_get_audio_bus_layout"] = _cmd_get_audio_bus_layout
+	handlers["cmd_remove_audio_bus"] = _cmd_remove_audio_bus
+	handlers["cmd_remove_audio_bus_effect"] = _cmd_remove_audio_bus_effect
 
 
 # -- handlers ----------------------------------------------------------------
@@ -117,6 +121,56 @@ func _cmd_add_audio_bus_effect(params: Dictionary) -> Dictionary:
 		"bus_index": bus_index,
 		"effect_type": effect_type,
 		"effect_index": effect_index,
+	})
+
+
+## Remove an audio bus — the inverse of add_audio_bus (issue #219 G8). The Master bus
+## (index 0) is never removable. Undo restores the bus with all properties + effects via
+## MCPAudioBusCapture; effect resources are kept alive with add_undo_reference.
+func _cmd_remove_audio_bus(params: Dictionary) -> Dictionary:
+	var bus_index := _resolve_bus_index(params.get("bus"))
+	if bus_index < 0:
+		return _router._fail("VALIDATION_ERROR", "No audio bus '%s'." % str(params.get("bus")))
+	if bus_index == 0:
+		return _router._fail("VALIDATION_ERROR", "Cannot remove the Master bus.")
+	var state := AudioBusCapture.capture(bus_index)
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Remove audio bus %s" % state["name"])
+	ur.add_do_method(AudioServer, "remove_bus", bus_index)
+	ur.add_undo_method(self, "_restore_audio_bus", bus_index, state)
+	for entry in state["effects"]:
+		ur.add_undo_reference(entry["effect"])
+	ur.commit_action()
+	return _router._ok({"name": state["name"], "index": bus_index, "removed": true})
+
+
+func _restore_audio_bus(index: int, state: Dictionary) -> void:
+	AudioBusCapture.restore(index, state)
+
+
+## Remove one effect from a bus — the inverse of add_audio_bus_effect (issue #219 G8).
+## Undo re-inserts the captured effect (and its enabled flag) at the same index.
+func _cmd_remove_audio_bus_effect(params: Dictionary) -> Dictionary:
+	var bus_index := _resolve_bus_index(params.get("bus"))
+	if bus_index < 0:
+		return _router._fail("VALIDATION_ERROR", "No audio bus '%s'." % str(params.get("bus")))
+	var effect_index := int(params.get("effect_index", -1))
+	if effect_index < 0 or effect_index >= AudioServer.get_bus_effect_count(bus_index):
+		return _router._fail("VALIDATION_ERROR", "No effect at index %d on bus '%s'." % [effect_index, String(AudioServer.get_bus_name(bus_index))])
+	var effect := AudioServer.get_bus_effect(bus_index, effect_index)
+	var enabled := AudioServer.is_bus_effect_enabled(bus_index, effect_index)
+	var ur := EditorInterface.get_editor_undo_redo()
+	ur.create_action("Remove effect %d from bus %d" % [effect_index, bus_index])
+	ur.add_do_method(AudioServer, "remove_bus_effect", bus_index, effect_index)
+	ur.add_undo_method(AudioServer, "add_bus_effect", bus_index, effect, effect_index)
+	ur.add_undo_method(AudioServer, "set_bus_effect_enabled", bus_index, effect_index, enabled)
+	ur.add_undo_reference(effect)
+	ur.commit_action()
+	return _router._ok({
+		"bus": String(AudioServer.get_bus_name(bus_index)),
+		"bus_index": bus_index,
+		"effect_index": effect_index,
+		"removed": true,
 	})
 
 

--- a/godot/tests/audio_bus_capture_smoke.gd
+++ b/godot/tests/audio_bus_capture_smoke.gd
@@ -1,0 +1,61 @@
+@tool
+extends SceneTree
+## Headless behavior test for MCPAudioBusCapture (issue #219 G8).
+##
+## Run via: godot --headless --path godot/ --script res://tests/audio_bus_capture_smoke.gd
+## Exercises capture → remove_bus → restore against the live AudioServer (available
+## headlessly) to prove a removed bus round-trips with its properties and effect stack —
+## which is exactly what the remove handler's UndoRedo undo step relies on.
+
+const AudioBusCapture := preload("res://addons/godot_mcp/audio_bus_capture.gd")
+
+
+func _initialize() -> void:
+	var failures: Array[String] = []
+
+	# Build a bus with a couple of properties + a (disabled) reverb effect.
+	var index := AudioServer.get_bus_count()
+	AudioServer.add_bus(index)
+	AudioServer.set_bus_name(index, "SFX")
+	AudioServer.set_bus_volume_db(index, -6.0)
+	AudioServer.set_bus_send(index, "Master")
+	AudioServer.set_bus_mute(index, true)
+	var reverb := AudioEffectReverb.new()
+	AudioServer.add_bus_effect(index, reverb, 0)
+	AudioServer.set_bus_effect_enabled(index, 0, false)
+
+	# Capture, then remove the bus.
+	var state := AudioBusCapture.capture(index)
+	_eq(failures, "captured.name", state.get("name"), "SFX")
+	_eq(failures, "captured.effects", (state.get("effects") as Array).size(), 1)
+	AudioServer.remove_bus(index)
+	if AudioServer.get_bus_index("SFX") != -1:
+		failures.append("bus 'SFX' still present after remove_bus")
+
+	# Restore at the same index and verify everything came back.
+	AudioBusCapture.restore(index, state)
+	var restored := AudioServer.get_bus_index("SFX")
+	if restored != index:
+		failures.append("restored bus index: expected %d, got %d" % [index, restored])
+	else:
+		_eq(failures, "restored.volume_db", AudioServer.get_bus_volume_db(restored), -6.0)
+		_eq(failures, "restored.send", String(AudioServer.get_bus_send(restored)), "Master")
+		_eq(failures, "restored.mute", AudioServer.is_bus_mute(restored), true)
+		_eq(failures, "restored.effect_count", AudioServer.get_bus_effect_count(restored), 1)
+		_eq(failures, "restored.effect_is_reverb", AudioServer.get_bus_effect(restored, 0) is AudioEffectReverb, true)
+		_eq(failures, "restored.effect_enabled", AudioServer.is_bus_effect_enabled(restored, 0), false)
+		AudioServer.remove_bus(restored)  # leave the layout clean
+
+	if failures.is_empty():
+		print("AUDIO_BUS_CAPTURE_TEST_OK")
+		quit(0)
+	else:
+		for f in failures:
+			printerr("FAIL: %s" % f)
+		print("AUDIO_BUS_CAPTURE_TEST_FAIL")
+		quit(1)
+
+
+func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
+	if got != want:
+		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/mcp_server/models/audio.py
+++ b/mcp_server/models/audio.py
@@ -44,3 +44,24 @@ class AudioBusEffectResult(BaseModel):
     effect_type: str
     effect_index: int
     dry_run: bool = False
+
+
+class AudioBusRemoveResult(BaseModel):
+    """Result of removing an audio bus (issue #219 G8) — the inverse of ``add_audio_bus``.
+    Removal is undoable in the editor (the bus + its effects are restored on undo)."""
+
+    name: str
+    index: int
+    removed: bool = False
+    dry_run: bool = False
+
+
+class AudioBusEffectRemoveResult(BaseModel):
+    """Result of removing one effect from an audio bus (issue #219 G8) — the inverse of
+    ``add_audio_bus_effect``. Undoable (the effect is re-inserted at its index on undo)."""
+
+    bus: str
+    bus_index: int
+    effect_index: int
+    removed: bool = False
+    dry_run: bool = False

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -129,7 +129,7 @@ def create_server(
     register_scene_3d(mcp, bridge)
     register_particles(mcp, bridge)
     register_navigation(mcp, bridge)
-    register_audio(mcp, bridge)
+    register_audio(mcp, bridge, approval)
     register_tilemap(mcp, bridge)
     register_theme_ui(mcp, bridge)
     register_shader(mcp, bridge)

--- a/mcp_server/tools/audio.py
+++ b/mcp_server/tools/audio.py
@@ -21,19 +21,31 @@ from mcp_server.defaults import (
     DEFAULT_AUDIO_PLAYER_TYPE,
 )
 from mcp_server.models.audio import (
+    AudioBusEffectRemoveResult,
     AudioBusEffectResult,
     AudioBusLayoutResult,
+    AudioBusRemoveResult,
     AudioBusResult,
     AudioPlayerResult,
 )
-from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_node_exists
+from mcp_server.safety import (
+    DESTRUCTIVE,
+    MUTATING,
+    READ_ONLY,
+    ApprovalGate,
+    enforce_preconditions,
+    require_bridge_connected,
+    require_confirmation,
+    require_node_exists,
+)
 from mcp_server.tools._route import route, run_or_preview
 
 AUDIO = {AUDIO_TAG}
 
 
-def register_audio(mcp: FastMCP, bridge: Bridge) -> None:
+def register_audio(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None) -> None:
     """Register the audio tools."""
+    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=AUDIO)
     @enforce_preconditions
@@ -102,4 +114,51 @@ def register_audio(mcp: FastMCP, bridge: Bridge) -> None:
         preview = {"bus": bus, "bus_index": -1, "effect_type": effect_type, "effect_index": -1}
         return await run_or_preview(
             dry_run, AudioBusEffectResult, preview, bridge, "cmd_add_audio_bus_effect", params
+        )
+
+    @mcp.tool(meta=DESTRUCTIVE, tags=AUDIO)
+    @enforce_preconditions
+    async def remove_audio_bus(
+        bus: str, confirm: bool = False, dry_run: bool = False
+    ) -> AudioBusRemoveResult:
+        """Remove the audio bus named ``bus`` from the AudioServer layout — the inverse of
+        ``add_audio_bus``. The Master bus cannot be removed. Destructive: requires
+        ``confirm=True``. Undoable in the editor (the bus and its effects are restored on
+        undo).
+        """
+        require_bridge_connected(bridge)
+        if not dry_run:
+            require_confirmation(confirm, "remove_audio_bus")
+            await approval.require("remove_audio_bus", "destructive", {"bus": bus})
+        params = {"bus": bus, "confirm": True}
+        preview = {"name": bus, "index": -1, "removed": False}
+        return await run_or_preview(
+            dry_run, AudioBusRemoveResult, preview, bridge, "cmd_remove_audio_bus", params
+        )
+
+    @mcp.tool(meta=DESTRUCTIVE, tags=AUDIO)
+    @enforce_preconditions
+    async def remove_audio_bus_effect(
+        bus: str, effect_index: int, confirm: bool = False, dry_run: bool = False
+    ) -> AudioBusEffectRemoveResult:
+        """Remove the effect at ``effect_index`` from the bus named ``bus`` — the inverse
+        of ``add_audio_bus_effect`` (use ``get_audio_bus_layout`` to find the index).
+        Destructive: requires ``confirm=True``. Undoable in the editor (the effect is
+        re-inserted at its index on undo).
+        """
+        require_bridge_connected(bridge)
+        if not dry_run:
+            require_confirmation(confirm, "remove_audio_bus_effect")
+            await approval.require(
+                "remove_audio_bus_effect", "destructive", {"bus": bus, "effect_index": effect_index}
+            )
+        params = {"bus": bus, "effect_index": effect_index, "confirm": True}
+        preview = {"bus": bus, "bus_index": -1, "effect_index": effect_index, "removed": False}
+        return await run_or_preview(
+            dry_run,
+            AudioBusEffectRemoveResult,
+            preview,
+            bridge,
+            "cmd_remove_audio_bus_effect",
+            params,
         )

--- a/tests/contract/test_audio.py
+++ b/tests/contract/test_audio.py
@@ -54,6 +54,12 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "effect_index": 0,
                 },
             )
+        case "cmd_remove_audio_bus":
+            return ResponseEnvelope.success(cmd.id, {"name": "SFX", "index": 1, "removed": True})
+        case "cmd_remove_audio_bus_effect":
+            return ResponseEnvelope.success(
+                cmd.id, {"bus": "SFX", "bus_index": 1, "effect_index": 0, "removed": True}
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -120,3 +126,57 @@ async def test_dry_run_sends_no_mutation() -> None:
         result = await client.call_tool("add_audio_bus", {"name": "SFX", "dry_run": True})
     assert result.structured_content["dry_run"] is True
     assert "cmd_add_audio_bus" not in _commands(conn)
+
+
+async def test_audio_bus_removers_are_destructive() -> None:
+    # #219 G8: the removers are destructive (confirm-gated), the inverse of the adders.
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "audio"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert tools["remove_audio_bus"].meta["safety_class"] == "destructive"
+    assert tools["remove_audio_bus_effect"].meta["safety_class"] == "destructive"
+
+
+async def test_remove_audio_bus_requires_confirm() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "audio"})
+        blocked = await client.call_tool(
+            "remove_audio_bus", {"bus": "SFX"}, raise_on_error=False
+        )
+        assert blocked.is_error and "confirm" in str(blocked.content)
+        assert "cmd_remove_audio_bus" not in _commands(conn)
+        ok = await client.call_tool("remove_audio_bus", {"bus": "SFX", "confirm": True})
+    assert ok.structured_content["removed"] is True
+    assert ok.structured_content["index"] == 1
+    assert "cmd_remove_audio_bus" in _commands(conn)
+
+
+async def test_remove_audio_bus_dry_run_sends_no_command() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "audio"})
+        result = await client.call_tool(
+            "remove_audio_bus", {"bus": "SFX", "dry_run": True}
+        )
+    assert result.structured_content["dry_run"] is True
+    assert result.structured_content["removed"] is False
+    assert "cmd_remove_audio_bus" not in _commands(conn)
+
+
+async def test_remove_audio_bus_effect_requires_confirm() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("enable_toolset", {"category": "audio"})
+        blocked = await client.call_tool(
+            "remove_audio_bus_effect", {"bus": "SFX", "effect_index": 0}, raise_on_error=False
+        )
+        assert blocked.is_error and "confirm" in str(blocked.content)
+        assert "cmd_remove_audio_bus_effect" not in _commands(conn)
+        ok = await client.call_tool(
+            "remove_audio_bus_effect", {"bus": "SFX", "effect_index": 0, "confirm": True}
+        )
+    assert ok.structured_content["removed"] is True
+    assert ok.structured_content["effect_index"] == 0
+    assert "cmd_remove_audio_bus_effect" in _commands(conn)

--- a/tests/integration/test_audio_e2e.py
+++ b/tests/integration/test_audio_e2e.py
@@ -87,6 +87,31 @@ async def _run() -> None:
         assert abs(music["volume_db"] - (-3.0)) < 0.01
         assert any(e["type"] == "AudioEffectReverb" for e in music["effects"])
 
+        # G8 (#219): remove the effect, then the bus — confirm each via the layout.
+        removed_effect = await _ok(
+            bridge,
+            "cmd_remove_audio_bus_effect",
+            {"bus": "Music", "effect_index": 0, "confirm": True},
+        )
+        assert removed_effect["removed"] is True and removed_effect["effect_index"] == 0
+        layout2 = await _ok(bridge, "cmd_get_audio_bus_layout", {})
+        music2 = next(b for b in layout2["buses"] if b["name"] == "Music")
+        assert not any(e["type"] == "AudioEffectReverb" for e in music2["effects"])
+
+        removed_bus = await _ok(bridge, "cmd_remove_audio_bus", {"bus": "Music", "confirm": True})
+        assert removed_bus["removed"] is True and removed_bus["name"] == "Music"
+        layout3 = await _ok(bridge, "cmd_get_audio_bus_layout", {})
+        assert not any(b["name"] == "Music" for b in layout3["buses"])
+
+        # the Master bus is never removable; a bad effect index is rejected
+        master = await bridge.send("cmd_remove_audio_bus", {"bus": "Master", "confirm": True})
+        assert master.ok is False and master.error == "VALIDATION_ERROR"
+        bad_idx = await bridge.send(
+            "cmd_remove_audio_bus_effect",
+            {"bus": "Master", "effect_index": 99, "confirm": True},
+        )
+        assert bad_idx.ok is False and bad_idx.error == "VALIDATION_ERROR"
+
         # validation: bad player type, duplicate bus, unknown bus, bad effect type, bad stream
         bad_player = await bridge.send(
             "cmd_add_audio_player", {"parent_path": ".", "player_type": "Node2D"}


### PR DESCRIPTION
### **User description**
## Summary
`add_audio_bus` / `add_audio_bus_effect` had no removers, so neither could be undone in a rollback (**final** enabler **G8** of the #219 umbrella, found by audit #212).

Adds two `destructive` `[Both]` tools:
- **`remove_audio_bus(bus, confirm)`** → `AudioBusRemoveResult { name, index, removed }` — inverse of `add_audio_bus`. The **Master** bus is never removable.
- **`remove_audio_bus_effect(bus, effect_index, confirm)`** → `AudioBusEffectRemoveResult { bus, bus_index, effect_index, removed }` — inverse of `add_audio_bus_effect`.

Both are `confirm`-gated + run through the `ApprovalGate` (threaded into `register_audio`) + `dry_run`, and are **undoable** in the editor:
- `_cmd_remove_audio_bus` captures the bus's full state (name / volume / send / mute / solo / bypass + effect stack) via a new **`MCPAudioBusCapture`** lib and restores it on undo.
- `_cmd_remove_audio_bus_effect` re-inserts the captured effect at its index. Effect resources are kept alive with `add_undo_reference`.

### API note
The bypass setter is `AudioServer.set_bus_bypass_effects` (only the *getter* is `is_bus_bypassing_effects`) — a wrong guess was caught by the `--check-only` parse against Godot 4.7.

## Acceptance criteria (#219 G8)
- [x] `remove_audio_bus` / `remove_audio_bus_effect` (destructive) — invert `add_audio_bus` / `add_audio_bus_effect`

## Test plan
- **Contract** (`tests/contract/test_audio.py`): both are `destructive`; confirm-gating (blocked without `confirm`, routes with it); `dry_run` sends nothing.
- **Addon (headless)**: `audio_bus_capture_smoke.gd` does capture → `remove_bus` → restore against the **real AudioServer** and verifies the bus + its (disabled) effect come back → `AUDIO_BUS_CAPTURE_TEST_OK`. Both addon scripts pass `--check-only`.
- **E2E** (`tests/integration/test_audio_e2e.py`): remove the effect, then the bus, verifying each via `get_audio_bus_layout`; the Master bus is rejected and a bad effect index errors (CI).
- Preflight: CI-parity `ruff` clean, `mypy` clean, 496 unit+contract pass, zero-skip clean. Docs + README (139 tools).

**This is the final #219 item** — G5/P3/P4/G7/G6/P2 are merged. Once this lands, #219 is complete and I'll close the umbrella.
🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds destructive audio bus removers for rollback support

- Introduces confirm-gated removal tools with undo capability

- Updates tool contracts and documentation to reflect new destructive tools

- Enhances test coverage for the new audio removal functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["remove_audio_bus"] -- "destructive" --> B["AudioServer.remove_bus"]
  C["remove_audio_bus_effect"] -- "destructive" --> D["AudioServer.remove_bus_effect"]
  B -- "undoable" --> E["MCPAudioBusCapture.restore"]
  D -- "undoable" --> F["AudioServer.add_bus_effect"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>audio.py</strong><dd><code>Add result models for audio bus removals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-0058cd974ebe3736399c27c92e3be652e45f81190e469ead7e20129848178ce1">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio.py</strong><dd><code>Implement destructive audio bus removal tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-1bbcb366f3184e0a474218a898292882fc26eb076559215d797db8f00f25f4f3">+61/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio_bus_capture.gd</strong><dd><code>Implement undoable audio bus capture/restore logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-f9b684b7ae70d1889e078e78437e2f4981a1c45473eba1eb6ce086258937bd59">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio.gd</strong><dd><code>Add command handlers for audio bus removals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-5728f1e1ee6781c1a4b302aa291887f9b4bd7f3c2df900dc9d20779a964473b8">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server.py</strong><dd><code>Pass approval gate to audio registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-f24be50e829d65c1c3626dad15c1b306dd882fc305e41024df58c9a7649f07b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_audio.py</strong><dd><code>Add contract tests for audio removers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-f383bfe7953949be93a283f2ff93566ac3b1f228b161235af8a7488ee8d16ee0">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_audio_e2e.py</strong><dd><code>Add end-to-end tests for audio bus removals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-a0399e0a9330a6c0ac398d83a4c05548c647ebf50ed59647bd9830732b4597f5">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio_bus_capture_smoke.gd</strong><dd><code>Add headless smoke test for audio bus capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-5d36d9c45b39031cc6d396ecf6f06eaa5985d629e2c68e85ba6288abda2b28f3">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update tool count and audio category description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document new destructive audio tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/254/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

