### PR TITLE
Add author_resource, export_build, and batch_refactor prompts

### DIFF
--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -29,6 +29,9 @@ def register_prompts(mcp: FastMCP) -> list[str]:
         _register_script_edit(mcp),
         _register_debug_scene(mcp),
         _register_troubleshoot(mcp),
+        _register_author_resource(mcp),
+        _register_export_build(mcp),
+        _register_batch_refactor(mcp),
     ]
 
 
@@ -377,3 +380,197 @@ def _register_troubleshoot(mcp: FastMCP) -> str:
         ]
 
     return "troubleshoot"
+
+
+# Per-kind authoring recipes for the author_resource prompt. Each names the toolset
+# to enable and the tool sequence; ``{save_path}`` is filled per call. Keep the tool
+# names in sync with the exposed godot_<toolset>_<action> surface.
+_AUTHOR_RESOURCE_RECIPES = {
+    "tileset": (
+        "Author a TileSet (the resource that makes cells placeable on a TileMapLayer):\n\n"
+        "Step 1 — Enable the toolset:\n"
+        "  godot_enable_toolset('tilemap')\n\n"
+        "Step 2 — Create the TileSet (save it and/or assign to a node):\n"
+        "  godot_tilemap_create_tileset(save_path='{save_path}', tile_size=[16, 16])\n"
+        "  (or node_path='./TileMapLayer' to assign it in-scene)\n\n"
+        "Step 3 — Add an atlas source from an imported texture:\n"
+        "  godot_tilemap_add_tileset_atlas_source(\n"
+        "      tileset_path='{save_path}',\n"
+        "      texture_path='res://art/tiles.png', region_size=[16, 16])\n"
+        "  → returns source_id\n\n"
+        "Step 4 — Create the individual tiles you want to place:\n"
+        "  godot_tilemap_create_tile(\n"
+        "      tileset_path='{save_path}', source_id=<id>, atlas_coords=[0, 0])\n\n"
+        "Step 5 — Place tiles (needs a TileMapLayer in the open scene):\n"
+        "  godot_tilemap_set_cell(node_path='./TileMapLayer', coords=[0, 0],\n"
+        "      source_id=<id>, atlas_coords=[0, 0])"
+    ),
+    "meshlibrary": (
+        "Author a MeshLibrary (the resource a GridMap places cells from):\n\n"
+        "Step 1 — Enable the toolset:\n"
+        "  godot_enable_toolset('scene_3d')\n\n"
+        "Step 2 — Create the MeshLibrary:\n"
+        "  godot_scene_3d_create_mesh_library(save_path='{save_path}')\n\n"
+        "Step 3 — Add an item per mesh (from an imported mesh/scene):\n"
+        "  godot_scene_3d_add_mesh_library_item(\n"
+        "      library_path='{save_path}', mesh_path='res://art/wall.obj')\n"
+        "  → returns the item id\n\n"
+        "Step 4 — Place cells (needs a GridMap in the open scene):\n"
+        "  godot_scene_3d_gridmap_set_cell(\n"
+        "      node_path='./GridMap', cell=[0, 0, 0], item=<id>)"
+    ),
+    "theme": (
+        "Author a Theme (shared styling for Control nodes):\n\n"
+        "Step 1 — Enable the toolset:\n"
+        "  godot_enable_toolset('theme_ui')\n\n"
+        "Step 2 — Create the Theme (assign to a Control; save to share it):\n"
+        "  godot_theme_ui_create(node_path='./UI', save_path='{save_path}')\n\n"
+        "Step 3 — Set styling on nodes that use it:\n"
+        "  godot_theme_ui_set_color(node_path='./UI/Label', name='font_color', "
+        "color='#ffffff')\n"
+        "  godot_theme_ui_set_font_size(node_path='./UI/Label', name='font_size', size=24)\n"
+        "  godot_theme_ui_set_stylebox(node_path='./UI/Panel', name='panel', ...)"
+    ),
+    "shader": (
+        "Author a Shader and apply it to a node:\n\n"
+        "Step 1 — Enable the toolset:\n"
+        "  godot_enable_toolset('shader')\n\n"
+        "Step 2 — Create the .gdshader file:\n"
+        "  godot_shader_create(shader_path='res://shaders/effect.gdshader', code='...')\n\n"
+        "Step 3 — Wrap it in a ShaderMaterial and assign it:\n"
+        "  godot_shader_assign_material(node_path='./Sprite2D',\n"
+        "      shader_path='res://shaders/effect.gdshader')\n\n"
+        "Step 4 — Tune uniforms:\n"
+        "  godot_shader_set_param(node_path='./Sprite2D', name='intensity', value=0.5)"
+    ),
+    "custom": (
+        "Author a custom/built-in Resource (.tres) directly:\n\n"
+        "Step 1 — Enable the toolset:\n"
+        "  godot_enable_toolset('resources_edit')\n\n"
+        "Step 2 — Create the resource of the type you need:\n"
+        "  godot_resources_edit_create_resource(\n"
+        "      type='CurveTexture', resource_path='{save_path}', properties={{}})\n\n"
+        "Step 3 — Edit individual properties later:\n"
+        "  godot_resources_edit_set_resource_property(\n"
+        "      resource_path='{save_path}', property='width', value=256)"
+    ),
+}
+
+
+def _register_author_resource(mcp: FastMCP) -> str:
+    kinds = ", ".join(sorted(_AUTHOR_RESOURCE_RECIPES))
+
+    @mcp.prompt(
+        name="author_resource",
+        description=(
+            "Step-by-step workflow for authoring a Godot resource and the tools to use. "
+            f"Set resource_kind to one of: {kinds}. Covers TileSet, MeshLibrary, Theme, "
+            "Shader, and custom .tres resources."
+        ),
+    )
+    def author_resource(
+        resource_kind: str = "tileset",
+        save_path: str = "res://resources/new_resource.tres",
+    ) -> list[Message]:
+        """Instruct the agent how to author a resource of the requested kind."""
+        recipe = _AUTHOR_RESOURCE_RECIPES.get(resource_kind.lower().strip())
+        if recipe is None:
+            body = (
+                f"Unknown resource_kind '{resource_kind}'. Choose one of: {kinds}.\n"
+                "Re-invoke author_resource with a supported resource_kind."
+            )
+        else:
+            body = recipe.format(save_path=save_path) + (
+                "\n\nSAFETY REMINDER:\n"
+                "- Every step above is a mutating tool; add dry_run=True to preview first.\n"
+                "- Verify with godot_inspection tools (e.g. read the saved .tres) when done."
+            )
+        return [Message(role="user", content=body)]
+
+    return "author_resource"
+
+
+def _register_export_build(mcp: FastMCP) -> str:
+    @mcp.prompt(
+        name="export_build",
+        description=(
+            "Workflow for exporting a project build for a target platform using the "
+            "export toolset: discover presets, check templates, export, verify."
+        ),
+    )
+    def export_build(
+        preset: str = "",
+        output_path: str = "res://build/game",
+    ) -> list[Message]:
+        """Instruct the agent how to export a build for a platform preset."""
+        target = preset or "<your preset, e.g. 'Windows Desktop' / 'Linux/X11' / 'Web'>"
+        return [
+            Message(
+                role="user",
+                content=(
+                    f"Export a build to '{output_path}' using preset: {target}\n\n"
+                    "Step 1 — Enable the toolset:\n"
+                    "  godot_enable_toolset('export')\n\n"
+                    "Step 2 — Discover the presets defined in export_presets.cfg:\n"
+                    "  godot_export_list_presets()\n"
+                    "  → Match the preset name exactly (it is case-sensitive).\n\n"
+                    "Step 3 — Confirm export templates are installed for the target:\n"
+                    "  godot_export_get_info()\n"
+                    "  → If templates are missing, install them in Godot "
+                    "(Editor → Manage Export Templates) before exporting.\n\n"
+                    "Step 4 — Export (runs Godot headless; can be slow):\n"
+                    f"  godot_export_project(preset='{target}', output_path='{output_path}',\n"
+                    "      debug=False, timeout_seconds=300)\n\n"
+                    "Step 5 — Verify the result:\n"
+                    "  → Check exit_code == 0 and that 'errors' is empty.\n"
+                    "  → A non-zero code with no errors usually means a missing template "
+                    "or a bad preset name (re-check Step 2/3)."
+                ),
+            ),
+        ]
+
+    return "export_build"
+
+
+def _register_batch_refactor(mcp: FastMCP) -> str:
+    @mcp.prompt(
+        name="batch_refactor",
+        description=(
+            "Workflow for changing a property across many nodes safely with the batch "
+            "toolset: find targets, preview with dry_run, apply, verify."
+        ),
+    )
+    def batch_refactor(
+        node_type: str = "Node",
+        property: str = "",
+        value: str = "",
+    ) -> list[Message]:
+        """Instruct the agent how to apply a property change across many nodes."""
+        prop = property or "<property, e.g. 'modulate'>"
+        val = value or "<value, JSON-shaped for the target Godot type>"
+        return [
+            Message(
+                role="user",
+                content=(
+                    f"Set '{prop}' = {val} on every {node_type} in scope, safely.\n\n"
+                    "Step 1 — Enable the toolset (add scene_edit if you also create/move "
+                    "nodes):\n"
+                    "  godot_enable_toolset('batch')\n\n"
+                    "Step 2 — Find the targets first, so you know the blast radius:\n"
+                    f"  godot_batch_find_nodes_by_type(node_type='{node_type}')\n\n"
+                    "Step 3 — PREVIEW with dry_run before changing anything:\n"
+                    f"  godot_batch_set_property(property='{prop}', value={val},\n"
+                    f"      node_type='{node_type}', dry_run=True)\n"
+                    "  → Review 'applied' and 'skipped' (nodes lacking the property).\n\n"
+                    "Step 4 — Apply once the plan looks right (one undoable action):\n"
+                    f"  godot_batch_set_property(property='{prop}', value={val},\n"
+                    f"      node_type='{node_type}')\n\n"
+                    "Step 5 — For a project-wide change across scene files, use:\n"
+                    "  godot_batch_cross_scene_set_property(...)  (also supports dry_run)\n\n"
+                    "VALUE SHAPES: Vector2/3 as {'x':1,'y':2} or [1,2]; Color as "
+                    "{'r':1,'g':0,'b':0,'a':1} or '#ff0000'; primitives as-is."
+                ),
+            ),
+        ]
+
+    return "batch_refactor"

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -15,6 +15,33 @@ from fastmcp.prompts import Message
 from mcp_server.toolset_protocol import TOOLSET_PROTOCOL
 
 
