### PR TITLE
test(e2e): particles — assert orbit_velocity_min, not editor-hidden initial_velocity_min (#263)

### DIFF
--- a/tests/integration/test_particles_e2e.py
+++ b/tests/integration/test_particles_e2e.py
@@ -77,7 +77,10 @@ async def _run() -> None:
         mat = await _ok(
             bridge,
             "cmd_set_particle_material",
-            {"node_path": "FX", "properties": {"spread": 33.0, "initial_velocity_min": 25.0}},
+            # orbit_velocity_min round-trips through the editor's property list;
+            # initial_velocity_* are settable but the editor renderer omits them from
+            # the read (a Godot editor-vs-headless property-exposure quirk, see #263).
+            {"node_path": "FX", "properties": {"spread": 33.0, "orbit_velocity_min": 25.0}},
         )
         assert mat["properties"]["spread"] == 33.0
 
@@ -92,7 +95,7 @@ async def _run() -> None:
         read = await _ok(bridge, "cmd_get_particle_material", {"node_path": "FX"})
         assert read["has_material"] is True
         assert read["properties"]["spread"] == 33.0
-        assert read["properties"]["initial_velocity_min"] == 25.0
+        assert read["properties"]["orbit_velocity_min"] == 25.0
         assert read["color_ramp"] is not None
         assert len(read["color_ramp"]["offsets"]) == 3 and len(read["color_ramp"]["colors"]) == 3
 


### PR DESCRIPTION
Part of #263.

## Investigation

`test_live_particles` asserted `get_particle_material` returns `initial_velocity_min`. Probing the live editor showed the **set succeeds** but the **read omits** `initial_velocity_*`. Root cause: Godot's editor renderer exposes `ParticleProcessMaterial`'s property list differently from the headless `--script` dummy renderer — `initial_velocity_min/max` (and `damping_min`, `scale_min`) are present headlessly but **absent in the live editor read**, while `spread` and `orbit_velocity_min` are present in both.

Evidence (live editor, via the bridge):
```
spread:            present=True  value=33.0
orbit_velocity_min:present=True  value=4.0
initial_velocity_min/damping_min/scale_min: present=False
```

The addon's `resource_properties` (filters to `EDITOR & STORAGE`) is behaving correctly — it surfaces what Godot reports in that context. So this is **test-side drift**: the test picked a property the editor hides.

## Fix

Assert `orbit_velocity_min` (editor-exposed, round-trips) instead of `initial_velocity_min`. `spread` still covers the basic round-trip.

## Verification

```
test_particles_e2e.py::test_live_particles PASSED   (live Godot 4.7)
```

## Note

Not changing `resource_properties` to force-include editor-hidden props — it's used by every resource read (theme, shader, etc.) and loosening the `EDITOR & STORAGE` filter would broadly change behavior. The `initial_velocity_*` editor-exposure quirk is documented here and in #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)