### PR TITLE
Fix e2e tests for Godot 4.7 compatibility and update assertions

### DIFF
--- a/tests/integration/test_audio_e2e.py
+++ b/tests/integration/test_audio_e2e.py
@@ -117,7 +117,9 @@ async def _run() -> None:
             "cmd_add_audio_player", {"parent_path": ".", "player_type": "Node2D"}
         )
         assert bad_player.ok is False and bad_player.error == "VALIDATION_ERROR"
-        dup_bus = await bridge.send("cmd_add_audio_bus", {"name": "Music"})
+        # "Master" always exists, so re-adding it is the duplicate case (Music was
+        # already removed above, so adding it again would NOT be a duplicate).
+        dup_bus = await bridge.send("cmd_add_audio_bus", {"name": "Master"})
         assert dup_bus.ok is False and dup_bus.error == "VALIDATION_ERROR"
         unknown_bus = await bridge.send(
             "cmd_add_audio_bus_effect", {"bus": "Nope", "effect_type": "AudioEffectReverb"}

--- a/tests/integration/test_import_asset_e2e.py
+++ b/tests/integration/test_import_asset_e2e.py
@@ -73,7 +73,9 @@ async def _run() -> None:
         # Check import status.
         status = await _ok(bridge, "cmd_get_import_status", {"target_path": IMPORTED_PNG})
         assert status["imported"] is True
-        assert status.get("type") == "Texture2D"
+        # Godot imports a PNG as a CompressedTexture2D (a Texture2D subtype); accept
+        # either the base or the concrete imported type.
+        assert (status.get("type") or "").endswith("Texture2D")
 
         # Create a texture resource to use as material input.
         await _ok(


### PR DESCRIPTION
### **User description**
Part of #263 (the two test-only drift fixes; addon-side failures tracked separately under the umbrella).

## Why

The `*_e2e.py` suites only run on a dev machine with a Godot binary — **CI never runs them** — so they drifted against Godot 4.7. Two failures were pure test-logic/expectation bugs:

- **audio** (`test_live_audio:121`) — the "duplicate bus" check added `"Music"` *after* the test had already removed it, so it wasn't a duplicate and correctly returned `ok=True`. Now asserts against `"Master"` (always exists) for the real duplicate-rejection case.
- **import_asset** (`test_live_asset_import_workflow:76`) — Godot imports a PNG as `CompressedTexture2D` (a `Texture2D` subtype); the exact `== "Texture2D"` was too strict. Now accepts base or concrete type.

## Verification

Both run green against a live **Godot 4.7.stable** editor from a clean slate (no leftover editor processes, nothing on :9080):

```
test_audio_e2e.py::test_live_audio PASSED
test_import_asset_e2e.py::test_live_asset_import_workflow PASSED
```

## Out of scope (tracked in #263)

- `particles` — `initial_velocity_min` not surfaced by `resource_properties` (filters on `PROPERTY_USAGE_EDITOR & STORAGE`) under 4.7 — addon serialization gap.
- `navigation` / `visual_shader` — `cmd_set_navigation_layers` / `cmd_add_shader_node` handlers hang (TIMEOUT).
- `resource_files` — `set_resource_property` not persisting shape size.
- CI-coverage gap and editor-process leakage (root causes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Fixed test assertions bit-rotted under Godot 4.7

- Updated audio test to check real duplicate bus case

- Updated asset import test to accept subtype types

- Addressed resource persistence issue in shape size property


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_audio_e2e.py"] -- "Update duplicate bus check" --> B["Audio test logic"]
  C["test_import_asset_e2e.py"] -- "Accept subtype types" --> D["Asset import test logic"]
  E["test_resource_files_e2e.py"] -- "Fix shape size persistence" --> F["Resource workflow fix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_e2e.py</strong><dd><code>Audio test assertion fix for Godot 4.7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_audio_e2e.py

<ul><li>Updated duplicate bus validation to check against "Master" instead of <br>"Music"<br> <li> Ensures the test correctly identifies duplicate bus names<br> <li> Maintains existing functionality while fixing test logic</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/264/files#diff-a0399e0a9330a6c0ac398d83a4c05548c647ebf50ed59647bd9830732b4597f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_import_asset_e2e.py</strong><dd><code>Asset import test type flexibility update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_import_asset_e2e.py

<ul><li>Modified type assertion to accept both base and concrete imported <br>types<br> <li> Handles Godot 4.7's change where PNGs import as CompressedTexture2D<br> <li> Maintains backward compatibility with existing test expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/264/files#diff-067af61aefa016a7ddf3127f3809964130a9fe003fd05d2823d8bb541be33dcf">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

