### PR TITLE
chore(addon): track theme_read .uid sidecar(s)

### DIFF
--- a/godot/addons/godot_mcp/theme_read.gd.uid
+++ b/godot/addons/godot_mcp/theme_read.gd.uid
@@ -1,0 +1,1 @@
+uid://d3jd8mro04c2m

--- a/godot/tests/theme_read_smoke.gd.uid
+++ b/godot/tests/theme_read_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://c5xhiywq2jig3


### PR DESCRIPTION
Commits the Godot UID sidecar(s) for the already-merged `theme_read` script(s) — generated by Godot but never committed (they were untracked in the working tree). Tracking `.uid` keeps resource UIDs stable across machines/checkouts (Godot 4.4+ best practice) and is consistent with the addon's other scripts, whose `.uid` are already tracked.

Artifact-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)