### PR TITLE
fix(bridge): reconnect supervisor so editor start order doesn't matter (closes #274)

### DIFF
--- a/mcp_server/bridge.py
+++ b/mcp_server/bridge.py
@@ -24,6 +24,10 @@ from mcp_server.models.envelope import CommandEnvelope, ErrorCode, ResponseEnvel
 
 logger = logging.getLogger(__name__)
 
+# How often the stay_connected supervisor polls for a dropped link while connected.
+# Bounds the reconnect latency after the editor closes/restarts; cheap on localhost.
+_SUPERVISE_POLL_SECONDS = 1.0
+
 
 class Connection(Protocol):
     """The minimal transport the bridge needs (a WebSocket connection)."""
@@ -66,10 +70,29 @@ class Bridge:
         self._reader: asyncio.Task[None] | None = None
         self._pending: dict[str, asyncio.Future[ResponseEnvelope]] = {}
         self._counter = 0
+        self._connect_lock = asyncio.Lock()
 
     @property
     def connected(self) -> bool:
         return self._conn is not None
+
+    async def _ensure_connected(self) -> bool:
+        """(Re)connect on demand when disconnected, so a server that started *before*
+        the Godot editor — or one whose link dropped — recovers on the next ``send``
+        instead of staying dead until restart (the common "MCP not connecting in Godot"
+        case). Concurrency-safe: only one connect attempt runs at a time and the others
+        await its outcome. A single best-effort attempt (the next send retries); never
+        raises."""
+        if self._conn is not None:
+            return True
+        async with self._connect_lock:
+            if self._conn is not None:  # another send connected while we waited
+                return True
+            try:
+                await self.connect()
+            except (ConnectionError, OSError, TimeoutError):
+                return False
+            return True
 
     async def connect(self) -> None:
         """Open a single connection and start the response reader."""
@@ -93,6 +116,29 @@ class Bridge:
                 logger.debug("bridge reconnect", extra={"attempt": attempt, "delay": delay})
                 await self._sleep(delay)
 
+    async def stay_connected(self) -> None:
+        """Background supervisor: keep a live link to the addon, (re)connecting with
+        backoff whenever it is down.
+
+        This is what makes the start order not matter: the server commonly boots
+        *before* the Godot editor/addon is listening (the usual "MCP not connecting in
+        Godot" cause), and a single startup connect would then stay dead forever. The
+        supervisor reconnects as soon as the editor appears — and again if the link
+        drops — so ``connected`` reflects reality for preconditions, health, and the
+        dock without any per-call work. Runs until cancelled; only cancellation escapes.
+        """
+        attempt = 0
+        while True:
+            if self._conn is None:
+                if await self._ensure_connected():
+                    attempt = 0
+                else:
+                    delay = compute_delay(self._policy, attempt, self._rand())
+                    attempt += 1
+                    await self._sleep(delay)
+                    continue
+            await self._sleep(_SUPERVISE_POLL_SECONDS)
+
     async def close(self) -> None:
         """Close the connection and fail any in-flight requests."""
         if self._reader is not None:
