### PR TITLE
Add author_resource, export_build, and batch_refactor prompts with Claude skills layer

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,31 @@
+# godot-mcp skills
+
+Optional [Claude](https://claude.com/claude-code) **skills** that help an agent drive the godot-mcp server well. Unlike the server's MCP **prompts** (which a user invokes as slash commands), a skill auto-triggers when the agent recognizes a matching task from its `description` — so the guidance reaches the model without anyone typing a command. They are Claude-specific; other MCP clients should use the server's prompts instead.
+
+These skills stay pure to the raw godot-mcp surface (toolsets, prompts, tools) — no game-specific or agent-workflow logic.
+
+## Skills
+
+| Skill | Use it for |
+|-------|-----------|
+| `godot-mcp-getting-started` | Connect/verify the bridge, the toolset-gating model, the `dry_run`/`confirm` safety convention |
+| `godot-mcp-build-a-scene` | Scaffold/edit a scene: nodes, scripts, collision, save & verify |
+| `godot-mcp-playtest-and-debug` | Play a live scene, inspect/sample, simulate input, assert, and diagnose errors |
+
+## Install
+
+Copy the skill directories to either location:
+
+- **Personal (all projects):** `~/.claude/skills/`
+- **Project (shared with a repo):** `<your-project>/.claude/skills/`
+
+```bash
+# from this repo root, into your personal skills dir
+cp -R skills/godot-mcp-* ~/.claude/skills/
+```
+
+Each skill is a self-contained directory with a `SKILL.md`. After copying, the agent picks them up automatically; no MCP server change is required.
+
+## Relationship to the server's prompts
+
+Skills route to the same gated toolsets and the built-in workflow prompts (`build_scene`, `play_test`, `debug_scene`, `troubleshoot`, `author_resource`, `export_build`, `batch_refactor`, …). The prompts remain the canonical, client-agnostic recipes; the skills are the autonomous Claude front door.

--- a/skills/godot-mcp-build-a-scene/SKILL.md
+++ b/skills/godot-mcp-build-a-scene/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: godot-mcp-build-a-scene
+description: Build or edit a Godot scene through the godot-mcp server — create/open a scene, add and position nodes, attach GDScript, add collision, then save and verify. Use when the user wants to scaffold or modify a Godot .tscn scene via godot-mcp. Triggers on "build a Godot scene", "add a node in Godot", "create a scene", "attach a script to a node", "set up a player scene", "edit the scene tree".
+---
+
+# godot-mcp: build a scene
+
+Scaffold a scene with the `scene_edit` and `scripts` toolsets. If you haven't verified the bridge or the gating model, read `godot-mcp-getting-started` first. The server's `/mcp__godot-mcp__build_scene` prompt is the parameterized version of this recipe.
+
+## 1. Enable the toolsets
+
+```
+godot_enable_toolset('scene_edit')
+godot_enable_toolset('scripts')
+godot_enable_toolset('physics')    # only if you need collision
+```
+
+## 2. Create or open the scene
+
+```
+godot_scene_edit_create_scene(scene_path='res://scenes/main.tscn', root_type='Node2D')
+# or, if it already exists:
+godot_scene_edit_open_scene(scene_path='res://scenes/main.tscn')
+```
+
+## 3. Add and position nodes
+
+`parent_path='.'` is the scene root. Position via a typed property value.
+
+```
+godot_scene_edit_create_node(parent_path='.', node_type='Sprite2D', node_name='Player')
+godot_scene_edit_set_node_property(node_path='./Player', property='position', value={'x': 64, 'y': 64})
+```
+
+## 4. Attach a script
+
+```
+godot_scripts_write(script_path='res://scripts/player.gd', content='extends Sprite2D\n...')
+godot_scene_edit_attach_script(node_path='./Player', script_path='res://scripts/player.gd')
+```
+
+## 5. Add collision (optional)
+
+```
+godot_physics_setup_collision(
+    node_path='./Player',
+    collision_node_type='CollisionShape2D',
+    shape_type='CircleShape2D',
+    properties={'radius': 32})
+```
+
+## 6. Save and verify
+
+```
+godot_scene_edit_save_scene()
+godot_inspection_get_scene_tree(max_depth=2)     # confirm the hierarchy
+godot_scripts_get_parse_errors()                 # confirm scripts compile
+```
+
+## Safety
+
+- Preview any uncertain change with `dry_run=True` before committing it.
+- Destructive ops (`godot_scene_edit_delete_node`, `godot_scene_edit_reload_scene`) need `confirm=True`.
+- For the same property across many nodes, switch to the `batch` toolset and preview with `dry_run` first.

--- a/skills/godot-mcp-getting-started/SKILL.md
+++ b/skills/godot-mcp-getting-started/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: godot-mcp-getting-started
+description: Connect to and drive a Godot editor through the godot-mcp server. Use at the start of any Godot task via godot-mcp — it teaches the toolset-gating model (enable a toolset before its tools exist), the dry_run/confirm safety convention, and how to verify the bridge. Triggers on "use godot-mcp", "drive Godot", "control the Godot editor", "godot-mcp tools aren't showing up", "unknown tool from godot", "set up godot-mcp".
+---
+
+# godot-mcp: getting started
+
+godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the two most common failures: missing tools and unconfirmed destructive edits.
+
+## 1. Confirm the bridge is up
+
+The server talks to a running Godot editor over a WebSocket bridge. If Godot isn't open with the addon enabled, every editor tool fails.
+
+```
+godot_health_check()      # bridge connected? which URL?
+godot_get_server_info()   # toolsets, active scene, next_steps, common errors
+```
+
+If disconnected: open the `godot/` project in Godot 4.4+, enable the plugin (Project Settings → Plugins → godot_mcp), and check the status dock.
+
+## 2. Toolsets are gated — enable before you use
+
+Only `core` (diagnostics/toolset management) and `inspection` (read-only reading) are on by default. **Every other capability is hidden until you enable it.** Calling a hidden tool returns `ToolError: unknown tool` — there is no fallback.
+
+```
+godot_list_toolsets()                 # what exists / what's enabled
+godot_enable_toolset('scene_edit')    # turn on what you need, then call its tools
+```
+
+Quick map: edit scenes → `scene_edit` · scripts → `scripts` · live play → `runtime` (+ `input`) · debug breakpoints → `debugger` (+ `runtime`) · physics → `physics` · autoloads/resources → `resources_edit` · export → `export` · many-node changes → `batch`.
+
+## 3. The safety convention
+
+- **Read-only** tools never mutate — no flags needed.
+- **Mutating** tools accept `dry_run=True` — they report what *would* change and do nothing. Preview when unsure.
+- **Destructive** tools (delete/overwrite, e.g. `godot_scene_edit_delete_node`) require `confirm=True` or they refuse; they also support `dry_run`.
+
+## 4. Use the built-in workflow prompts
+
+The server ships step-by-step recipes as MCP prompts (slash commands like `/mcp__godot-mcp__build_scene`): `toolset_discovery`, `build_scene`, `play_test`, `script_edit`, `debug_scene`, `troubleshoot`. Reach for them, or use the companion skills `godot-mcp-build-a-scene` and `godot-mcp-playtest-and-debug`.
+
+## When something fails
+
+- `unknown tool` → the toolset isn't enabled (step 2), or you mixed up a server-side tool with an editor tool.
+- `PRECONDITION_FAILED` → read `required`: `active_scene` (open a scene), `confirm` (add `confirm=True`), `bridge_connected` (step 1).
+- Run `godot_get_server_info()` first — its `next_steps` field usually names the fix.

--- a/skills/godot-mcp-playtest-and-debug/SKILL.md
+++ b/skills/godot-mcp-playtest-and-debug/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: godot-mcp-playtest-and-debug
+description: Run, inspect, and debug a live Godot game through the godot-mcp server — play a scene in the editor, read the running scene tree, sample properties, simulate input, assert state, and diagnose errors. Use when the user wants to play-test, reproduce a bug, or debug runtime behavior in Godot via godot-mcp. Triggers on "play-test in Godot", "run the game and check", "simulate input in Godot", "why does my Godot game crash", "debug the running scene", "inspect the live game".
+---
+
+# godot-mcp: play-test and debug
+
+Drive a live game session with the `runtime`, `input`, and `testing` toolsets, and diagnose failures. Godot must be open with the addon enabled (see `godot-mcp-getting-started`). The server's `/mcp__godot-mcp__play_test`, `/mcp__godot-mcp__debug_scene`, and `/mcp__godot-mcp__troubleshoot` prompts cover the parameterized flows.
+
+## 1. Enable the toolsets
+
+```
+godot_enable_toolset('runtime')
+godot_enable_toolset('input')
+godot_enable_toolset('testing')
+godot_enable_toolset('resources_edit')   # to register the runtime probe if needed
+```
+
+## 2. Make sure the runtime probe is registered
+
+Live inspection/input needs the `MCPRuntimeProbe` autoload.
+
+```
+godot_inspection_get_project_info()        # check autoloads for 'MCPRuntimeProbe'
+godot_resources_edit_register_autoload(
+    name='MCPRuntimeProbe',
+    path='res://addons/godot_mcp/mcp_runtime_probe.gd')   # only if missing
+```
+
+## 3. Play and inspect
+
+```
+godot_runtime_play_scene(scene_path='res://scenes/main.tscn')
+godot_runtime_is_playing()                 # → {'playing': true}
+godot_runtime_get_game_scene_tree()        # the live hierarchy
+godot_runtime_monitor_property(node_path='/root/Main/Player', property='position', samples=30)
+godot_runtime_get_property_samples()        # collect the sampled values
+```
+
+## 4. Simulate input
+
+```
+godot_input_simulate_action(action='ui_right', pressed=true)   # hold
+godot_input_simulate_action(action='ui_right', pressed=false)  # release
+godot_input_simulate_key(key='Space', pressed=true)
+godot_input_play_sequence(events=[...], delay_ms=100)          # replay a macro
+```
+
+## 5. Assert state, then stop
+
+```
+godot_testing_assert_node_state(node_path='/root/Main/Player', property='visible', expected=true)
+godot_runtime_stop_scene()
+```
+
+## Debugging failures
+
+- **Crash on play** → `godot_runtime_run_and_capture(scene='res://scenes/main.tscn', timeout_seconds=5)`, then read `errors`/`warnings` (null refs, missing nodes, bad signal connections).
+- **Script won't parse** → `godot_scripts_get_parse_errors(script_path='res://scripts/x.gd')`, fix the reported line/column.
+- **Input does nothing** → confirm `godot_runtime_is_playing()` is true and the probe autoload is present (step 2).
+- **Step through code** → enable `debugger` + `runtime`, set a breakpoint, inspect the stack.
+- Stuck? Run `godot_get_server_info()` and follow `next_steps`, or use the `troubleshoot` prompt.

--- a/tests/unit/test_skills_metadata.py
+++ b/tests/unit/test_skills_metadata.py
@@ -1,0 +1,96 @@
+"""Validation for the bundled Claude skills under ``skills/``.
+
+Skills are client-side ``SKILL.md`` files that Claude auto-triggers on a
+description match. They are not Python, but they are part of the product surface,
+so we pin the things that silently rot: valid frontmatter, a name that matches
+its directory, a usefully long trigger description, and — since every workflow on
+this server starts with toolset gating — a reminder to enable a toolset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_server.server import create_server
+
+# Tool-call-shaped references in skill bodies, e.g. ``godot_runtime_play_scene(``.
+# The trailing ``(`` avoids matching plugin/path tokens like ``addons/godot_mcp/``.
+_TOOL_CALL_RE = re.compile(r"godot_[a-z0-9_]+(?=\()")
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "skills"
+
+# The skills we ship. Keep in lockstep with the directories under skills/.
+EXPECTED_SKILLS = {
+    "godot-mcp-getting-started",
+    "godot-mcp-build-a-scene",
+    "godot-mcp-playtest-and-debug",
+}
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """Parse the leading ``---`` YAML-ish frontmatter block (flat key: value)."""
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].strip().splitlines()
+    out: dict[str, str] = {}
+    for line in block:
+        if ":" in line:
+            key, _, value = line.partition(":")
+            out[key.strip()] = value.strip()
+    return out
+
+
+def _skill_dirs() -> list[Path]:
+    return sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir())
+
+
+def test_expected_skills_present() -> None:
+    """Every shipped skill directory exists with a SKILL.md."""
+    assert SKILLS_DIR.is_dir(), "skills/ directory must exist"
+    found = {p.name for p in _skill_dirs()}
+    assert EXPECTED_SKILLS <= found, f"Missing skills: {EXPECTED_SKILLS - found}"
+    for name in EXPECTED_SKILLS:
+        assert (SKILLS_DIR / name / "SKILL.md").is_file(), f"{name}/SKILL.md missing"
+
+
+@pytest.mark.parametrize("skill_name", sorted(EXPECTED_SKILLS))
+def test_skill_frontmatter_and_body(skill_name: str) -> None:
+    """Each SKILL.md has valid frontmatter and teaches toolset gating."""
+    text = (SKILLS_DIR / skill_name / "SKILL.md").read_text(encoding="utf-8")
+    fm = _parse_frontmatter(text)
+
+    assert fm.get("name") == skill_name, f"frontmatter name must equal dir '{skill_name}'"
+    description = fm.get("description", "")
+    assert len(description) >= 40, "description must be descriptive enough to trigger on"
+    assert "godot" in description.lower(), "description should mention Godot for relevance"
+
+    body = text[text.find("\n---", 3) + 4 :]
+    assert body.strip(), "SKILL.md must have a body after the frontmatter"
+    # Every workflow on this server begins with enabling the right toolset.
+    assert "godot_enable_toolset" in body, "skill body must show the toolset-gating step"
+
+
+def test_skill_tool_references_exist() -> None:
+    """Every godot_*() tool call shown in a skill resolves to a real tool.
+
+    Guards against teaching the model tool names that don't exist (e.g. a renamed
+    or imagined tool), which would silently fail at call time.
+    """
+    server: Any = create_server()
+    tool_names = {t.name for t in asyncio.run(server._list_tools())}
+    unknown: dict[str, set[str]] = {}
+    for skill in _skill_dirs():
+        text = (skill / "SKILL.md").read_text(encoding="utf-8")
+        refs = set(_TOOL_CALL_RE.findall(text))
+        missing = {r for r in refs if r not in tool_names}
+        if missing:
+            unknown[skill.name] = missing
+    assert not unknown, f"Skills reference unknown tools: {unknown}"


### PR DESCRIPTION
### **User description**
Part of #257 (item 3 of 3). Adds a client-side **skills** layer — the autonomous Claude front door to the server. Unlike MCP **prompts** (user-invoked slash commands), a skill auto-triggers when the agent recognizes a matching task from its `description`, so the guidance reaches the model with no command typed. Claude-specific; other MCP clients keep using the server's prompts.

## New skills (`skills/`)

| Skill | Use it for |
|-------|-----------|
| `godot-mcp-getting-started` | Bridge check, the toolset-gating model, the `dry_run`/`confirm` safety convention |
| `godot-mcp-build-a-scene` | Scaffold/edit a scene: nodes, scripts, collision, save & verify |
| `godot-mcp-playtest-and-debug` | Play a live scene, inspect/sample, simulate input, assert, diagnose errors |

Plus `skills/README.md` with install instructions (copy to `~/.claude/skills/` or a project's `.claude/skills/`).

## Design

- **Pure to the raw MCP surface** — toolsets, prompts, tools only. No game vocabulary, no agent/TDD/verify-loop logic (that belongs in the separate agent project). Skills route to the built-in prompts rather than re-implementing them.
- Tool names verified against the live registry (caught and fixed `godot_runtime_stop` → `godot_runtime_stop_scene`).

## Test plan

- `tests/unit/test_skills_metadata.py` (red→green): each skill dir + `SKILL.md` exists; frontmatter `name` matches the directory; description is trigger-worthy and mentions Godot; body shows the toolset-gating step; and **every `godot_*()` tool call shown resolves to a real registered tool** (drift guard).
- Preflight: `pytest tests/unit/test_skills_metadata.py` green (5 passed) · `ruff` clean · `mypy` clean (222 files) · zero-skip clean.

## Notes

- The `skills/` dir is a new top-level product artifact; it doesn't change the server or its packaging.
- README references the prompts added in #259 (`author_resource`/`export_build`/`batch_refactor`) — accurate once that PR merges.

Closes #257 once #258 (merged) + #259 + this land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds three new user-facing MCP prompts for resource authoring, build export, and batch refactoring

- Enhances server instructions with dry_run/confirm safety convention

- Introduces Claude skills layer for autonomous workflow guidance

- Updates contract tests to validate new prompt registrations and tool references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mcp_server/prompts/prompts.py"] -- "Register new prompts" --> B["_register_author_resource"]
  A -- "Register new prompts" --> C["_register_export_build"]
  A -- "Register new prompts" --> D["_register_batch_refactor"]
  E["tests/contract/test_prompts_contract.py"] -- "Validate prompt registration" --> A
  F["skills/"] -- "Add Claude skills layer" --> G["godot-mcp-getting-started"]
  F -- "Add Claude skills layer" --> H["godot-mcp-build-a-scene"]
  F -- "Add Claude skills layer" --> I["godot-mcp-playtest-and-debug"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>prompts.py</strong><dd><code>New user-facing MCP prompts added</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/prompts/prompts.py

<ul><li>Added three new prompt functions: _register_author_resource, <br>_register_export_build, and _register_batch_refactor<br> <li> Implemented parameterized workflows for TileSet, MeshLibrary, Theme, <br>Shader, and custom resource authoring<br> <li> Created step-by-step export build workflows with preset discovery and <br>template verification<br> <li> Added batch refactoring workflow with dry_run preview capability</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Build scene skill implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-mcp-build-a-scene/SKILL.md

<ul><li>Created skill for building/editing Godot scenes<br> <li> Defined workflow steps for enabling toolsets, creating/opening scenes, <br>adding nodes<br> <li> Included instructions for attaching scripts and adding collision<br> <li> Added safety guidelines with dry_run and confirm usage</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/260/files#diff-59ce2994db8cf924ab5a97082bf60935293962f335f03f0d0bac475bbf359345">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Getting started skill implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-mcp-getting-started/SKILL.md

<ul><li>Created getting started skill for initial Godot session setup<br> <li> Explained toolset gating model and safety convention (dry_run/confirm)<br> <li> Documented bridge verification steps and error handling<br> <li> Linked to built-in workflow prompts for further guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/260/files#diff-af89f4ff4bbb41a1d63dc1cf09f6dccae9672e7ffa91ad92d38615b038522e68">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Play-test and debug skill implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-mcp-playtest-and-debug/SKILL.md

<ul><li>Created play-test and debug skill for live game sessions<br> <li> Defined workflow steps for enabling toolsets, registering runtime <br>probe<br> <li> Included instructions for playing, inspecting, and simulating input<br> <li> Added debugging failure scenarios and troubleshooting guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/260/files#diff-00ae3c02d7998fff31f3ce2cc310bdb7f36fc5071f0b9e72a1e4cc9b9300a1bd">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_prompts_contract.py</strong><dd><code>Contract tests updated for new prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_prompts_contract.py

<ul><li>Added test cases for the new author_resource prompt including <br>resource_kind branching<br> <li> Added test cases for the new export_build prompt with <br>preset/output_path parameters<br> <li> Added test cases for the new batch_refactor prompt with dry_run <br>preview validation<br> <li> Updated expected prompts list to include the three new prompts</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_skills_metadata.py</strong><dd><code>Skills metadata validation tests added</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_skills_metadata.py

<ul><li>Added validation tests for Claude skills metadata<br> <li> Implemented frontmatter parsing and validation<br> <li> Created tool reference validation to ensure all godot_*() calls <br>resolve to real tools<br> <li> Added test cases for skill directory structure and content <br>requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/260/files#diff-148034ce3818b396ba3d1b82d3dbe03e6a29886ff085b1a02d22275f5c97fc36">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Claude skills documentation added</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/README.md

<ul><li>Added documentation for Claude skills layer<br> <li> Explained skill installation process and locations<br> <li> Described relationship between skills and server prompts<br> <li> Documented three new skills: getting-started, build-a-scene, and <br>playtest-and-debug</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/260/files#diff-4d647326e823e7202ff18d96504599a2f17893ead7e40499f82899106dbad2c7">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

