### PR TITLE
feat(prompts): teach the dry_run/confirm safety convention in server instructions (#257)

### DIFF
--- a/mcp_server/toolset_protocol.py
+++ b/mcp_server/toolset_protocol.py
@@ -73,6 +73,15 @@ SERVER_VS_ADDON = (
     "godot_enable_toolset first."
 )
 
+SAFETY_CONVENTION = (
+    "SAFETY CONVENTION (every mutating tool):\n"
+    "- Mutating tools accept dry_run=True — they report what WOULD change and perform "
+    "nothing. Preview first when unsure.\n"
+    "- Destructive tools (delete/overwrite, e.g. delete_node, reload_scene) require "
+    "confirm=True or they refuse to run; they also support dry_run.\n"
+    "- Read-only tools never mutate and need neither flag."
+)
+
 # The full gating protocol, shared verbatim by the server instructions and the
 # toolset_discovery prompt. Edit the parts above; both surfaces stay in sync.
 TOOLSET_PROTOCOL = "\n\n".join(
@@ -84,6 +93,8 @@ TOOLSET_PROTOCOL = "\n\n".join(
 SERVER_INSTRUCTIONS = (
     "WARNING: You MUST follow the steps below or EVERY tool call will fail.\n\n"
     + TOOLSET_PROTOCOL
+    + "\n\n"
+    + SAFETY_CONVENTION
     + "\n\nDOCUMENTATION:\n"
     + DOC_LINKS
     + "\n\nThis server also exposes workflow prompts (toolset_discovery, build_scene, "

--- a/tests/contract/test_instructions_contract.py
+++ b/tests/contract/test_instructions_contract.py
@@ -1,0 +1,39 @@
+"""Contract test for the server-level MCP instructions.
+
+The ``instructions`` string is returned in the MCP ``initialize`` handshake and
+is the only guidance most clients surface to the model automatically (without a
+user invoking a prompt). It must teach the must-know conventions so the model
+behaves correctly with no human in the loop:
+
+- toolset gating (enable a toolset before using its tools), and
+- the safety convention (mutations accept ``dry_run``; destructive tools require
+  ``confirm``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mcp_server.server import create_server
+
+
+@pytest.fixture
+def instructions() -> str:
+    """The server's top-level MCP instructions string."""
+    server: Any = create_server()
+    text: str = str(server.instructions)
+    assert text, "server must set non-empty instructions"
+    return text
+
+
+def test_instructions_cover_toolset_gating(instructions: str) -> None:
+    """The gating protocol is the first thing a model must know."""
+    assert "enable_toolset" in instructions
+
+
+def test_instructions_cover_safety_convention(instructions: str) -> None:
+    """Mutations preview with dry_run; destructive ops require confirm."""
+    assert "dry_run" in instructions
+    assert "confirm" in instructions


### PR DESCRIPTION
Part of #257 (item 1 of 3). Items 2 (extend prompts) and 3 (Claude skills) follow in their own PRs.

## Change

`SERVER_INSTRUCTIONS` (the text most MCP clients auto-surface to the model on `initialize`) already taught toolset gating, the decision tree, and the server/addon boundary, but not the `dry_run`/`confirm` safety convention — so the model learned it only by failing a call or by a user invoking a prompt. Added a `SAFETY_CONVENTION` section to `mcp_server/toolset_protocol.py` and wove it into `SERVER_INSTRUCTIONS`.

## Test plan

- New contract test `tests/contract/test_instructions_contract.py` (red→green): asserts the instructions cover both gating (`enable_toolset`) and the safety convention (`dry_run`, `confirm`).
- Preflight: `pytest` (contract + prompts) green · `ruff` clean · `mypy` clean (221 files) · zero-skip gate clean.
- Qodo review: score 90, no security concerns, no major issues, no inline findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)