### PR TITLE
chore(addon): track audio_bus_capture .uid sidecar(s)

### DIFF
--- a/godot/addons/godot_mcp/audio_bus_capture.gd.uid
+++ b/godot/addons/godot_mcp/audio_bus_capture.gd.uid
@@ -1,0 +1,1 @@
+uid://xp1k5v5kl7qu

--- a/godot/tests/audio_bus_capture_smoke.gd.uid
+++ b/godot/tests/audio_bus_capture_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://b3yssy5a7plxc


### PR DESCRIPTION
Commits the Godot UID sidecar(s) for the already-merged `audio_bus_capture` script(s) — generated by Godot but never committed (they were untracked in the working tree). Tracking `.uid` keeps resource UIDs stable across machines/checkouts (Godot 4.4+ best practice) and is consistent with the addon's other scripts, whose `.uid` are already tracked.

Artifact-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)