@@ -114,10 +160,12 @@ class Bridge:
         Returns a structured ``ResponseEnvelope`` for every outcome — including
         a disconnected bridge or a timed-out request — never raising.
         """
-        if self._conn is None:
+        if self._conn is None and not await self._ensure_connected():
             return ResponseEnvelope.failure(
                 "-", ErrorCode.BRIDGE_DISCONNECTED, "Godot bridge is not connected."
             )
+        conn = self._conn
+        assert conn is not None  # _ensure_connected() set it (or we returned above)
 
         msg_id = self._next_id()
         envelope = CommandEnvelope(id=msg_id, command=command, params=params or {})
@@ -125,7 +173,7 @@ class Bridge:
         self._pending[msg_id] = future
 
         try:
-            await self._conn.send(envelope.model_dump_json())
+            await conn.send(envelope.model_dump_json())
         except Exception:
             # The transport dropped mid-send: don't leak the waiter or raise.
             self._pending.pop(msg_id, None)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -11,9 +11,10 @@ missing editor never blocks the server) and closes on shutdown
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 
 from fastmcp import FastMCP
 
@@ -90,13 +91,20 @@ def create_server(
             logger.info("bridge connected", extra={"url": config.bridge.url})
         except Exception:
             logger.warning(
-                "bridge not connected at startup; continuing (check the editor/addon)",
+                "bridge not connected at startup; retrying in the background "
+                "(check the editor/addon)",
                 extra={"url": config.bridge.url},
                 exc_info=True,
             )
+        # Keep (re)connecting in the background so the editor start order doesn't matter
+        # and a dropped link self-heals — the server often boots before Godot is up.
+        supervisor = asyncio.create_task(bridge.stay_connected())
         try:
             yield
         finally:
+            supervisor.cancel()
+            with suppress(asyncio.CancelledError):
+                await supervisor
             await bridge.close()
 
     mcp = FastMCP(

--- a/tests/contract/test_bridge_envelope.py
+++ b/tests/contract/test_bridge_envelope.py
@@ -19,6 +19,7 @@ from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
 from tests.fakes import (
     FakeAddonConnection,
     connector_for,
+    flaky_connector,
     immediate_sleep,
     ping_responder,
 )
@@ -108,8 +109,14 @@ async def test_timeout_returns_timeout_envelope() -> None:
 
 
 async def test_send_without_connection_is_structured_error() -> None:
-    bridge = Bridge(BridgeConfig())  # never connected
-    resp = await bridge.send("ping")
+    # Addon unreachable: the lazy reconnect attempt fails, so send returns a structured
+    # BRIDGE_DISCONNECTED (never raises). A failing fake connector keeps this hermetic —
+    # the default real-socket connector would otherwise reach a live editor on :9080.
+    bridge = Bridge(
+        BridgeConfig(),
+        connector=flaky_connector(fail_times=99, connection=FakeAddonConnection()),
+    )
+    resp = await bridge.send("cmd_ping")
     assert resp.ok is False
     assert resp.error == "BRIDGE_DISCONNECTED"
 

--- a/tests/unit/test_bridge_reconnect.py
+++ b/tests/unit/test_bridge_reconnect.py
@@ -1,0 +1,86 @@
+"""Bridge lazy-reconnect on send.
+
+Regression for the most common "MCP not connecting in Godot" failure: the server
+process starts *before* the Godot editor/addon is listening, so the one-shot startup
+``connect()`` fails — and without lazy reconnect every later ``send()`` returns
+``BRIDGE_DISCONNECTED`` forever, even once the addon is up. A send must transparently
+(re)connect instead of staying dead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import ErrorCode
+from tests.fakes import FakeAddonConnection, flaky_connector
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _yield_sleep(_seconds: float) -> None:
+    """A backoff sleep that yields to the loop without real delay (deterministic)."""
+    await asyncio.sleep(0)
+
+
+async def test_send_reconnects_after_failed_startup_connect() -> None:
+    # Startup connect fails (Godot not up yet); the addon comes up before the first
+    # send. That send must reconnect and succeed — not return BRIDGE_DISCONNECTED.
+    bridge = Bridge(
+        BridgeConfig(),
+        connector=flaky_connector(fail_times=1, connection=FakeAddonConnection()),
+    )
+    with pytest.raises(ConnectionError):
+        await bridge.connect()  # the one-shot startup attempt, while Godot is down
+    assert bridge.connected is False
+
+    resp = await bridge.send("cmd_ping")
+    assert resp.ok, f"send should have reconnected, got {resp.error}"
+    assert resp.result == {"pong": True}
+    assert bridge.connected is True
+    await bridge.close()
+
+
+async def test_send_still_fails_cleanly_when_addon_stays_down() -> None:
+    # When the addon really is unreachable, send still returns a structured
+    # BRIDGE_DISCONNECTED (never raises) — the reconnect attempt just fails.
+    bridge = Bridge(
+        BridgeConfig(),
+        connector=flaky_connector(fail_times=99, connection=FakeAddonConnection()),
+    )
+    with pytest.raises(ConnectionError):
+        await bridge.connect()
+
+    resp = await bridge.send("cmd_ping")
+    assert not resp.ok
+    assert resp.error == ErrorCode.BRIDGE_DISCONNECTED
+    assert bridge.connected is False
+
+
+async def test_stay_connected_supervisor_connects_once_addon_comes_up() -> None:
+    # The server boots before Godot: the supervisor must connect on its own once the
+    # addon is listening, so `connected` flips to True for preconditions/health/dock
+    # with no tool call. flaky_connector fails twice (Godot still down), then connects.
+    bridge = Bridge(
+        BridgeConfig(),
+        connector=flaky_connector(fail_times=2, connection=FakeAddonConnection()),
+        sleep=_yield_sleep,
+        rand=lambda: 0.0,
+    )
+    assert bridge.connected is False
+    supervisor = asyncio.create_task(bridge.stay_connected())
+    try:
+        for _ in range(100):  # let the supervisor tick; it connects within a few
+            if bridge.connected:
+                break
+            await asyncio.sleep(0)
+        assert bridge.connected is True
+    finally:
+        supervisor.cancel()
+        with suppress(asyncio.CancelledError):
+            await supervisor
+        await bridge.close()


