### PR TITLE
docs: reflect the bridge inversion + add an architecture diagram (#276)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -37,5 +37,5 @@ MUST:
 
 ANTI-PATTERNS:
 - A second code path to Godot that bypasses the bridge envelope.
-- Hard-coded bridge URL/port inside library code (read from config; default `ws://localhost:9080`).
+- Hard-coded bridge URL/port inside library code (read from config / `GODOT_MCP_BRIDGE_URL`; default `ws://127.0.0.1:9080`).
 - `datetime.now()` / ambient time without injection.

--- a/.claude/rules/async-patterns.md
+++ b/.claude/rules/async-patterns.md
@@ -11,8 +11,8 @@ FastMCP runs an async server. The WebSocket bridge is the one place latency and 
 
 - All `@mcp.tool()` / `@mcp.resource()` handlers are `async def`. Never call `asyncio.run()` inside the server — the runtime owns the loop.
 - No blocking synchronous I/O inside `async def` (wrap unavoidable sync calls in an executor, with a comment).
-- The bridge client sets an explicit timeout on every request; a request that outlives its timeout resolves to a `TIMEOUT` envelope (see [[error-handling]]), it does not hang.
-- Reconnect on bridge failure with exponential backoff (start ~200ms, jitter, capped). A `ping`→`pong` health check confirms liveness.
+- The bridge sets an explicit timeout on every request; a request that outlives its timeout resolves to a `TIMEOUT` envelope (see [[error-handling]]), it does not hang.
+- The server **listens** for the editor and accepts one active peer (a new connection replaces the old); reconnection lives on the **addon** side, which dials out and retries with exponential backoff (#276). A `cmd_ping`→`{pong}` exchange confirms liveness. A send with no connected peer resolves to a `BRIDGE_DISCONNECTED` envelope, it does not hang.
 - Request/response correlation by `id` is concurrency-safe — many in-flight commands, each resolved to its own waiter. No shared mutable state across requests.
 - Pydantic-typed boundaries in and out (see [[mcp-tools]]).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,16 @@ The defining feature is a **four-layer transport chain** (issue #3). Every agent
 ```mermaid
 flowchart TD
     AI["AI client (Claude Code / OpenCode / any stdio MCP client)"]
-    SRV["FastMCP server (Python, mcp_server/)"]
-    ADDON["Godot EditorPlugin (GDScript, godot/addons/godot_mcp/)"]
+    SRV["FastMCP server (Python, mcp_server/) — WebSocket listener"]
+    ADDON["Godot EditorPlugin (GDScript, godot/addons/godot_mcp/) — WebSocket client (connects out, reconnects)"]
     PROJ["Live Godot project"]
     AI -->|"stdio (MCP protocol)"| SRV
-    SRV -->|"WebSocket — localhost, default ws://localhost:9080"| ADDON
+    ADDON ==>|"WebSocket connect (editor dials), default ws://127.0.0.1:9080"| SRV
+    SRV -.->|"{id, command, params}"| ADDON
     ADDON -->|"Godot Editor API"| PROJ
 ```
+
+The editor **dials** the connection (bold) and reconnects; the server still **initiates every command** (dashed). The bridge inversion (#276) changed only who connects, not the request/response direction.
 
 - **MCP server** (`mcp_server/`, Python 3.11+, FastMCP) — the AI-facing entry point over stdio. Exposes **tools**, **resources** (`godot://...` URIs, issue #11), and **prompts** (workflow templates, issue #12). It owns all safety/permission logic and Pydantic domain models; it holds **no** Godot logic itself — it forwards to the addon over the WebSocket bridge.
 - **Godot addon** (`godot/addons/godot_mcp/`, GDScript, Godot 4.4+) — an `EditorPlugin` (`@tool`) whose `WebSocketPeer` **client** connects out to the server's bridge listener and reconnects with backoff (#276), routes incoming command envelopes to `cmd_*` handlers that call the Godot Editor API, and shows a status dock. This is the *only* layer that touches Godot.
@@ -62,7 +65,7 @@ docs/                      architecture.md (bridge contract), tool-contracts.md
 
 These span many files and are the things easiest to get wrong:
 
-- **JSON envelopes** (issue #3) — versioned from day one. Command: `{ id, command, params }`. Response: `{ id, ok, result, error }`. Requests correlate by `id`. The bridge reconnects with exponential backoff; `ping`→`pong` is the health check.
+- **JSON envelopes** (issue #3) — versioned from day one. Command: `{ id, command, params }`. Response: `{ id, ok, result, error }`. Requests correlate by `id`. The addon (WebSocket client) reconnects to the server's listener with exponential backoff (#276); `cmd_ping`→`{pong}` is the health check.
 - **Structured errors, never stack traces** — failures return `{ ok: false, error, hint }`. Preconditions return a richer form: `{ ok: false, error: "PRECONDITION_FAILED", hint, required }` (issue #14). Errors must be actionable for an agent with no human in the loop.
 - **Tool safety classes** (issue #14) — every tool is tagged `read_only` | `mutating` | `destructive` | `runtime`. `mutating`/`destructive` tools take `dry_run: bool = False`; `destructive` tools require `confirm=True`. Common preconditions: `require_active_scene`, `require_bridge_connected`, `require_node_exists(path)`. All safety logic lives in the MCP layer, **not** the addon.
 - **UndoRedo for every mutation** (issue #6) — all create/rename/delete/set operations in the addon must register with `EditorUndoRedoManager`.
@@ -86,7 +89,7 @@ The scaffold (issue #1) is in place: `uv`-managed Python package, the addon unde
   - `uv run ruff check .` — lint; `uv run mypy` — type check.
   - `./.claude/hooks/check-no-skipped-tests.sh` — zero-skip suite-health gate.
 - Server entrypoint: `uv run godot-mcp` runs the live FastMCP server over stdio (or HTTP via `GODOT_MCP_TRANSPORT=http`, default `127.0.0.1:9090`). `godot_health_check`, `godot_get_server_info` (capability snapshot), and the toolset-gating tools are all shipped.
-- The addon is enabled via Godot's *Project Settings → Plugins* (open the `godot/` folder as a project); the bridge defaults to `ws://localhost:9080` (configurable). No auth in v1 (localhost-only).
+- The addon is enabled via Godot's *Project Settings → Plugins* (open the `godot/` folder as a project); the addon connects out to the server's bridge listener (default `ws://127.0.0.1:9080`, configurable via `GODOT_MCP_BRIDGE_URL` on both sides) and reconnects automatically. No auth in v1 (localhost-only).
 - Clients register the server as a local stdio MCP command: Claude Code via `.mcp.json` / `claude mcp add`, OpenCode via `opencode.json` (concrete examples in `README.md`).
 
 ## Output and Responses

--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ Every agent action crosses a four-layer chain:
 flowchart TD
     AI["AI client<br/>Claude Code · OpenCode · Cursor · any stdio MCP client"]
     SRV["FastMCP server · Python 3.11+ · <code>mcp_server/</code><br/>Pydantic schemas · safety classes · preconditions · no Godot logic"]
-    ADDON["Godot addon · GDScript · <code>godot/addons/godot_mcp/</code><br/>EditorPlugin: TCPServer + WebSocketPeer · routes cmd_* envelopes"]
+    ADDON["Godot addon · GDScript · <code>godot/addons/godot_mcp/</code><br/>EditorPlugin: WebSocketPeer client (connects out, reconnects) · routes cmd_* envelopes"]
     PROJ["Live Godot project"]
     AI -->|"stdio · MCP protocol (JSON-RPC)"| SRV
-    SRV -->|"WebSocket · ws://localhost:9080"| ADDON
+    ADDON ==>|"WebSocket connect (editor dials) · ws://127.0.0.1:9080"| SRV
+    SRV -.->|"{id, command, params}"| ADDON
     ADDON -->|"Godot Editor API"| PROJ
-    PROJ -.->|"result"| ADDON
     ADDON -.->|"{id, ok, result, error, hint}"| SRV
     SRV -.->|"typed tool result"| AI
 ```
+
+The **editor dials** the connection (bold arrow) and reconnects on its own; the **server still drives every command** (dashed `{id, command, …}`). Those two directions are decoupled — the bridge inversion (#276) only changed who connects.
 
 A single tool call — `godot_scene_edit_create_node` — travels the full chain and back:
 
@@ -131,7 +133,7 @@ cp -r godot/addons/godot_mcp /path/to/your/project/addons/
 
 Then in Godot: **Project → Project Settings → Plugins → godot_mcp → Enable**.
 
-A status dock appears (bottom panel). It shows connection state, project name, active scene, and selected node. The bridge listens on `ws://localhost:9080` by default.
+A status dock appears (bottom panel). It shows connection state, project name, active scene, and selected node. The addon connects out to the MCP server's bridge listener (`ws://127.0.0.1:9080` by default) and reconnects automatically — so editor and server can start in either order.
 
 ### 3. Configure your MCP client
 
@@ -225,7 +227,7 @@ Then enable the plugin in Project Settings.
 
 **What the addon provides:**
 - **Status dock** — read-only panel showing bridge state, project info, active scene, selected node, and recent commands
-- **WebSocket bridge** — listens on `ws://localhost:9080` (configurable)
+- **WebSocket bridge** — a client that connects out to the MCP server's listener at `ws://127.0.0.1:9080` (configurable) and reconnects with backoff
 - **Command router** — handles 80+ `cmd_*` commands that call the Godot Editor API
 - **Debugger plugin** — captures the `godot_mcp:` debugger channel for live game inspection
 - **Runtime probe** — `mcp_runtime_probe.gd`, an autoload you add to your game for live input/profiling
@@ -581,7 +583,7 @@ All configuration is optional and passed via environment variables:
 | `GODOT_MCP_TRANSPORT` | `stdio` | `stdio` or `http` |
 | `GODOT_MCP_HTTP_HOST` | `127.0.0.1` | HTTP bind host |
 | `GODOT_MCP_HTTP_PORT` | `9090` | HTTP bind port |
-| `GODOT_MCP_BRIDGE_URL` | `ws://localhost:9080` | Godot addon WebSocket URL |
+| `GODOT_MCP_BRIDGE_URL` | `ws://127.0.0.1:9080` | Bridge endpoint — the server **binds** it (listener) and the addon **connects** to it; set the same value on both sides |
 | `GODOT_MCP_GODOT_BIN` | auto-discovered | Godot executable for `godot_runtime_run_and_capture` / `godot_export_project` |
 | `GODOT_MCP_PROJECT_DIR` | connected editor's project | Project directory for runner, export, and analysis |
 | `GODOT_MCP_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) — JSON to stderr |
@@ -592,9 +594,9 @@ All configuration is optional and passed via environment variables:
 ## Troubleshooting
 
 ### "Godot bridge is not connected"
-- Ensure Godot is running with the **godot_mcp addon enabled** (status dock visible).
-- Check that nothing else is using port `9080`.
-- Check the Godot Output panel for WebSocket errors.
+- Ensure Godot is running with the **godot_mcp addon enabled** (status dock visible). The addon connects out to the server and reconnects automatically, so start order doesn't matter — give it a moment after either side starts.
+- Check that nothing else is using port `9080` (the **server** binds it; the addon dials in).
+- Check the Godot Output panel for WebSocket errors, and confirm both sides agree on `GODOT_MCP_BRIDGE_URL` if you changed it.
 
 ### "Toolset requires Godot 4.4+"
 - Upgrade to Godot 4.4 or newer. The addon checks version on enable.
@@ -631,7 +633,7 @@ godot/
   addons/godot_mcp/
     plugin.cfg                   # addon manifest (name, version, Godot 4.4+)
     godot_mcp.gd                 # EditorPlugin entry: dock, bridge, debugger
-    mcp_bridge.gd                # TCPServer + WebSocketPeer (receives envelopes)
+    mcp_bridge.gd                # WebSocketPeer client — connects out, reconnects, receives envelopes
     command_router.gd            # dispatches cmd_* → Godot API handlers
     mcp_dock.gd                  # read-only status dock
     scene_inspect.gd             # JSON-safe scene tree / node serialization
@@ -642,7 +644,7 @@ godot/
 mcp_server/                      # FastMCP server (Python 3.11+)
   main.py                        # stdio / Streamable-HTTP entrypoint
   server.py                      # server factory: bridge + all tool registrations
-  bridge.py                      # async WebSocket client (id correlation, timeout, reconnect)
+  bridge.py                      # async WebSocket listener (id correlation, timeout; the addon dials in)
   toolsets.py                    # gated toolset system
   categories.py                  # toolset tag constants
   safety.py                      # safety classes, preconditions, dry_run/confirm

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,9 +20,19 @@ The server listens on `http://localhost:9090`.
 
 ## Bridge networking
 
-The default `GODOT_MCP_BRIDGE_URL` is `ws://host.docker.internal:9080`, which reaches a
-Godot editor running on the Docker host. On Linux you may need to add
-`extra_hosts: ["host.docker.internal:host-gateway"]` to the compose service.
+Since the bridge inversion (#276) the **server is the listener** and the Godot editor
+connects *in*, so the container must publish the bridge port and bind all interfaces:
+
+- In the container (compose `environment`): `GODOT_MCP_BRIDGE_URL: ws://0.0.0.0:9080`, and
+  publish it: `ports: ["9080:9080"]`.
+- On the host, point the editor's addon at the published port:
+  `GODOT_MCP_BRIDGE_URL=ws://127.0.0.1:9080`.
+- Binding `0.0.0.0` relaxes the localhost-only default — only do this on a trusted host.
+
+> The bundled `docker-compose.yml` still carries the pre-inversion
+> `ws://host.docker.internal:9080` and doesn't publish `9080` yet (the server dialed *out*
+> to the host editor under the old direction). Apply the two changes above until the compose
+> fix lands — tracked in [#285](https://github.com/hybridindie/godot-mcp/issues/285).
 
 ## Mounting a project
 

--- a/docs/architecture-diagram.md
+++ b/docs/architecture-diagram.md
@@ -1,0 +1,76 @@
+# godot-mcp architecture (visual)
+
+Companion to [`architecture.md`](architecture.md) — the same system, rendered. The
+defining detail (post-#276/#277): the **editor dials**, the **server listens**, but the
+**server still drives every command**. Those two directions are decoupled.
+
+## Components
+
+```mermaid
+flowchart LR
+    CC["AI client<br/>Claude Code · OpenCode · any stdio MCP client"]
+
+    subgraph server["FastMCP server — mcp_server/ (Python)"]
+        direction TB
+        TOOLS["tools · resources · prompts<br/><i>delegation only</i>"]
+        SAFETY["safety.py<br/>safety class · dry_run/confirm · preconditions"]
+        BRIDGE["bridge.py — WebSocket <b>LISTENER</b><br/>serve() · id-correlation · timeout"]
+        TOOLS --> SAFETY --> BRIDGE
+    end
+
+    subgraph addon["Godot addon — addons/godot_mcp/ (GDScript, @tool)"]
+        direction TB
+        WSC["mcp_bridge.gd — WebSocket <b>CLIENT</b><br/>connect_to_url · reconnect w/ backoff"]
+        ROUTER["command_router.gd"]
+        HANDLERS["cmd_* handlers<br/>Editor API · UndoRedo · type_coerce"]
+        DOCK["status dock (read-only)"]
+        WSC --> ROUTER --> HANDLERS
+        WSC -. connection status .-> DOCK
+    end
+
+    PROJ["Live Godot project"]
+
+    CC <-->|"stdio (MCP protocol)"| TOOLS
+    WSC ==>|"dials out · ws://127.0.0.1:9080"| BRIDGE
+    BRIDGE -.->|"{id, command, params}"| WSC
+    HANDLERS -->|"Godot Editor API"| PROJ
+```
+
+- **Bold arrow** = the transport connection the **editor initiates** (and reconnects).
+- **Dashed arrow** = commands, which the **server still initiates** once the link is up.
+- Solid `stdio` / `Editor API` arrows = the two ends of the chain.
+
+## Request lifecycle (and the inversion)
+
+```mermaid
+sequenceDiagram
+    participant AI as AI client
+    participant S as MCP server<br/>(listener)
+    participant A as Godot addon<br/>(client)
+    participant G as Godot project
+
+    Note over S: boots, binds :9080, waits
+    A->>S: WebSocket connect (dials out; retries w/ backoff)
+    Note over A,S: bridge up — addon dialed, server listens
+
+    AI->>S: tool call (stdio MCP)
+    S->>S: safety — class · dry_run/confirm · preconditions
+    S-->>A: {id, command: "cmd_...", params}
+    A->>G: Godot Editor API (+ UndoRedo on mutations)
+    G-->>A: result
+    A-->>S: {id, ok, result | error, hint}
+    S-->>AI: typed tool result
+
+    Note over A,S: editor closes → server waits;<br/>editor reopens → addon re-dials, self-heals
+```
+
+## Why this shape
+
+- The **editor is the party that comes and goes** (the user restarts it constantly), so it
+  owns reconnection — start order no longer matters and a restart self-heals.
+- The **server owns all safety/preconditions**; the addon owns all Godot calls. Neither
+  crosses the seam.
+- The **envelope** (`{id, command, params}` → `{id, ok, result, error, hint}`, correlated by
+  `id`, many in flight) is unchanged — only *who dials* flipped.
+- Same principle applies to the future **agent-chat dock → agents backend**: editor-side
+  client dials the stable backend.


### PR DESCRIPTION
The bridge direction flipped in #276/#277 — the MCP server is now the WebSocket **listener** and the Godot addon **connects out and reconnects**. Several docs still described the old "addon = `TCPServer`, server dials in" model. This brings every live doc in line and adds a clearer diagram.

## Changes (docs only)
- **README.md** — flipped the architecture mermaid (editor dials = bold, server commands = dashed), fixed the addon/bridge descriptions (`WebSocketPeer` client; `bridge.py` is a listener), the file-tree comments, the `GODOT_MCP_BRIDGE_URL` env row, and the *"Godot bridge is not connected"* troubleshooting (start order no longer matters; the addon reconnects).
- **CLAUDE.md** — flipped the mermaid + the addon/setup/envelope lines (`cmd_ping`, `127.0.0.1`, `GODOT_MCP_BRIDGE_URL` on both sides).
- **.claude/rules/architecture.md, async-patterns.md** — the server listens and accepts one peer (new connection replaces old); reconnection lives on the addon side; default URL `127.0.0.1`.
- **docker/README.md** — the inverted flow needs the container to publish `9080` + bind `0.0.0.0`; flagged that the bundled `docker-compose.yml` predates it (compose fix tracked in #285).
- **docs/architecture-diagram.md** *(new)* — component + sequence diagrams making the decoupling explicit: the **editor dials**, the **server still drives every command**.

## Notes
- `docs/architecture.md` and `.claude/rules/addon.md` were already updated in #277 (merged).
- The Docker compose file itself genuinely broke under the inversion — that's a code/config fix, out of scope here, tracked in **#285**.

No code change; CI is the lint/types/tests gate (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)