### PR TITLE
Add --quit-after watchdog to prevent smoke process leaks

### DIFF
--- a/tests/integration/_godot.py
+++ b/tests/integration/_godot.py
@@ -36,13 +36,29 @@ def find_godot() -> str | None:
 GODOT_BIN = find_godot()
 
 
+# Engine-side watchdog: Godot quits after this many main-loop iterations no matter
+# what, so an orphaned headless run (parent pytest killed mid-smoke, where the
+# subprocess timeout can never fire) self-terminates instead of leaking. Far above
+# any legit smoke's frame budget (the heaviest quits itself after ~3 frames), and an
+# idle/errored loop burns through it near-instantly, so normal runs are unaffected.
+QUIT_AFTER_FRAMES = 1800
+
+
 def run_godot(args: list[str], timeout: int = 120) -> subprocess.CompletedProcess[str]:
     """Run the Godot binary against the addon project and capture output.
 
-    ``args`` are appended after ``--headless --path <godot project>``.
+    ``args`` are appended after ``--headless --quit-after <n> --path <godot project>``.
     """
     assert GODOT_BIN is not None, "run_godot called without a Godot binary"
-    cmd = [GODOT_BIN, "--headless", "--path", str(GODOT_PROJECT), *args]
+    cmd = [
+        GODOT_BIN,
+        "--headless",
+        "--quit-after",
+        str(QUIT_AFTER_FRAMES),
+        "--path",
+        str(GODOT_PROJECT),
+        *args,
+    ]
     return subprocess.run(
         cmd,
         capture_output=True,

--- a/tests/unit/test_godot_runner_watchdog.py
+++ b/tests/unit/test_godot_runner_watchdog.py
@@ -1,0 +1,37 @@
+"""run_godot must pass an engine-side ``--quit-after`` watchdog.
+
+The smoke runner's ``subprocess.run`` timeout only fires while the parent test
+process is alive. If a pytest run is interrupted mid-smoke, the headless Godot
+child is orphaned and the timeout can never fire — leaking a process that runs
+until it quits on its own (observed: smoke editors alive for days). Passing
+``--quit-after`` makes the engine self-terminate even when orphaned.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import tests.integration._godot as godot
+
+
+def test_run_godot_passes_quit_after_watchdog() -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+        captured["cmd"] = cmd
+        return mock.Mock(returncode=0, stdout="", stderr="")
+
+    with (
+        mock.patch.object(godot, "GODOT_BIN", "/fake/godot"),
+        mock.patch("tests.integration._godot.subprocess.run", side_effect=fake_run),
+    ):
+        godot.run_godot(["--script", "res://tests/x_smoke.gd"])
+
+    cmd = captured["cmd"]
+    assert "--quit-after" in cmd, f"watchdog flag missing from command: {cmd}"
+    # The frame count must follow the flag and be a positive integer.
+    n = cmd[cmd.index("--quit-after") + 1]
+    assert int(n) > 0
+    # The original args must still be present.
+    assert "--script" in cmd and "res://tests/x_smoke.gd" in cmd


### PR DESCRIPTION
### **User description**
Part of #263 — the process-leak hardening.

## Problem

The smoke runner (`run_godot`, used by `tests/integration/test_addon_*.py`) relies on `subprocess.run(timeout=120)`. That timeout only fires while the **parent pytest process is alive**. If a run is interrupted mid-smoke (session crash, Ctrl-C, harness kill), the headless Godot child is orphaned and the timeout can never fire — observed as smoke editors (`theme_read_smoke`, `audio_bus_capture_smoke`) left running for **days**, holding the project and re-emitting `.uid` files.

## Fix

Pass an engine-side `--quit-after <frames>` watchdog so Godot self-terminates even when orphaned (cross-platform; no reliable parent-death signal on macOS otherwise). `QUIT_AFTER_FRAMES = 1800` is far above any legitimate smoke's budget (the heaviest, `input_inject_smoke`, quits itself after ~3 frames; the rest quit in `_initialize`), and an idle/errored loop burns through it near-instantly — so normal runs are unaffected.

## Verification

- New unit test (CI-runnable, mocks `subprocess.run`) pins that `run_godot` includes `--quit-after`.
- All 6 `run_godot`-based smoke tests pass with the watchdog against live Godot 4.7.
- `ruff`/`mypy` clean.

## Scope

- Hardens the **`--script` smoke runner** (the observed leak source). The e2e `--editor` tests spawn via `Popen` with a correct terminate/wait/kill teardown; adding `--quit-after` to a long editor session risks cutting a test mid-run, so they're intentionally left as-is.
- CI coverage for these suites (so drift/regressions are caught automatically) is tracked separately in #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Adds engine-side watchdog to prevent process leaks

- Hardens smoke runner against orphaned Godot processes

- Ensures CI-runnable test validates watchdog flag inclusion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run_godot()"] -- "adds --quit-after" --> B["Godot engine"]
  B -- "self-terminates on idle" --> C["Prevents leaks"]
  D["test_run_godot_passes_quit_after_watchdog"] -- "validates flag presence" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_godot.py</strong><dd><code>Add engine watchdog to prevent process leaks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/_godot.py

<ul><li>Added QUIT_AFTER_FRAMES constant set to 1800<br> <li> Modified run_godot() to include --quit-after flag in command<br> <li> Engine-side watchdog ensures Godot self-terminates when orphaned</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/270/files#diff-0ccb101f0e9d1b2c7eec57d968ab721ce4f08b6a793cc5fa2cefa730258d4129">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_godot_runner_watchdog.py</strong><dd><code>Add CI-runnable test for watchdog validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_godot_runner_watchdog.py

<ul><li>Added new unit test for validating --quit-after flag inclusion<br> <li> Mocks subprocess.run to capture command and verify flag presence<br> <li> Tests that watchdog flag is properly passed through run_godot()</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/270/files#diff-d248359e82bd32902e93520a588375f200e5b0faed736bcb7ad0ac6f7d9957cf">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

