### PR TITLE
Fix resource property persistence in MCP addon

### DIFF
--- a/godot/addons/godot_mcp/handlers/resources.gd
+++ b/godot/addons/godot_mcp/handlers/resources.gd
@@ -95,8 +95,10 @@ func _cmd_set_resource_property(params: Dictionary) -> Dictionary:
 	var new_value: Variant = Coerce.from_json(params.get("value"), prop_type)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set %s.%s" % [path.get_file(), property])
-	ur.add_do_method(self, "_set_and_save_resource", path, property, new_value)
-	ur.add_undo_method(self, "_set_and_save_resource", path, property, old_value)
+	# _set_and_save_resource lives on the router, not this handler — target _router
+	# so the UndoRedo actually invokes it (else the set silently never runs).
+	ur.add_do_method(_router, "_set_and_save_resource", path, property, new_value)
+	ur.add_undo_method(_router, "_set_and_save_resource", path, property, old_value)
 	ur.commit_action()
 	return _router._ok({
 		"resource_path": path,

--- a/tests/unit/test_resources_handler_undoredo_target.py
+++ b/tests/unit/test_resources_handler_undoredo_target.py
@@ -1,0 +1,34 @@
+"""Regression guard for the set_resource_property UndoRedo target (#263/#268).
+
+``_set_and_save_resource`` is defined on the command router, not on the resources
+handler. The handler must register its UndoRedo do/undo against ``_router`` — if it
+targets ``self`` (as it once did), the method resolves to nothing and the set
+silently never runs.
+
+The addon is GDScript and can't execute in CI (no editor), so this pins the fix
+at the source level instead — cheap, CI-runnable, and enough to catch a
+reintroduction of the wrong-target bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RESOURCES_GD = (
+    Path(__file__).resolve().parents[2]
+    / "godot"
+    / "addons"
+    / "godot_mcp"
+    / "handlers"
+    / "resources.gd"
+)
+
+
+def test_set_resource_property_undoredo_targets_router() -> None:
+    src = _RESOURCES_GD.read_text(encoding="utf-8")
+    # Must invoke the router-defined helper on _router...
+    assert 'add_do_method(_router, "_set_and_save_resource"' in src
+    assert 'add_undo_method(_router, "_set_and_save_resource"' in src
+    # ...and never on self (where the method does not exist → silent no-op).
+    assert 'add_do_method(self, "_set_and_save_resource"' not in src
+    assert 'add_undo_method(self, "_set_and_save_resource"' not in src


### PR DESCRIPTION
### **User description**
Part of #263 — the last of the addon bugs.

## Root cause

`cmd_set_resource_property` registered:
```gdscript
ur.add_do_method(self, "_set_and_save_resource", path, property, new_value)
```
but `_set_and_save_resource` is defined on **`MCPCommandRouter`**, not on the `MCPResourcesHandlers` instance (`self`). So the do/undo methods targeted an object without that method — the action committed but **never mutated or saved** the resource. The handler still returned `ok` (it re-reads the value afterward, which was unchanged), so the failure was silent: the test set `size` to `{10,20}` and re-read `{4,5}`. No stderr error.

## Fix

Target `_router` (where the helper lives) for both the do and undo methods.

## Verification

```
test_resource_files_e2e.py::test_live_resource_workflow PASSED   (live Godot 4.7)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed resource property persistence issue

- Corrected UndoRedo method targeting in resource handler

- Resolved silent failure in set_resource_property command

- Enabled e2e tests to pass with Godot 4.7


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCPResourcesHandlers"] -- "add_do_method" --> B["_router"]
  A -- "add_undo_method" --> B
  B -- "_set_and_save_resource" --> C["Resource Persistence"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resources.gd</strong><dd><code>Fix resource property persistence bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/resources.gd

<ul><li>Corrected UndoRedo method targeting from <code>self</code> to <code>_router</code><br> <li> Fixed <code>_set_and_save_resource</code> call to target the correct object<br> <li> Resolved silent failure where resource properties were not persisted<br> <li> Enabled proper undo/redo functionality for resource property changes</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/268/files#diff-ca2728fb0062aa5af4069b7cddcbd102924ff530de4a547f020200d2ffec0860">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

