### PR TITLE
chore(addon): track input_action_read .uid sidecar(s)

### DIFF
--- a/godot/addons/godot_mcp/input_action_read.gd.uid
+++ b/godot/addons/godot_mcp/input_action_read.gd.uid
@@ -1,0 +1,1 @@
+uid://ckkm7b8dn86w8

--- a/godot/tests/input_action_read_smoke.gd.uid
+++ b/godot/tests/input_action_read_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://dovqcw5g30auf


### PR DESCRIPTION
Commits the Godot UID sidecar(s) for the already-merged `input_action_read` script(s) — generated by Godot but never committed (they were untracked in the working tree). Tracking `.uid` keeps resource UIDs stable across machines/checkouts (Godot 4.4+ best practice) and is consistent with the addon's other scripts, whose `.uid` are already tracked.

Artifact-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)