### PR TITLE
chore(addon): track run_commands_smoke .uid sidecar(s)

### DIFF
--- a/godot/tests/run_commands_smoke.gd.uid
+++ b/godot/tests/run_commands_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://cju5q0kjxuib8


### PR DESCRIPTION
Commits the Godot UID sidecar(s) for the already-merged `run_commands_smoke` script(s) — generated by Godot but never committed (they were untracked in the working tree). Tracking `.uid` keeps resource UIDs stable across machines/checkouts (Godot 4.4+ best practice) and is consistent with the addon's other scripts, whose `.uid` are already tracked.

Artifact-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)