### PR TITLE
docs(server): reference canonical /mcp path (no trailing slash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,14 @@ want **several** clients on the same live editor (e.g. Claude Code *and* the
 HTTP service and have every client connect to it instead of each spawning its own:
 
 ```bash
-scripts/serve-http.sh            # http://127.0.0.1:9090/mcp/  + editor bridge :9080
+scripts/serve-http.sh            # http://127.0.0.1:9090/mcp  + editor bridge :9080
 ```
 
-Clients then point at `http://127.0.0.1:9090/mcp/` (FastMCP's Streamable HTTP
+Clients then point at `http://127.0.0.1:9090/mcp` (FastMCP's Streamable HTTP
 mount). Claude Code, via `.mcp.json`:
 
 ```json
-{ "mcpServers": { "godot": { "type": "http", "url": "http://127.0.0.1:9090/mcp/" } } }
+{ "mcpServers": { "godot": { "type": "http", "url": "http://127.0.0.1:9090/mcp" } } }
 ```
 
 ---

--- a/scripts/serve-http.sh
+++ b/scripts/serve-http.sh
@@ -6,9 +6,9 @@
 # godot-agents project — drive the same live editor through it. (stdio spawns a
 # per-client subprocess, which can't share the single editor bridge.)
 #
-# Clients point at  http://HOST:PORT/mcp/  (FastMCP's default mount path).
+# Clients point at  http://HOST:PORT/mcp  (FastMCP's default mount path).
 #
-#   Claude Code   .mcp.json -> { "type": "http", "url": "http://127.0.0.1:9090/mcp/" }
+#   Claude Code   .mcp.json -> { "type": "http", "url": "http://127.0.0.1:9090/mcp" }
 #   godot-agents  GODOT_MCP_TRANSPORT=http  (defaults to the same host/port)
 #
 # Env overrides: GODOT_MCP_HTTP_HOST (127.0.0.1), GODOT_MCP_HTTP_PORT (9090),
@@ -21,7 +21,7 @@ export GODOT_MCP_TRANSPORT=http
 export GODOT_MCP_HTTP_HOST="${GODOT_MCP_HTTP_HOST:-127.0.0.1}"
 export GODOT_MCP_HTTP_PORT="${GODOT_MCP_HTTP_PORT:-9090}"
 
-echo "godot-mcp HTTP service -> http://${GODOT_MCP_HTTP_HOST}:${GODOT_MCP_HTTP_PORT}/mcp/" >&2
+echo "godot-mcp HTTP service -> http://${GODOT_MCP_HTTP_HOST}:${GODOT_MCP_HTTP_PORT}/mcp" >&2
 echo "editor bridge          -> ${GODOT_MCP_BRIDGE_URL:-ws://127.0.0.1:9080}" >&2
 
 exec uv run godot-mcp "$@"


### PR DESCRIPTION
## Summary
`/mcp/` 307-redirects to the canonical `/mcp`. Point the `scripts/serve-http.sh` message and the README `.mcp.json` example at `/mcp` so clients connect without the redirect (and stop logging 307s).

Docs/script only. Pairs with godot-agents #232 (the client default `/mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)