### PR TITLE
Fix resource persistence and navigation handler hangs in MCP addon

### DIFF
--- a/tests/integration/test_addon_script_check.py
+++ b/tests/integration/test_addon_script_check.py
@@ -1,0 +1,53 @@
+"""Headless compile/load gate for every addon script.
+
+Runs ``godot --check-only`` over each ``.gd`` under the addon and fails if any
+emits a parse/compile error. This localizes a broken script to a precise file and
+message in CI, rather than surfacing only as a plugin-load / bridge-connect
+failure in the e2e suites.
+
+Scope note: at the project's default GDScript warning settings this catches hard
+parse/compile errors (syntax, undeclared identifiers, bad signatures) — NOT the
+"method/property absent on a typed value" class behind #265/#266. That class is an
+``unsafe_method_access`` *warning* that GDScript cannot distinguish from the
+addon's intentional dynamic access (``Variant`` params, subtype access after an
+``is`` check), so it can't be promoted to an error project-wide. The behavioral
+safety net for that class is the live e2e suite (#269/#271).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT, run_godot
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+# Substrings that signal a parse/compile failure (and a warning-treated-as-error,
+# in case warnings are ever promoted).
+_FAIL_MARKERS = ("Parse Error", "Parse error", "Failed to load script", "treated as error")
+
+_ADDON_DIR = GODOT_PROJECT / "addons" / "godot_mcp"
+
+
+def _res_path(gd_path: Path) -> str:
+    return "res://" + gd_path.relative_to(GODOT_PROJECT).as_posix()
+
+
+def test_all_addon_scripts_compile() -> None:
+    scripts = sorted(_ADDON_DIR.rglob("*.gd"))
+    assert scripts, "no addon scripts found — wrong path?"
+
+    failures: list[str] = []
+    for gd in scripts:
+        res = _res_path(gd)
+        result = run_godot(["--check-only", "--script", res])
+        output = f"{result.stdout}\n{result.stderr}"
+        if any(marker in output for marker in _FAIL_MARKERS):
+            detail = "\n".join(
+                line for line in output.splitlines() if any(m in line for m in _FAIL_MARKERS)
+            )
+            failures.append(f"{res}:\n{detail}")
+
+    assert not failures, "addon scripts failed --check-only:\n\n" + "\n\n".join(failures)

--- a/tests/integration/test_addon_script_check.py
+++ b/tests/integration/test_addon_script_check.py
@@ -44,10 +44,35 @@ def test_all_addon_scripts_compile() -> None:
         res = _res_path(gd)
         result = run_godot(["--check-only", "--script", res])
         output = f"{result.stdout}\n{result.stderr}"
-        if any(marker in output for marker in _FAIL_MARKERS):
-            detail = "\n".join(
-                line for line in output.splitlines() if any(m in line for m in _FAIL_MARKERS)
+        # Primary signal: Godot prints "Parse Error"/"Failed to load script" but still
+        # exits 0 on a compile error (see test_gate_catches_a_broken_script), so the
+        # markers — not the exit code — are what catch a broken script. A non-zero exit
+        # is treated as a failure too, to catch a crash / missing-script / bad invocation
+        # that wouldn't print a known marker.
+        if result.returncode != 0 or any(marker in output for marker in _FAIL_MARKERS):
+            detail = (
+                "\n".join(
+                    line for line in output.splitlines() if any(m in line for m in _FAIL_MARKERS)
+                )
+                or f"exit code {result.returncode} with no recognized marker"
             )
             failures.append(f"{res}:\n{detail}")
 
     assert not failures, "addon scripts failed --check-only:\n\n" + "\n\n".join(failures)
+
+
+def test_gate_catches_a_broken_script() -> None:
+    """Negative control: a script with a real parse error trips the markers — proving the
+    gate isn't a silent no-op. (Godot's --check-only exits 0 even here, which is exactly
+    why test_all_addon_scripts_compile keys off the markers, not the exit code.)"""
+    bad = GODOT_PROJECT / "tests" / "_tmp_broken_check.gd"
+    bad.write_text("extends Node\nfunc _ready() ->:\n\tpass\n", encoding="utf-8")
+    try:
+        result = run_godot(["--check-only", "--script", _res_path(bad)])
+        output = f"{result.stdout}\n{result.stderr}"
+        assert any(marker in output for marker in _FAIL_MARKERS), (
+            f"the gate did not flag a deliberately-broken script:\n{output}"
+        )
+    finally:
+        bad.unlink(missing_ok=True)
+        (bad.parent / (bad.name + ".uid")).unlink(missing_ok=True)


### PR DESCRIPTION
### **User description**
Part of #269. Adds a headless **compile/load gate** for the addon — the achievable half of the "harden against the bug class" work.

## What

`tests/integration/test_addon_script_check.py` runs `godot --check-only` over every `addons/godot_mcp/**/*.gd` and fails on any parse/compile error, with the precise file + message. GODOT_BIN-gated, so it runs on the self-hosted runner (#271) next to the editor suites. Verified: passes on the clean addon (~10s for 45 scripts), fails on an injected syntax error.

## Honest scope — warnings-as-errors was investigated and rejected

I tested promoting `unsafe_method_access`/`unsafe_property_access` to errors to catch the #265/#266 class (`shader.has_node()`, `_router._valid_bits()`) statically. It requires `exclude_addons=false` (addon scripts are exempt by default) — and then **41/45 addon scripts fail**, almost all on *legitimate* dynamic access this generic command router is built on:

- `.get()`/`.has()`/`.is_empty()`/`.append()` on `Variant` (from `params.get(...)`)
- subtype members (`node.process_material`, `node.collision_layer`, …) on a `Node`-typed var **after** a runtime `is` check

GDScript's analyzer can't tell those apart from the real bugs (same `unsafe_method_access` warning, "may be present on a subtype"), so making it an error would mean casting through ~41 files — bloating the thin handlers for marginal gain over the e2e runner, which already catches these behaviorally.

**Net:** the live e2e runner (#271) remains the real safety net for that bug class; string-dispatch bugs (e.g. #268's wrong UndoRedo target) keep their cheap structural guards; this gate adds fast, precise coverage for the *compile* class.

If you want full static safety later, type-hardening the addon (cast all dynamic access) could be its own tracked effort — happy to open an issue, though I'd weigh it against the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed resource property persistence in MCP addon

- Resolved navigation handler hang due to missing router helpers

- Added compile/load gate for addon scripts

- Enabled e2e tests to pass with Godot 4.7


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCPResourcesHandlers"] -- "add_do_method" --> B["_router"]
  A -- "add_undo_method" --> B
  C["navigation.gd"] -- "calls _router._valid_bits()" --> B
  D["physics.gd"] -- "calls _router._bitmask()" --> B
  E["command_router.gd"] -- "contains _valid_bits, _bitmask" --> B
  F["test_addon_script_check.py"] -- "compile gate" --> G["Addon scripts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_addon_script_check.py</strong><dd><code>Add compile/load gate for addon scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_addon_script_check.py

<ul><li>Added headless compile/load gate for addon scripts<br> <li> Runs <code>godot --check-only</code> over every <code>.gd</code> file in addon<br> <li> Fails on any parse/compile error with precise file+message<br> <li> Skipped if GODOT_BIN is not available</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/272/files#diff-66b6193c5f0d539f373c85c4f3a5e5b70cf4eda501fc6e6e451e9c471de44438">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command_router.gd</strong><dd><code>Add shared bit validation and conversion helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/command_router.gd

<ul><li>Added <code>_valid_bits</code> function to validate bit indices in [1, 32]<br> <li> Added <code>_bitmask</code> function to convert array of bit indices into bitmask <br>integer<br> <li> These functions are now shared across handlers using 1-based bit <br>indices</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>physics.gd</strong><dd><code>Refactor physics handler to use router helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/physics.gd

<ul><li>Updated <code>_cmd_set_physics_layers</code> to call router helpers instead of <br>local copies<br> <li> Removed duplicate <code>_valid_bits</code> and <code>_bitmask</code> functions from physics <br>handler<br> <li> Ensures consistency with navigation handler usage</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resources.gd</strong><dd><code>Fix resource property persistence bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/resources.gd

<ul><li>Fixed <code>cmd_set_resource_property</code> to target <code>_router</code> for do/undo methods<br> <li> Corrected UndoRedo method targeting from <code>self</code> to <code>_router</code><br> <li> Resolved silent failure where resource properties were not persisted<br> <li> Enabled proper undo/redo functionality for resource property changes</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

