### PR TITLE
Add CI workflow for live-editor e2e tests on self-hosted Godot runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,10 +60,10 @@ jobs:
       # Provided by the runner image, or override with the GODOT_BIN repo variable.
       GODOT_BIN: ${{ vars.GODOT_BIN || '/opt/godot/godot' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.1
         with:
           enable-cache: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,75 @@
+# Live-editor end-to-end suites — the coverage the GitHub-hosted `ci` job can't
+# provide. The e2e (`test_*_e2e.py`) and addon-smoke (`test_addon_*.py`) tests are
+# gated `skipif(GODOT_BIN is None)`, so on `ubuntu-latest` they silently skip.
+# This job runs them on a SELF-HOSTED runner that has a Godot editor binary —
+# closing the CI gap behind #263/#269.
+#
+# RUNNER REQUIREMENTS (k3s self-hosted, label `godot`):
+#   - Godot 4.7 *editor* binary (not the export-template/server build — the suites
+#     need `--editor`). Runs fully headless via `--headless` (dummy display/audio).
+#   - Python 3.11+ and uv available (or installed by the steps below).
+#   - The binary path is `$GODOT_BIN` — set the `GODOT_BIN` repo/org Actions
+#     variable, or bake it at the default path below in the runner image.
+# The eval workflow uses the same self-hosted convention (label `godot-eval`); a
+# single runner can carry both labels if it has Godot installed.
+name: e2e
+
+on:
+  pull_request:
+    # Editor suites validate the addon + bridge + server; skip doc-only churn.
+    paths:
+      - "godot/**"
+      - "mcp_server/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/e2e.yml"
+  workflow_dispatch:
+
+# One in-flight run per ref; cancel superseded PR pushes so the runner isn't queued up.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  editor-suites:
+    name: live editor (e2e + addon smoke)
+    runs-on: [self-hosted, godot]
+    timeout-minutes: 20
+    env:
+      # Provided by the runner image, or override with the GODOT_BIN repo variable.
+      GODOT_BIN: ${{ vars.GODOT_BIN || '/opt/godot/godot' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Show Godot version
+        run: '"$GODOT_BIN" --version'
+
+      - name: Warm asset import
+        # Populate .godot/ once so the editor doesn't import on first launch mid-test
+        # (the suites' connect-retry covers a cold start, but this removes the flake).
+        # Best-effort: unrelated import warnings must not fail the run.
+        run: 'timeout 180 "$GODOT_BIN" --headless --import --path godot/ || true'
+
+      - name: Editor e2e + addon smoke suites
+        # The two globs match exactly the editor-dependent integration tests
+        # (everything gated on GODOT_BIN / using run_godot); new e2e files are
+        # picked up automatically. -p no:cacheprovider keeps the runner workspace clean.
+        run: >-
+          uv run pytest -q -p no:cacheprovider
+          tests/integration/test_*_e2e.py
+          tests/integration/test_addon_*.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,13 @@
 #     variable, or bake it at the default path below in the runner image.
 # The eval workflow uses the same self-hosted convention (label `godot-eval`); a
 # single runner can carry both labels if it has Godot installed.
+#
+# SECURITY (public repo): a self-hosted runner must never execute untrusted fork
+# code. The job below is guarded so only same-repo branch PRs, manual dispatch, and
+# the nightly schedule run on the runner — fork PRs skip it. Also set the repo
+# Actions setting "Require approval for all outside collaborators" and prefer an
+# ephemeral runner (fresh pod per job) so a run can't persist state or reach the
+# co-located `godot-eval` runner's credentials.
 name: e2e
 
 on:
@@ -25,6 +32,8 @@ on:
       - "uv.lock"
       - ".github/workflows/e2e.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC nightly regression safety net
 
 # One in-flight run per ref; cancel superseded PR pushes so the runner isn't queued up.
 concurrency:
@@ -38,6 +47,14 @@ jobs:
   editor-suites:
     name: live editor (e2e + addon smoke)
     runs-on: [self-hosted, godot]
+    # SECURITY (public repo + self-hosted runner): never execute untrusted fork code
+    # on the runner. Only same-repo branch PRs, manual dispatch, and the schedule run;
+    # fork PRs skip this job (it reports as skipped, non-blocking). Defense-in-depth on
+    # top of the repo setting "Require approval for all outside collaborators"; prefer
+    # an ephemeral runner so each run starts from a clean pod.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
     env:
       # Provided by the runner image, or override with the GODOT_BIN repo variable.
@@ -56,8 +73,16 @@ jobs:
       - name: Sync dependencies
         run: uv sync --frozen
 
-      - name: Show Godot version
-        run: '"$GODOT_BIN" --version'
+      - name: Verify Godot version (pinned to 4.7)
+        # The suites are validated against the version the godot/ project declares
+        # (config/features=PackedStringArray("4.7")). Fail fast if the runner drifts.
+        run: |
+          ver="$("$GODOT_BIN" --version)"
+          echo "Godot: $ver"
+          case "$ver" in
+            4.7*) ;;
+            *) echo "::error::expected Godot 4.7.x on the runner, got '$ver'"; exit 1 ;;
+          esac
 
       - name: Warm asset import
         # Populate .godot/ once so the editor doesn't import on first launch mid-test


### PR DESCRIPTION
### **User description**
Closes the repo side of #269 — gives the live-editor suites real CI coverage so the #263 class of drift/regressions is caught automatically.

## What

A new `e2e` workflow (`.github/workflows/e2e.yml`) that runs the editor-dependent tests on a **self-hosted runner** (`runs-on: [self-hosted, godot]`) — the same convention `eval.yml` already established with `godot-eval`. On `ubuntu-latest` these are `skipif(GODOT_BIN is None)` and silently skip; here they actually run.

- **Selection:** two globs — `tests/integration/test_*_e2e.py` + `tests/integration/test_addon_*.py` — which match *exactly* the GODOT_BIN-gated / `run_godot` tests (verified), so new e2e files are picked up automatically.
- **Warm import:** `godot --headless --import` before the suite to populate `.godot/` and avoid first-launch import flakes (the suites' connect-retry covers cold start, but this removes the race).
- **`GODOT_BIN`:** from the runner image at `/opt/godot/godot`, overridable via the `GODOT_BIN` repo Actions variable.
- **Triggers:** `pull_request` (code paths only — skips doc-only churn) + `workflow_dispatch`. Concurrency cancels superseded PR runs.

## Runner requirements (k3s, label `godot`)

- Godot **4.7 editor** binary (not the server/export-template build — the suites need `--editor`); runs fully headless.
- Python 3.11+ / uv (the steps install uv).
- A single runner can carry both `godot` and `godot-eval` labels if it has Godot.

## Notes

- Until a `godot`-labeled runner is registered, this job stays **queued** and is **non-blocking** (it's not a required check unless added to branch protection) — so this can merge before or after the runner is deployed.
- The runner image (`docker/runner.Dockerfile`) and the k3s deployment (ARC `RunnerDeployment` or plain) are the next pieces — happy to write those once you confirm ARC-vs-plain and whether the existing `godot-eval` runner can be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds CI coverage for live-editor e2e tests

- Runs tests on self-hosted Godot runner

- Includes warm import step to avoid first-launch flakes

- Enables detection of handler regressions and Godot 4.7 drift


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pull Request"] -- "Triggers" --> B["e2e Workflow"]
  B -- "Runs on" --> C["Self-Hosted Godot Runner"]
  C -- "Checks out code" --> D["Install uv & Python"]
  D -- "Sync deps" --> E["Warm import assets"]
  E -- "Run tests" --> F["Editor e2e + addon smoke suites"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e.yml</strong><dd><code>New CI workflow for e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e.yml

<ul><li>Introduces a new GitHub Actions workflow for running live-editor <br>end-to-end tests<br> <li> Configures job to run on self-hosted Godot runner with required <br>dependencies<br> <li> Adds warm import step to avoid first-launch flakes during test <br>execution<br> <li> Sets up test suite selection to match existing GODOT_BIN-gated tests</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/271/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e">+75/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