### PR DESCRIPTION
## Symptom

"The MCP is not connecting in Godot" — the dock / client shows the bridge **disconnected** even though the addon is enabled and listening, so no tools work.

## Root cause (diagnosed, not guessed)

The server connects to the bridge **once** at startup (`lifespan` → `bridge.connect()`, best-effort). If the server process starts **before** Godot is listening — the common case (the MCP client spawns the server on load; the user opens Godot afterward) — that single attempt fails and the server stays **permanently disconnected**:

- `Bridge.send()` returns `BRIDGE_DISCONNECTED` whenever `_conn is None`, never reconnecting;
- `require_bridge_connected` (precondition on ~6 tools) fail-fasts on the same `connected` property;
- `connect_with_retry`/backoff existed but was **never wired into the live path**.

Contradicts the documented contract (`CLAUDE.md` + `.claude/rules/async-patterns.md`: "Reconnect on bridge failure with exponential backoff").

**Evidence:** locally the server started 74s *before* Godot; a fresh `Bridge.connect()` + `cmd_ping` against the same live addon succeeds — only the long-lived server was stuck. (The addon, bridge, and envelope are all fine.)

## Fix

- **`Bridge.stay_connected()`** — a background supervisor that (re)connects with backoff whenever the link is down, started from the server lifespan. Start order stops mattering and a dropped editor self-heals; `connected` reflects reality for preconditions, health, and the dock with **no caller changes**.
- **Lazy reconnect in `send()`** too — immediate recovery within a supervisor poll gap.
- **Startup behavior preserved** — a single best-effort connect still logs the warning, and health still reports disconnected when the addon is genuinely absent.

## Acceptance (#274)
- [x] A server started before Godot connects on its own once the editor is up — `test_stay_connected_supervisor_connects_once_addon_comes_up` + verified live against the running editor.
- [x] A send reconnects after a failed startup connect / dropped link — `test_send_reconnects_after_failed_startup_connect`.
- [x] Genuinely-absent addon still reports disconnected with the startup warning — existing `test_health_check_reports_disconnected_when_godot_absent` still green.

## Test plan
- New `tests/unit/test_bridge_reconnect.py` (3 tests: lazy reconnect, clean failure when down, supervisor reconnect — all hermetic via fake connectors).
- Fixed a latent test that reached a real editor on :9080 (now injects a failing fake connector).
- Full unit+contract suite **513 passed**; mypy + ruff + zero-skip clean; supervisor verified connecting to the live editor.

## Immediate workaround (for anyone hitting this before merge)
Restart the godot-mcp MCP server once Godot is already running (toggle/restart it in your client) — a fresh start connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)