### PR TITLE
Fix visual shader handler hangs and node ID validation for Godot 4.7

### DIFF
--- a/godot/addons/godot_mcp/handlers/visual_shader.gd
+++ b/godot/addons/godot_mcp/handlers/visual_shader.gd
@@ -86,8 +86,9 @@ func _cmd_add_shader_node(params: Dictionary) -> Dictionary:
 
 	if not path.begins_with("res://"):
 		return _router._fail("VALIDATION_ERROR", "shader_path must start with res://.")
-	if node_id < 0:
-		return _router._fail("VALIDATION_ERROR", "'node_id' must be >= 0.")
+	# Godot reserves node ids 0 (output) and 1; add_node requires id >= 2.
+	if node_id < 2:
+		return _router._fail("VALIDATION_ERROR", "'node_id' must be >= 2 (0 and 1 are reserved).")
 	if not ClassDB.class_exists(node_type):
 		return _router._fail("VALIDATION_ERROR", "Unknown node type '%s'." % node_type)
 	if not ClassDB.can_instantiate(node_type):
@@ -107,7 +108,8 @@ func _cmd_add_shader_node(params: Dictionary) -> Dictionary:
 	var node: VisualShaderNode = instance
 
 	var mode: int = int(shader.get_mode())
-	if shader.has_node(mode, node_id):
+	# VisualShader has no has_node(); existence is checked via the node-id list.
+	if node_id in shader.get_node_list(mode):
 		return _router._fail("VALIDATION_ERROR", "Node id %d already exists." % node_id)
 
 	var ur := EditorInterface.get_editor_undo_redo()
@@ -169,7 +171,8 @@ func _cmd_set_shader_node_param(params: Dictionary) -> Dictionary:
 		return _router._fail("INTERNAL_ERROR", "Failed to load shader '%s'." % path)
 
 	var mode: int = int(shader.get_mode())
-	if not shader.has_node(mode, node_id):
+	# VisualShader has no has_node(); existence is checked via the node-id list.
+	if node_id not in shader.get_node_list(mode):
 		return _router._fail("VALIDATION_ERROR", "No node with id %d in shader." % node_id)
 	var node: VisualShaderNode = shader.get_node(mode, node_id)
 

--- a/tests/integration/test_visual_shader_e2e.py
+++ b/tests/integration/test_visual_shader_e2e.py
@@ -57,19 +57,19 @@ async def _run() -> None:
             {
                 "shader_path": SHADER,
                 "node_type": "VisualShaderNodeColorConstant",
-                "node_id": 1,
+                "node_id": 2,
                 "position": [100.0, 200.0],
             },
         )
         assert added["added"] is True
-        assert added["node_id"] == 1
+        assert added["node_id"] == 2
 
         connected = await _ok(
             bridge,
             "cmd_connect_shader_nodes",
             {
                 "shader_path": SHADER,
-                "from_node": 1,
+                "from_node": 2,
                 "from_port": 0,
                 "to_node": 0,
                 "to_port": 0,
@@ -80,10 +80,10 @@ async def _run() -> None:
         # G6 (#219): read the graph back — mode, the added node, and the connection.
         graph = await _ok(bridge, "cmd_read_visual_shader", {"shader_path": SHADER})
         assert graph["mode"] == "canvas_item"
-        node1 = next(n for n in graph["nodes"] if n["id"] == 1)
+        node1 = next(n for n in graph["nodes"] if n["id"] == 2)
         assert node1["type"] == "VisualShaderNodeColorConstant"
         assert node1["position"] == {"x": 100.0, "y": 200.0}
-        assert {"from_node": 1, "from_port": 0, "to_node": 0, "to_port": 0} in graph["connections"]
+        assert {"from_node": 2, "from_port": 0, "to_node": 0, "to_port": 0} in graph["connections"]
 
         types = await _ok(bridge, "cmd_list_shader_node_types", {})
         assert any(t.startswith("VisualShaderNode") for t in types["types"])


### PR DESCRIPTION
### **User description**
Part of #263. Fixes the second handler-hang bug, plus a reserved-id bug it exposed.

## Root causes (Godot 4.7, found by probing raw frames + editor stderr)

1. **`has_node` crash → TIMEOUT.** `cmd_add_shader_node` and `cmd_set_shader_node_param` called `shader.has_node(mode, id)`, but `VisualShader` has no `has_node()` (it's on `Node`/`AnimationNodeBlendTree`). The handler crashed (`Nonexistent function 'has_node' in base VisualShader`), aborted before replying, and the router emitted a bare `{"id":N}` frame → dropped as unparseable → the call timed out. Fixed with the documented check: `id in shader.get_node_list(type)`.
2. **Reserved node ids.** `add_shader_node` only validated `node_id >= 0`, but Godot reserves ids 0 (output) and 1 — the engine guard `ERR_FAIL_COND(p_id < 2)` rejects them, so `add_node` silently failed and the later `connect_nodes` failed too. Now validates `node_id >= 2` with a clear error.

The test used `node_id: 1` (never valid under Godot) — updated to `2`. This is why the suite never caught it: e2e tests don't run in CI.

## Verification

Passes against a live **Godot 4.7.stable** editor from a clean slate:
```
test_visual_shader_e2e.py::test_live_visual_shader_workflow PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed handler hangs in visual shader operations

- Corrected node ID validation to respect Godot 4.7 engine constraints

- Updated e2e tests to use valid node IDs

- Resolved `has_node` crash by using proper existence check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["visual_shader.gd _cmd_add_shader_node"] -- "validate node_id >= 2" --> B
  A -- "use get_node_list instead of has_node" --> C
  D["visual_shader.gd _cmd_set_shader_node_param"] -- "use get_node_list" --> C
  E["test_visual_shader_e2e.py"] -- "update node_id from 1 to 2" --> F
  B -- "fix handler hang" --> G
  C -- "fix handler hang" --> G
  F -- "pass e2e test" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_visual_shader_e2e.py</strong><dd><code>Update test node IDs for Godot 4.7 compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_visual_shader_e2e.py

<ul><li>Updated node_id from 1 to 2 in test cases to comply with Godot 4.7 <br>constraints<br> <li> Adjusted assertions to match new node_id values<br> <li> Ensured test validates correct node connections after updates</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/266/files#diff-c63c164c4e0b39b3b9e26b9cf99ae8745e93a2a49fcd39e39edf1e0ee58a68eb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visual_shader.gd</strong><dd><code>Fix visual shader handler hangs and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/visual_shader.gd

<ul><li>Changed node ID validation to require >= 2, respecting Godot's <br>reserved IDs (0 and 1)<br> <li> Replaced <code>shader.has_node()</code> calls with <code>node_id in </code><br><code>shader.get_node_list(mode)</code> due to VisualShader lacking <code>has_node()</code><br> <li> Fixed handler crashes that caused timeouts during visual shader <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/266/files#diff-1a15b4e5dbf86dbc670b36feff984bd20e39675dd6e101d58c72c293985afc07">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