+def _as_arg(text: str) -> str:
+    """Render a string as a valid quoted literal for a tool-call example.
+
+    ``repr`` picks safe quoting (switching to double quotes when the value
+    contains a single quote), so interpolated user values never break the
+    example syntax we teach the model.
+    """
+    return repr(text)
+
+
+def _as_value(value: str) -> str:
+    """Render a batch ``value`` as it should appear in a call.
+
+    JSON-shaped values (objects, arrays, numbers, booleans, null) render as-is;
+    anything else is treated as a string literal and quoted — so a color like
+    ``#ff0000`` becomes ``'#ff0000'`` rather than the invalid bare ``#ff0000``.
+    """
+    v = value.strip()
+    if v[:1] in "{[" or v.lower() in {"true", "false", "null"}:
+        return v
+    try:
+        float(v)
+    except ValueError:
+        return _as_arg(v)
+    return v
+
+
 def register_prompts(mcp: FastMCP) -> list[str]:
     """Register all workflow prompts on the server.
 
@@ -432,14 +459,14 @@ _AUTHOR_RESOURCE_RECIPES = {
         "  godot_theme_ui_set_stylebox(node_path='./UI/Panel', name='panel', ...)"
     ),
     "shader": (
-        "Author a Shader and apply it to a node:\n\n"
+        "Author a Shader and apply it to a node (use a .gdshader save_path):\n\n"
         "Step 1 — Enable the toolset:\n"
         "  godot_enable_toolset('shader')\n\n"
         "Step 2 — Create the .gdshader file:\n"
-        "  godot_shader_create(shader_path='res://shaders/effect.gdshader', code='...')\n\n"
+        "  godot_shader_create(shader_path='{save_path}', code='...')\n\n"
         "Step 3 — Wrap it in a ShaderMaterial and assign it:\n"
         "  godot_shader_assign_material(node_path='./Sprite2D',\n"
-        "      shader_path='res://shaders/effect.gdshader')\n\n"
+        "      shader_path='{save_path}')\n\n"
         "Step 4 — Tune uniforms:\n"
         "  godot_shader_set_param(node_path='./Sprite2D', name='intensity', value=0.5)"
     ),
@@ -519,7 +546,8 @@ def _register_export_build(mcp: FastMCP) -> str:
                     "  → If templates are missing, install them in Godot "
                     "(Editor → Manage Export Templates) before exporting.\n\n"
                     "Step 4 — Export (runs Godot headless; can be slow):\n"
-                    f"  godot_export_project(preset='{target}', output_path='{output_path}',\n"
+                    f"  godot_export_project(preset={_as_arg(target)}, "
+                    f"output_path={_as_arg(output_path)},\n"
                     "      debug=False, timeout_seconds=300)\n\n"
                     "Step 5 — Verify the result:\n"
                     "  → Check exit_code == 0 and that 'errors' is empty.\n"
@@ -546,25 +574,25 @@ def _register_batch_refactor(mcp: FastMCP) -> str:
         value: str = "",
     ) -> list[Message]:
         """Instruct the agent how to apply a property change across many nodes."""
-        prop = property or "<property, e.g. 'modulate'>"
-        val = value or "<value, JSON-shaped for the target Godot type>"
+        prop = property or "modulate"
+        val = _as_value(value) if value.strip() else "<value, JSON-shaped for the type>"
         return [
             Message(
                 role="user",
                 content=(
-                    f"Set '{prop}' = {val} on every {node_type} in scope, safely.\n\n"
+                    f"Set {_as_arg(prop)} = {val} on every {node_type} in scope, safely.\n\n"
                     "Step 1 — Enable the toolset (add scene_edit if you also create/move "
                     "nodes):\n"
                     "  godot_enable_toolset('batch')\n\n"
                     "Step 2 — Find the targets first, so you know the blast radius:\n"
-                    f"  godot_batch_find_nodes_by_type(node_type='{node_type}')\n\n"
+                    f"  godot_batch_find_nodes_by_type(node_type={_as_arg(node_type)})\n\n"
                     "Step 3 — PREVIEW with dry_run before changing anything:\n"
-                    f"  godot_batch_set_property(property='{prop}', value={val},\n"
-                    f"      node_type='{node_type}', dry_run=True)\n"
+                    f"  godot_batch_set_property(property={_as_arg(prop)}, value={val},\n"
+                    f"      node_type={_as_arg(node_type)}, dry_run=True)\n"
                     "  → Review 'applied' and 'skipped' (nodes lacking the property).\n\n"
                     "Step 4 — Apply once the plan looks right (one undoable action):\n"
-                    f"  godot_batch_set_property(property='{prop}', value={val},\n"
-                    f"      node_type='{node_type}')\n\n"
+                    f"  godot_batch_set_property(property={_as_arg(prop)}, value={val},\n"
+                    f"      node_type={_as_arg(node_type)})\n\n"
                     "Step 5 — For a project-wide change across scene files, use:\n"
                     "  godot_batch_cross_scene_set_property(...)  (also supports dry_run)\n\n"
                     "VALUE SHAPES: Vector2/3 as {'x':1,'y':2} or [1,2]; Color as "

--- a/tests/contract/test_prompts_contract.py
+++ b/tests/contract/test_prompts_contract.py
@@ -40,6 +40,9 @@ def test_prompts_are_registered(server: Any) -> None:
         "play_test",
         "script_edit",
         "troubleshoot",
+        "author_resource",
+        "export_build",
+        "batch_refactor",
     }
     names = asyncio.run(_get_prompt_names(server))
     assert expected <= names, f"Missing prompts: {expected - names}"
@@ -99,6 +102,63 @@ def test_script_edit_prompt_parameterized(server: Any) -> None:
     assert "./Hero" in content
     assert "godot_scripts_write" in content
     assert "godot_scripts_patch" in content
+
+
+def test_author_resource_prompt_parameterized(server: Any) -> None:
+    """author_resource branches on resource_kind and cites the right toolset/tools."""
+    tileset = asyncio.run(
+        _render_prompt(
+            server,
+            "author_resource",
+            {"resource_kind": "tileset", "save_path": "res://tiles/ground.tres"},
+        )
+    )
+    content = " ".join(str(m.content) for m in tileset.messages)
+    assert "res://tiles/ground.tres" in content
+    assert "godot_enable_toolset('tilemap')" in content
+    assert "godot_tilemap_create_tileset" in content
+    assert "godot_tilemap_add_tileset_atlas_source" in content
+
+    # A different kind routes to a different toolset.
+    shader = asyncio.run(_render_prompt(server, "author_resource", {"resource_kind": "shader"}))
+    shader_content = " ".join(str(m.content) for m in shader.messages)
+    assert "godot_enable_toolset('shader')" in shader_content
+    assert "godot_shader_create" in shader_content
+
+
+def test_export_build_prompt_parameterized(server: Any) -> None:
+    """export_build accepts preset/output_path and walks the export toolset."""
+    result = asyncio.run(
+        _render_prompt(
+            server,
+            "export_build",
+            {"preset": "Windows Desktop", "output_path": "res://build/game.exe"},
+        )
+    )
+    content = " ".join(str(m.content) for m in result.messages)
+    assert "Windows Desktop" in content
+    assert "res://build/game.exe" in content
+    assert "godot_enable_toolset('export')" in content
+    assert "godot_export_list_presets" in content
+    assert "godot_export_project" in content
+
+
+def test_batch_refactor_prompt_parameterized(server: Any) -> None:
+    """batch_refactor previews with dry_run before applying across many nodes."""
+    result = asyncio.run(
+        _render_prompt(
+            server,
+            "batch_refactor",
+            {"node_type": "Sprite2D", "property": "modulate", "value": "#ff0000"},
+        )
+    )
+    content = " ".join(str(m.content) for m in result.messages)
+    assert "Sprite2D" in content
+    assert "modulate" in content
+    assert "godot_enable_toolset('batch')" in content
+    assert "godot_batch_find_nodes_by_type" in content
+    assert "godot_batch_set_property" in content
+    assert "dry_run=True" in content
 
 
 def test_troubleshoot_prompt_returns_messages(server: Any) -> None:

--- a/tests/contract/test_prompts_contract.py
+++ b/tests/contract/test_prompts_contract.py
@@ -126,6 +126,19 @@ def test_author_resource_prompt_parameterized(server: Any) -> None:
     assert "godot_shader_create" in shader_content
 
 
+def test_author_resource_unknown_kind_lists_supported(server: Any) -> None:
+    """An unsupported resource_kind returns guidance naming the supported kinds."""
+    result = asyncio.run(
+        _render_prompt(server, "author_resource", {"resource_kind": "nonsense"})
+    )
+    content = " ".join(str(m.content) for m in result.messages)
+    assert "nonsense" in content
+    # It should steer the model to a valid kind, not a tool-call recipe.
+    for kind in ("tileset", "meshlibrary", "theme", "shader", "custom"):
+        assert kind in content
+    assert "godot_tilemap_create_tileset" not in content
+
+
 def test_export_build_prompt_parameterized(server: Any) -> None:
     """export_build accepts preset/output_path and walks the export toolset."""
     result = asyncio.run(


### PR DESCRIPTION
### **User description**
Part of #257 (item 2 of 3). Extends the user-facing MCP prompt library to cover the workflow gaps Qodo and the plan named. Prompts are user-initiated slash commands (e.g. `/mcp__godot-mcp__export_build`) — step-numbered recipes that route to the right gated toolset and the real exposed `godot_<toolset>_<action>` tools. They instruct; they don't act.

## New prompts

- **`author_resource`** — parameterized by `resource_kind` (`tileset`, `meshlibrary`, `theme`, `shader`, `custom`). One prompt, per-kind recipe (keeps the surface small per the "fewer, richer" principle). TileSet → atlas → tile → place; MeshLibrary under `scene_3d`; Theme/Shader/custom `.tres` each routed to their toolset.
- **`export_build`** — `preset` / `output_path`: discover presets → check templates → `godot_export_project` → verify exit code, with the common "missing template / wrong preset name" failure called out.
- **`batch_refactor`** — `node_type` / `property` / `value`: find targets → **preview with `dry_run=True`** → apply (one undoable action) → cross-scene variant for project-wide changes, plus value-shape hints.

Tool names were taken from the live exposed registry (not invented); `install_tool_naming` renames functions, so I dumped the real `godot_*` names and cited those.

## Test plan

- `tests/contract/test_prompts_contract.py` (red→green): new prompts appear in the registry; each renders with its key toolset/tool references and parameter substitution.
- Preflight: `pytest` contract + unit green (566 passed) · `ruff` clean · `mypy` clean (221 files) · zero-skip clean.
- Pre-existing note: 6 `tests/integration/test_*_e2e.py` "live" tests fail locally because they need a *running* Godot editor (`skipif(GODOT_BIN is None)` only gates on the binary, not a live session). Confirmed identical failures on clean `origin/main` — unrelated to this change.

## Out of scope

- Item 3 (Claude skills layer) — separate PR, tracked in #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds three new user-facing prompts for resource authoring, build export, and batch refactoring

- Each prompt includes step-by-step workflows with toolset enabling and specific tool calls

- Prompts support parameterization and include safety reminders with dry_run usage

- Contract tests added to validate prompt registration and rendering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mcp_server/prompts/prompts.py"] -- "Register new prompts" --> B["_register_author_resource"]
  A -- "Register new prompts" --> C["_register_export_build"]
  A -- "Register new prompts" --> D["_register_batch_refactor"]
  E["tests/contract/test_prompts_contract.py"] -- "Validate prompt registration" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prompts.py</strong><dd><code>New prompts for resource authoring, export, and refactoring</code></dd></summary>
<hr>

mcp_server/prompts/prompts.py

<ul><li>Added three new prompt functions: _register_author_resource, <br>_register_export_build, and _register_batch_refactor<br> <li> Implemented parameterized workflows for TileSet, MeshLibrary, Theme, <br>Shader, and custom resource authoring<br> <li> Created step-by-step export build workflows with preset discovery and <br>template verification<br> <li> Added batch refactoring workflow with dry_run preview capability</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/259/files#diff-648954b45285621923044320df5900c173a29cf23ac6ac62c0f695138efd0ea6">+197/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_prompts_contract.py</strong><dd><code>Contract tests for new prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_prompts_contract.py

<ul><li>Added test cases for the new author_resource prompt including <br>resource_kind branching<br> <li> Added test cases for the new export_build prompt with <br>preset/output_path parameters<br> <li> Added test cases for the new batch_refactor prompt with dry_run <br>preview validation<br> <li> Updated expected prompts list to include the three new prompts</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/259/files#diff-ba0bb9e2578614678901b6896fedcb58590b17c7923058aced387ec640c4e4e7">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

