### PR TITLE
Fix navigation handler hang and shared helper duplication

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -439,6 +439,32 @@ func _invalidate_prop_cache(obj: Object) -> void:
 	_prop_cache.erase(obj.get_instance_id())
 
 
+## Shared by handlers that take 1-based bit indices (physics layers/mask,
+## navigation layers). A valid value is an array of ints in [1, 32].
+func _valid_bits(value: Variant) -> bool:
+	if not (value is Array):
+		return false
+	for bit in value:
+		if typeof(bit) not in [TYPE_INT, TYPE_FLOAT]:
+			return false
+		var index := int(bit)
+		if index < 1 or index > 32:
+			return false
+	return true
+
+
+## Fold an array of 1-based bit indices into a bitmask. Out-of-range bits are
+## ignored; validate with _valid_bits first to reject bad input.
+func _bitmask(bits: Variant) -> int:
+	var mask := 0
+	if bits is Array:
+		for bit in bits:
+			var index := int(bit)
+			if index >= 1 and index <= 32:
+				mask |= 1 << (index - 1)
+	return mask
+
+
 func _scene_name(root: Node) -> String:
 	if not root.scene_file_path.is_empty():
 		return root.scene_file_path.get_file()

--- a/godot/addons/godot_mcp/handlers/physics.gd
+++ b/godot/addons/godot_mcp/handlers/physics.gd
@@ -105,17 +105,17 @@ func _cmd_set_physics_layers(params: Dictionary) -> Dictionary:
 	var node: Node = found["node"]
 	if not (node is CollisionObject2D or node is CollisionObject3D):
 		return _router._fail("VALIDATION_ERROR", "Node is not a physics body/area (CollisionObject2D/3D).")
-	if params.get("layers") != null and not _valid_bits(params["layers"]):
+	if params.get("layers") != null and not _router._valid_bits(params["layers"]):
 		return _router._fail("VALIDATION_ERROR", "'layers' must be an array of bit indices in [1, 32].")
-	if params.get("mask") != null and not _valid_bits(params["mask"]):
+	if params.get("mask") != null and not _router._valid_bits(params["mask"]):
 		return _router._fail("VALIDATION_ERROR", "'mask' must be an array of bit indices in [1, 32].")
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set physics layers on %s" % node.name)
 	if params.get("layers") != null:
-		ur.add_do_property(node, "collision_layer", _bitmask(params["layers"]))
+		ur.add_do_property(node, "collision_layer", _router._bitmask(params["layers"]))
 		ur.add_undo_property(node, "collision_layer", node.collision_layer)
 	if params.get("mask") != null:
-		ur.add_do_property(node, "collision_mask", _bitmask(params["mask"]))
+		ur.add_do_property(node, "collision_mask", _router._bitmask(params["mask"]))
 		ur.add_undo_property(node, "collision_mask", node.collision_mask)
 	ur.commit_action()
 	return _router._ok({
@@ -155,27 +155,5 @@ func _cmd_add_raycast(params: Dictionary) -> Dictionary:
 	ur.add_undo_method(parent, "remove_child", ray)
 	ur.commit_action()
 	return _router._ok({"node_path": Inspect.relative_path(ray, root), "created": true})
-
-
-func _valid_bits(value: Variant) -> bool:
-	if not (value is Array):
-		return false
-	for bit in value:
-		if typeof(bit) not in [TYPE_INT, TYPE_FLOAT]:
-			return false
-		var index := int(bit)
-		if index < 1 or index > 32:
-			return false
-	return true
-
-
-func _bitmask(bits: Variant) -> int:
-	var mask := 0
-	if bits is Array:
-		for bit in bits:
-			var index := int(bit)
-			if index >= 1 and index <= 32:
-				mask |= 1 << (index - 1)
-	return mask
 
 


### PR DESCRIPTION
### **User description**
Part of #263. Fixes the first of the two handler-hang bugs.

## Root cause

`navigation.gd::_cmd_set_navigation_layers` calls `_router._valid_bits()` / `_router._bitmask()`, but those helpers only existed as **private copies in `physics.gd`** — they were never on the router. So the handler crashed with `Nonexistent function '_valid_bits' in base MCPCommandRouter`, aborted before building a response, and the router sent a bare `{"id":"N"}` frame (no `ok`/`result`). The server's bridge can't validate that as a `ResponseEnvelope`, drops it ("dropping unparseable bridge message"), and the call **times out** — exactly the `test_navigation_e2e` failure.

Found by probing the raw WebSocket frame:
```
<-- RAW for cmd_set_navigation_layers: {"id":"5"}
```
and the editor's stderr:
```
SCRIPT ERROR: Nonexistent function '_valid_bits' in base 'RefCounted (MCPCommandRouter)'.
  at: MCPNavigationHandlers._cmd_set_navigation_layers (navigation.gd:112)
```

## Fix

Per `addon.md` (shared helpers shouldn't be copy-pasted across handlers): move `_valid_bits` / `_bitmask` onto `MCPCommandRouter`, next to the other shared helpers (`_property_type`, `_resolve`, `_ok`, `_fail`). Navigation already called the router form, so it now resolves; `physics.gd` is updated to call the router copies and its private duplicates removed.

## Verification

Both pass against a live **Godot 4.7.stable** editor from a clean slate:
```
test_navigation_e2e.py::test_live_navigation PASSED
test_physics_e2e.py::test_live_physics PASSED   (regression guard for the move)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed handler hang in `cmd_set_navigation_layers` due to missing router helpers

- Moved shared `_valid_bits` and `_bitmask` functions to `MCPCommandRouter`

- Updated physics handler to use router helpers, removing duplicate implementations

- Resolved test failures related to Godot 4.7 compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["navigation.gd::_cmd_set_navigation_layers"] -- "calls _router._valid_bits()" --> B["MCPCommandRouter"]
  C["physics.gd"] -- "calls _router._bitmask()" --> B
  B -- "contains _valid_bits, _bitmask" --> D["Shared helpers moved here"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command_router.gd</strong><dd><code>Add shared bit validation and conversion helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/command_router.gd

<ul><li>Added <code>_valid_bits</code> function to validate bit indices in [1, 32]<br> <li> Added <code>_bitmask</code> function to convert array of bit indices into bitmask <br>integer<br> <li> These functions are now shared across handlers that use 1-based bit <br>indices</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/265/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>physics.gd</strong><dd><code>Refactor physics handler to use router helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/physics.gd

<ul><li>Updated <code>_cmd_set_physics_layers</code> to call router helpers instead of <br>local copies<br> <li> Removed duplicate <code>_valid_bits</code> and <code>_bitmask</code> functions from physics <br>handler<br> <li> Ensures consistency with navigation handler usage</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/265/files#diff-28724bb054bad4591811a537ad774e663a867b1aa821647146cfd239aea410b0">+4/-26</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

