### PR TITLE
Docs: Surface new prompts and Claude skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A **generic, game-agnostic** [Model Context Protocol](https://modelcontextprotoc
   - [Safety Classes](#safety-classes)
   - [Version Gating](#version-gating)
   - [Workflow Patterns](#workflow-patterns)
+  - [Prompts & Skills](#prompts--skills)
   - [Error Handling](#error-handling)
 - [Live Runtime & The Probe Autoload](#live-runtime--the-probe-autoload)
 - [All Toolsets](#all-toolsets)
@@ -376,6 +377,15 @@ list_export_presets()
 export_project(preset="Web", output_path="builds/web")
 ```
 
+### Prompts & Skills
+
+Beyond the tool surface, two layers help an agent drive the server well:
+
+- **MCP prompts** — step-numbered workflow recipes the server exposes over MCP. Clients that surface prompts (Claude Code, etc.) show them as slash commands, e.g. `/mcp__godot-mcp__build_scene`. Shipped: `toolset_discovery`, `build_scene`, `play_test`, `script_edit`, `debug_scene`, `troubleshoot`, `author_resource`, `export_build`, `batch_refactor`. Discover with `list_prompts()`; render with `render_prompt(name, arguments={...})`.
+- **Claude skills** ([`skills/`](skills/README.md)) — optional, Claude-specific. Unlike prompts, a skill *auto-triggers* when the agent recognizes a matching task (no slash command), then routes to the prompts and tools. Copy a skill directory into `~/.claude/skills/` (personal) or your project's `.claude/skills/` (shared). Shipped: `godot-mcp-getting-started`, `godot-mcp-build-a-scene`, `godot-mcp-playtest-and-debug`.
+
+Both stay pure to the generic Godot surface — no game-specific vocabulary.
+
 ### Error Handling
 
 All errors are **structured** — never Python tracebacks. The agent can parse them and recover:
@@ -642,7 +652,9 @@ mcp_server/                      # FastMCP server (Python 3.11+)
   tools/                         # @mcp.tool() handlers (thin delegation)
   resources/                     # godot://… read-only resource handlers
   models/                        # Pydantic typed I/O models
-  prompts/                       # reserved (no prompts shipped yet)
+  prompts/                       # @mcp.prompt() workflow recipes (slash commands)
+
+skills/                          # optional Claude skills (auto-trigger) — see skills/README.md
 
 tests/
   contract/                      # envelope shapes + tool schemas (fake bridge)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -31,8 +31,13 @@ The server exposes **workflow prompts** that the LLM can discover and use:
 | `script_edit` | When writing, attaching, and iterating on GDScript |
 | `debug_scene` | When something is broken and you want a systematic diagnosis |
 | `troubleshoot` | When you see an error and need help interpreting it |
+| `author_resource` | When authoring a TileSet, MeshLibrary, Theme, Shader, or custom `.tres` |
+| `export_build` | When exporting a build for a target platform |
+| `batch_refactor` | When changing one property across many nodes safely |
 
 The LLM can discover these via `list_prompts()` and render them via `get_prompt(name)` or `render_prompt(name)`. Not all clients expose prompts to the user, but the ones that do (Claude Code, etc.) will surface them as templates.
+
+> **Claude skills:** if you use Claude, the [`skills/`](skills/README.md) directory ships skills that auto-trigger on a matching task (no slash command needed) and route to these prompts and tools — copy them into `~/.claude/skills/` or your project's `.claude/skills/`. See [`skills/README.md`](skills/README.md).
 
 ### 3. Tool Docstrings
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -1024,6 +1024,9 @@ separate game project.
 | `script_edit` | `script_path`, `node_path` | Write, attach, and verify a script: write_script → attach_script → get_parse_errors |
 | `debug_scene` | `scene_path`, `script_path` | Systematic debugging: debug_workflow, get_parse_errors, run_and_capture, analyze_signal_flow, find_unused_resources, detect_circular_dependencies |
 | `troubleshoot` | `error_message`, `scene_path`, `script_path` | Interpret a specific error message, find the source, and suggest fixes |
+| `author_resource` | `resource_kind`, `save_path` | Author a resource — TileSet, MeshLibrary, Theme, Shader, or custom `.tres` — routing to the right toolset per `resource_kind` |
+| `export_build` | `preset`, `output_path` | Export a platform build: discover presets, check templates, `export_project`, verify exit code |
+| `batch_refactor` | `node_type`, `property`, `value` | Change a property across many nodes safely: find targets, preview with `dry_run`, apply, plus a cross-scene variant |
 
 Prompts are discoverable via `list_prompts()` and renderable via `render_prompt(name, arguments={...})`.
 


### PR DESCRIPTION
### **User description**
Closes #261. Follow-up to #257 — closes the doc gaps left after the instructions/prompts/skills work merged (enforcement rule: docs updated when the surface changes). Doc-only, no code/test changes.

## Changes

- **`docs/tool-contracts.md`** — add `author_resource`, `export_build`, `batch_refactor` to the "Implemented prompts" table (were only the original 6).
- **`TUTORIAL.md`** — add the three prompts to the discoverable-prompts table; add a note pointing Claude users to `skills/`.
- **`README.md`** — new "Prompts & Skills" section (with ToC entry); fixed the stale `prompts/ # reserved (no prompts shipped yet)` repo-layout line; listed `skills/`.

## Verification

- Documented names cross-checked against the live server: 9 prompts and 3 skills match exactly.
- `tests/unit/test_skills_metadata.py` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Adds documentation for new prompts and skills

- Updates tool-contracts table with three additional prompts

- Enhances README and TUTORIAL with discoverability sections

- Includes Claude skills auto-trigger guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -- "Add Prompts & Skills section" --> B["TUTORIAL.md"]
  A -- "Update repo layout" --> C["docs/tool-contracts.md"]
  B -- "Add new prompts table entries" --> C
  A -- "Link to skills/ directory" --> D["skills/README.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add documentation for prompts and skills</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added "Prompts & Skills" section with table of contents entry<br> <li> Documented MCP prompts and Claude skills functionality<br> <li> Updated repository layout documentation to reflect prompts/ and <br>skills/ directories</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/262/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TUTORIAL.md</strong><dd><code>Update tutorial with new prompts and skills info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TUTORIAL.md

<ul><li>Added three new prompts (<code>author_resource</code>, <code>export_build</code>, <br><code>batch_refactor</code>) to discoverable prompts table<br> <li> Included note about Claude skills auto-trigger functionality<br> <li> Enhanced tutorial with guidance for Claude users</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/262/files#diff-3fdc97c7ca0f4787aa2e1186e152b32da368666f7e133445462738b92a18e5a6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Expand tool contracts with new prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Added three new prompts (<code>author_resource</code>, <code>export_build</code>, <br><code>batch_refactor</code>) to the "Implemented prompts" table<br> <li> Updated prompt descriptions with detailed information about each new <br>prompt's functionality<br> <li> Maintained existing documentation structure while expanding coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/262/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

