### PR TITLE
Add HTTP service mode for multi-client editor sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,28 @@ The server exposes two transports:
 
 | Transport | Use case | How to connect |
 |-----------|----------|----------------|
-| `stdio` | Claude Code, OpenCode, any local agent | `uv run godot-mcp` |
-| `http` | Remote or web-based clients | `GODOT_MCP_TRANSPORT=http uv run godot-mcp` |
+| `stdio` | A single local agent (Claude Code, OpenCode) | `uv run godot-mcp` |
+| `http` | Shared service; remote or web-based clients | `scripts/serve-http.sh` |
 
-`stdio` is the default and what most AI coding assistants expect. The server reads JSON-RPC from stdin and writes to stdout.
+`stdio` is the default and what most AI coding assistants expect: the client
+spawns its own server subprocess and they speak JSON-RPC over stdin/stdout.
+
+**Service mode (one server, many clients).** The bridge to the editor is a
+single connection — only one server process can own it at a time. So when you
+want **several** clients on the same live editor (e.g. Claude Code *and* the
+[godot-agents](https://github.com/hybridindie/godot-agents) project), run **one**
+HTTP service and have every client connect to it instead of each spawning its own:
+
+```bash
+scripts/serve-http.sh            # http://127.0.0.1:9090/mcp/  + editor bridge :9080
+```
+
+Clients then point at `http://127.0.0.1:9090/mcp/` (FastMCP's Streamable HTTP
+mount). Claude Code, via `.mcp.json`:
+
+```json
+{ "mcpServers": { "godot": { "type": "http", "url": "http://127.0.0.1:9090/mcp/" } } }
+```
 
 ---
 

--- a/scripts/serve-http.sh
+++ b/scripts/serve-http.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run godot-mcp as a long-lived HTTP service ("service mode").
+#
+# One server process owns the editor bridge (default ws://127.0.0.1:9080) and
+# serves MCP over Streamable HTTP, so multiple clients — Claude Code AND the
+# godot-agents project — drive the same live editor through it. (stdio spawns a
+# per-client subprocess, which can't share the single editor bridge.)
+#
+# Clients point at  http://HOST:PORT/mcp/  (FastMCP's default mount path).
+#
+#   Claude Code   .mcp.json -> { "type": "http", "url": "http://127.0.0.1:9090/mcp/" }
+#   godot-agents  GODOT_MCP_TRANSPORT=http  (defaults to the same host/port)
+#
+# Env overrides: GODOT_MCP_HTTP_HOST (127.0.0.1), GODOT_MCP_HTTP_PORT (9090),
+#                GODOT_MCP_BRIDGE_URL (ws://127.0.0.1:9080).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export GODOT_MCP_TRANSPORT=http
+export GODOT_MCP_HTTP_HOST="${GODOT_MCP_HTTP_HOST:-127.0.0.1}"
+export GODOT_MCP_HTTP_PORT="${GODOT_MCP_HTTP_PORT:-9090}"
+
+echo "godot-mcp HTTP service -> http://${GODOT_MCP_HTTP_HOST}:${GODOT_MCP_HTTP_PORT}/mcp/" >&2
+echo "editor bridge          -> ${GODOT_MCP_BRIDGE_URL:-ws://127.0.0.1:9080}" >&2
+
+exec uv run godot-mcp "$@"


### PR DESCRIPTION
### **User description**
## Summary
The editor bridge is a single connection — only one server process can own it at a time. So sharing one live editor across several clients (e.g. Claude Code **and** the [godot-agents](https://github.com/hybridindie/godot-agents) project) requires **one HTTP service** all clients connect to, rather than each spawning its own stdio subprocess. The README previously framed `http` only as "remote/web clients" and there was no launcher.

## Changes
- `scripts/serve-http.sh` — start the server in HTTP mode (env-overridable `GODOT_MCP_HTTP_HOST`/`_PORT`), printing the `/mcp/` URL and the editor bridge URL.
- `README.md` — document **service mode** in "MCP Client Configuration": one server, many clients, plus the Claude Code `.mcp.json` HTTP entry (`http://127.0.0.1:9090/mcp/`).

Docs/tooling only — no server code or tool surface changes.

## Acceptance criteria (#287)
- [x] `scripts/serve-http.sh` starts HTTP mode, env-overridable, prints `/mcp/` + bridge URLs
- [x] README documents service mode + the `.mcp.json` HTTP entry

## Test plan
- Ran `scripts/serve-http.sh` (on :9099): server came up on Streamable HTTP at `/mcp/` with the bridge listener, and a real MCP client connected and listed the 16 gated tools. (Verified together with the consuming change in godot-agents#215.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
documentation, enhancement


___

### **Description**
- Adds HTTP service mode for multi-client sharing

- Enables shared editor bridge access for multiple clients

- Documents service mode in README with example configurations

- Introduces `scripts/serve-http.sh` launcher script


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scripts/serve-http.sh"] -- "launches HTTP service" --> B["godot-mcp"]
  B -- "exposes /mcp/ endpoint" --> C["FastMCP HTTP mount"]
  C -- "serves to multiple clients" --> D["Claude Code"]
  C -- "serves to multiple clients" --> E["godot-agents"]
  B -- "shares editor bridge" --> F["Editor connection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serve-http.sh</strong><dd><code>HTTP service mode launcher script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/serve-http.sh

<ul><li>New bash script to launch godot-mcp in HTTP service mode<br> <li> Supports env-overridable host/port configuration<br> <li> Exports required environment variables for HTTP transport<br> <li> Prints both MCP endpoint and editor bridge URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/288/files#diff-d75265e78ffae4f027bdd36d6caac87a332d193b7ac851d561b8b3dbd9563dd6">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document HTTP service mode for multi-client sharing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updates transport table to clarify <code>http</code> usage for shared service mode<br> <li> Adds detailed documentation of service mode with example <br>configurations<br> <li> Includes Claude Code <code>.mcp.json</code> configuration example<br> <li> Explains the need for service mode when sharing editor bridge</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/288/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

