### PR TITLE
feat(core): godot_undo tool — agent-drivable editor undo for reversibility

### DIFF
--- a/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
+++ b/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
@@ -80,10 +80,18 @@ func _cmd_undo(params: Dictionary) -> Dictionary:
 	var count: int = int(params.get("count", 1))
 	if count < 1:
 		return _fail("INVALID_PARAM", "count must be >= 1")
+	var dry_run: bool = bool(params.get("dry_run", false))
 	var manager := EditorInterface.get_editor_undo_redo()
 	var root := EditorInterface.get_edited_scene_root()
 	var history_id: int = manager.get_object_history_id(root) if root != null else EditorUndoRedoManager.GLOBAL_HISTORY
 	var ur := manager.get_history_undo_redo(history_id)
+	var has_undo := ur != null and ur.has_undo()
+	var next_action := ur.get_current_action_name() if has_undo else ""
+	if dry_run:
+		# Preview only — the editor UndoRedo API can't report stack depth without
+		# popping, so a dry-run reports whether an undo is available and the next
+		# action's name, and performs nothing.
+		return _ok({"dry_run": true, "requested": count, "has_undo": has_undo, "would_undo_next": next_action})
 	var undone := 0
 	var last_action := ""
 	while undone < count:
@@ -92,7 +100,7 @@ func _cmd_undo(params: Dictionary) -> Dictionary:
 		last_action = ur.get_current_action_name()
 		ur.undo()
 		undone += 1
-	return _ok({"undone": undone, "requested": count, "last_action": last_action})
+	return _ok({"undone": undone, "requested": count, "last_action": last_action, "dry_run": false})
 ```
 
 (`cmd_undo` succeeds with `undone == 0` on an empty history rather than failing — an empty-history undo is a no-op, not an error; the caller decides. The Python tool turns `undone == 0` into a structured signal — Task 3. Replace `get_object_history_id`/`get_history_undo_redo`/`GLOBAL_HISTORY` with whatever Task 1 confirmed if they differ.)
@@ -149,9 +157,26 @@ async def test_godot_undo_forwards_cmd_undo_with_count() -> None:
     async with Client(_build(conn)) as client:
         result = await client.call_tool("godot_undo", {"count": 2})
     assert conn.last_command().command == "cmd_undo"
-    assert conn.last_command().params == {"count": 2}
+    assert conn.last_command().params == {"count": 2, "dry_run": False}
     assert result.structured_content["undone"] == 2
     assert result.structured_content["nothing_to_undo"] is False
+
+
+async def test_godot_undo_dry_run_previews_without_undoing() -> None:
+    def _preview(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_undo":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"dry_run": True, "requested": 1, "has_undo": True, "would_undo_next": "Create Node"},
+            )
+        return None
+
+    conn = FakeAddonConnection(responder=_preview)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {"dry_run": True})
+    assert conn.last_command().params == {"count": 1, "dry_run": True}
+    assert result.structured_content["would_undo_next"] == "Create Node"
+    assert "nothing_to_undo" not in result.structured_content  # not added on a dry-run
 
 
 async def test_godot_undo_reports_nothing_to_undo() -> None:
@@ -189,17 +214,20 @@ from mcp_server.tools._route import route
 
 def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
     @mcp.tool(meta=MUTATING, tags={CORE_TAG})
-    async def godot_undo(count: int = 1) -> dict[str, Any]:
+    async def godot_undo(count: int = 1, dry_run: bool = False) -> dict[str, Any]:
         """Undo the last ``count`` editor actions on the current scene's history.
 
-        Returns ``{undone, requested, last_action, nothing_to_undo}``. Undoing an
-        empty history is a no-op (``undone == 0``, ``nothing_to_undo == True``), not
-        an error — the reversibility ledger decides what that means.
+        With ``dry_run=True``, previews (``has_undo`` + ``would_undo_next``) without
+        undoing. Otherwise returns ``{undone, requested, last_action,
+        nothing_to_undo}``. Undoing an empty history is a no-op (``undone == 0``,
+        ``nothing_to_undo == True``), not an error — the reversibility ledger decides
+        what that means.
         """
         if count < 1:
             raise ToolError("count must be >= 1")  # structured, pre-bridge (see Task 4)
-        result = await route(bridge, "cmd_undo", {"count": count})
-        result["nothing_to_undo"] = result.get("undone", 0) == 0
+        result = await route(bridge, "cmd_undo", {"count": count, "dry_run": dry_run})
+        if not dry_run:
+            result["nothing_to_undo"] = result.get("undone", 0) == 0
         return result
 ```
 

--- a/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
+++ b/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
@@ -1,0 +1,237 @@
+# S4 — godot-mcp `undo` Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the agent a `godot_undo` core MCP tool that pops the live editor's undo history N steps, so the fluid executor's reversibility ledger can actually roll back arbitrary mutating tool calls.
+
+**Architecture:** A GDScript `cmd_undo` handler in the addon calls the editor's `EditorUndoRedoManager` to undo the current scene history N times, returning how many actions were undone; a thin `godot_undo` core FastMCP tool forwards to it via the standard `route()` helper. This is the S4 subsystem of the fluid-agent epic (see `../../../godot-agents/docs/superpowers/specs/2026-07-01-fluid-agent-epic-design.md`).
+
+**Tech Stack:** GDScript (Godot 4.7, `@tool` EditorPlugin), Python 3.11 + FastMCP, `pytest`.
+
+**Repo:** this is a **godot-mcp** change (not godot-agents). Branch from `main`: `feat/s4-undo-tool`.
+
+**Naming note:** the spec called it `godot_core_undo`, but core/meta tools drop the toolset prefix (naming rule #224), so the wire name is **`godot_undo`** and the addon command is **`cmd_undo`**.
+
+---
+
+## File structure
+
+- **Modify** `godot/addons/godot_mcp/command_router.gd` — register `_handlers["cmd_undo"]` and add `func _cmd_undo(params)`.
+- **Create** `mcp_server/tools/undo.py` — `register_undo(mcp, bridge)` exposing the `godot_undo` core tool. (New small module, mirrors `tools/health.py`; keeps the core surface focused.)
+- **Modify** `mcp_server/main.py` — call `register_undo(...)` alongside the other core registrations.
+- **Create** `tests/contract/test_undo.py` — contract tests for the tool (forwarding + error surface) using the bridge fake.
+- **Modify** `tests/contract/test_run_commands.py` (or add `tests/contract/test_undo_smoke.py`) — a live-editor `run_commands` smoke: mutate → `cmd_undo` → assert reverted. Marked/skipped when no live editor, consistent with existing smoke handling.
+
+---
+
+## Task 1: Spike — confirm the exact undo API in a live editor
+
+The 4.7 `EditorUndoRedoManager` surface is ambiguous from docs alone (it may expose `undo()`/`has_undo()` directly, or require `get_history_undo_redo(id).undo()`), and *which* history id holds the agent's scene edits must be confirmed. Resolve this empirically before writing the handler — do **not** guess.
+
+- [ ] **Step 1: Drive a probe through `run_commands` in a live editor.** With the addon connected, send a `run_commands` batch that (a) creates a node, then (b) runs this probe and returns the observations:
+
+```gdscript
+var m := EditorInterface.get_editor_undo_redo()
+var root := EditorInterface.get_edited_scene_root()
+var hid := m.get_object_history_id(root)          # confirm this method exists + returns the scene history
+var ur := m.get_history_undo_redo(hid)            # -> UndoRedo
+return {
+    "has_direct_undo": m.has_method("undo"),       # does EditorUndoRedoManager expose undo() itself?
+    "history_id": hid,
+    "ur_is_null": ur == null,
+    "ur_has_undo": ur != null and ur.has_undo(),
+    "ur_action_name": (ur.get_current_action_name() if ur != null else ""),
+}
+```
+
+- [ ] **Step 2: Record the verified call.** Write the confirmed snippet into this plan (below Task 2) as the canonical undo call: either `m.undo()` (if `has_direct_undo` and it targets the scene history) **or** `m.get_history_undo_redo(m.get_object_history_id(root)).undo()`. Note the exact history-id source for a scene with and without an edited root (fall back to `EditorUndoRedoManager.GLOBAL_HISTORY` when `root == null`).
+
+- [ ] **Step 3: Commit the spike finding.**
+
+```bash
+git add docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
+git commit -m "docs(s4): record verified editor undo API from live-editor spike"
+```
+
+> Everything below assumes the `get_history_undo_redo(...).undo()` form (the safe, well-documented path). If Step 1 shows a correct direct `m.undo()`, simplify the handler accordingly — the tests do not change.
+
+---
+
+## Task 2: GDScript `cmd_undo` handler
+
+**Files:** Modify `godot/addons/godot_mcp/command_router.gd`
+
+- [ ] **Step 1: Register the handler.** In the `_handlers[...]` registration block (near `_handlers["cmd_ping"]`), add:
+
+```gdscript
+	_handlers["cmd_undo"] = _cmd_undo
+```
+
+- [ ] **Step 2: Implement `_cmd_undo`.** Add near the other `_cmd_*` handlers. Match the **return shape of existing handlers in this file** (return the plain result `Dictionary`; the router wraps it into the `{id, ok, result, error}` envelope — verify against `_cmd_get_project_info`):
+
+```gdscript
+func _cmd_undo(params: Dictionary) -> Dictionary:
+	var count: int = int(params.get("count", 1))
+	if count < 1:
+		return {"error": "INVALID_PARAM", "hint": "count must be >= 1"}
+	var manager := EditorInterface.get_editor_undo_redo()
+	var root := EditorInterface.get_edited_scene_root()
+	var history_id: int = manager.get_object_history_id(root) if root != null else EditorUndoRedoManager.GLOBAL_HISTORY
+	var ur := manager.get_history_undo_redo(history_id)
+	var undone := 0
+	var last_action := ""
+	while undone < count:
+		if ur == null or not ur.has_undo():
+			break
+		last_action = ur.get_current_action_name()
+		ur.undo()
+		undone += 1
+	return {"undone": undone, "requested": count, "last_action": last_action}
+```
+
+(`cmd_undo` reports `undone` rather than erroring on an empty history — an empty-history undo is a no-op, not a failure; the caller decides. The Python tool converts `undone == 0` into a structured signal — Task 3.)
+
+- [ ] **Step 3: Track the addon change.** No test runs here yet (GDScript is exercised by the Task 5 smoke). Commit:
+
+```bash
+git add godot/addons/godot_mcp/command_router.gd
+git commit -m "feat(addon): cmd_undo handler pops the scene undo history N steps"
+```
+
+---
+
+## Task 3: Python `godot_undo` core tool (TDD)
+
+**Files:** Create `mcp_server/tools/undo.py`; Test `tests/contract/test_undo.py`
+
+- [ ] **Step 1: Write the failing contract test.** Mirror an existing contract test's fake-bridge setup (see `tests/contract/test_run_commands.py` for the fake wiring and `tests/fakes.py`).
+
+```python
+# tests/contract/test_undo.py
+import pytest
+from tests.fakes import FakeBridge, build_test_server  # match the helpers used by test_run_commands.py
+
+@pytest.mark.asyncio
+async def test_godot_undo_forwards_cmd_undo_with_count():
+    bridge = FakeBridge(result={"undone": 2, "requested": 2, "last_action": "Create Node"})
+    server = build_test_server(bridge)  # registers core tools incl. register_undo
+    result = await server.call_tool("godot_undo", {"count": 2})
+    assert bridge.last_command == "cmd_undo"
+    assert bridge.last_params == {"count": 2}
+    assert result["undone"] == 2
+
+@pytest.mark.asyncio
+async def test_godot_undo_reports_nothing_to_undo():
+    bridge = FakeBridge(result={"undone": 0, "requested": 1, "last_action": ""})
+    server = build_test_server(bridge)
+    result = await server.call_tool("godot_undo", {})
+    assert result["undone"] == 0
+    assert result["nothing_to_undo"] is True
+```
+
+> Adjust the imports/harness calls to match whatever `tests/contract/test_run_commands.py` actually uses — reuse that file's exact pattern rather than inventing helpers.
+
+- [ ] **Step 2: Run it, verify it fails.**
+
+Run: `uv run pytest tests/contract/test_undo.py -q`
+Expected: FAIL (`godot_undo` not registered / module missing).
+
+- [ ] **Step 3: Implement the tool.**
+
+```python
+# mcp_server/tools/undo.py
+"""Core `godot_undo` tool: pop the editor undo history N steps (#S4)."""
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.safety import MUTATING
+from mcp_server.tools._route import route
+
+
+def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
+    @mcp.tool(meta=MUTATING)  # core tool: no toolset tag -> always-on
+    async def godot_undo(count: int = 1) -> dict:
+        """Undo the last ``count`` editor actions on the current scene's history.
+
+        Returns ``{undone, requested, last_action, nothing_to_undo}``. Undoing an
+        empty history is a no-op (``undone == 0``, ``nothing_to_undo == True``), not
+        an error — the reversibility ledger decides what that means.
+        """
+        result = await route(bridge, "cmd_undo", {"count": count})
+        result["nothing_to_undo"] = result.get("undone", 0) == 0
+        return result
+```
+
+- [ ] **Step 4: Register it.** In `mcp_server/main.py`, alongside the other core registrations, add `from mcp_server.tools.undo import register_undo` and `register_undo(mcp, bridge)`.
+
+- [ ] **Step 5: Run the test, verify it passes.**
+
+Run: `uv run pytest tests/contract/test_undo.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add mcp_server/tools/undo.py mcp_server/main.py tests/contract/test_undo.py
+git commit -m "feat(server): godot_undo core tool forwarding to cmd_undo"
+```
+
+---
+
+## Task 4: Preflight validation for `cmd_undo`
+
+**Files:** wherever command param validation lives (find via `grep -rn "cmd_run_commands" mcp_server/` — the preflight validator `_preflight_validate` in `_route.py` or a validation registry).
+
+- [ ] **Step 1: Failing test** — `godot_undo(count=0)` raises a structured `ToolError` ("count must be >= 1"), not a bridge round-trip.
+
+```python
+@pytest.mark.asyncio
+async def test_godot_undo_rejects_nonpositive_count():
+    bridge = FakeBridge(result={})
+    server = build_test_server(bridge)
+    with pytest.raises(Exception) as exc:  # ToolError
+        await server.call_tool("godot_undo", {"count": 0})
+    assert "count" in str(exc.value)
+    assert bridge.last_command is None  # never reached the bridge
+```
+
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Add a `count >= 1` precondition for `cmd_undo` following the existing validation pattern (the GDScript handler already guards, but preflight keeps it a structured `ToolError` and avoids the round-trip).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit.**
+
+```bash
+git add -A && git commit -m "feat(server): preflight-validate godot_undo count >= 1"
+```
+
+---
+
+## Task 5: Live-editor smoke (mutate → undo → assert reverted)
+
+**Files:** add to `tests/contract/test_run_commands.py` pattern, or `tests/contract/test_undo_smoke.py`. Follows the existing skip-without-editor convention.
+
+- [ ] **Step 1:** Write a smoke that, against a connected editor, sends a `run_commands` batch: `create_node` a uniquely-named child → assert it exists in the scene tree → `cmd_undo` → assert the node is gone and `undone == 1`. Guard/skip exactly as the existing live smokes do (no live bridge → skip, not fail).
+- [ ] **Step 2:** Run the suite locally with an editor connected; confirm PASS. Without an editor, confirm it SKIPS (not fails).
+- [ ] **Step 3: Commit.**
+
+```bash
+git add -A && git commit -m "test(s4): live smoke — create_node then cmd_undo reverts it"
+```
+
+---
+
+## Task 6: Preflight + PR
+
+- [ ] **Step 1:** Full preflight per repo rules: `uv run pytest -q`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`, `./.claude/hooks/check-no-skipped-tests.sh`.
+- [ ] **Step 2:** Update `docs/tool-contracts.md` — add `godot_undo` to the core tool surface (safety class `mutating`, `count` param, returns `{undone, requested, last_action, nothing_to_undo}`).
+- [ ] **Step 3:** Open the PR (`closes` the S4 tracking issue once filed). Wait for Qodo review, address comments, merge.
+
+---
+
+## Notes / risks
+
+- **History fidelity (from the spec):** `cmd_undo` targets the *current scene* history; it assumes the agent is the sole mutator (true in eval/headless). A human editing the same scene concurrently could make undo pop *their* action — out of scope for v1, but the returned `last_action` lets the caller sanity-check what was undone before trusting the rollback.
+- **Non-undo-tracked mutations** (file writes: `create_resource`, project settings, new script files) are **not** covered by `cmd_undo` — those use the ledger's `file_restore` strategy (S2), not this tool. `godot_undo` only reverses `editor_undo`-strategy actions.
+- **`undone < requested`** is a legitimate outcome (history shorter than asked); the tool reports both so S2's ledger replay can detect a partial rollback and escalate.

--- a/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
+++ b/docs/superpowers/plans/2026-07-01-s4-godot-mcp-undo-tool.md
@@ -16,33 +16,39 @@
 
 ## File structure
 
-- **Modify** `godot/addons/godot_mcp/command_router.gd` — register `_handlers["cmd_undo"]` and add `func _cmd_undo(params)`.
-- **Create** `mcp_server/tools/undo.py` — `register_undo(mcp, bridge)` exposing the `godot_undo` core tool. (New small module, mirrors `tools/health.py`; keeps the core surface focused.)
-- **Modify** `mcp_server/main.py` — call `register_undo(...)` alongside the other core registrations.
-- **Create** `tests/contract/test_undo.py` — contract tests for the tool (forwarding + error surface) using the bridge fake.
-- **Modify** `tests/contract/test_run_commands.py` (or add `tests/contract/test_undo_smoke.py`) — a live-editor `run_commands` smoke: mutate → `cmd_undo` → assert reverted. Marked/skipped when no live editor, consistent with existing smoke handling.
+- **Modify** `godot/addons/godot_mcp/command_router.gd` — register `_handlers["cmd_undo"]` and add `func _cmd_undo(params)` (returning via the file's `_ok(...)` / `_fail(...)` helpers).
+- **Create** `mcp_server/tools/undo.py` — `register_undo(mcp, bridge)` exposing the `godot_undo` core tool. New small module, mirrors `tools/health.py` (same `@mcp.tool(meta=..., tags={CORE_TAG})` shape).
+- **Modify** `mcp_server/server.py` — call `register_undo(mcp, bridge)` inside `create_server`, alongside `register_health(...)` (~line 126). **Not** `main.py` — `main.py` only calls `create_server`; all `register_*` calls live in `create_server`.
+- **Create** `tests/contract/test_undo.py` — contract tests using the **real** fake harness: `FakeAddonConnection(responder=...)` + `connector_for` + `Bridge` + `create_server` + `Client(server)`, asserting via `result.structured_content` and `conn.last_command()` (see `tests/contract/test_inspection.py` for the exact pattern).
+- **Add** a live-editor `run_commands` smoke (in `tests/contract/test_undo.py` or `tests/contract/test_undo_smoke.py`): mutate → `cmd_undo` → assert reverted. Skipped when no live editor, consistent with existing live smokes.
 
 ---
 
 ## Task 1: Spike — confirm the exact undo API in a live editor
 
-The 4.7 `EditorUndoRedoManager` surface is ambiguous from docs alone (it may expose `undo()`/`has_undo()` directly, or require `get_history_undo_redo(id).undo()`), and *which* history id holds the agent's scene edits must be confirmed. Resolve this empirically before writing the handler — do **not** guess.
+`EditorInterface.get_editor_undo_redo()` is already used and proven in this file (`command_router.gd:307`), so the *accessor* is not in doubt. What is uncertain in 4.7 is the **undo-trigger path**: whether `EditorUndoRedoManager` exposes `undo()`/`has_undo()` directly or requires `get_history_undo_redo(id).undo()`, whether `get_object_history_id(...)` exists, and *which* history id holds the agent's scene edits. Confirm those specifics empirically before writing the handler — do **not** guess.
 
 - [ ] **Step 1: Drive a probe through `run_commands` in a live editor.** With the addon connected, send a `run_commands` batch that (a) creates a node, then (b) runs this probe and returns the observations:
 
 ```gdscript
 var m := EditorInterface.get_editor_undo_redo()
 var root := EditorInterface.get_edited_scene_root()
-var hid := m.get_object_history_id(root)          # confirm this method exists + returns the scene history
-var ur := m.get_history_undo_redo(hid)            # -> UndoRedo
-return {
-    "has_direct_undo": m.has_method("undo"),       # does EditorUndoRedoManager expose undo() itself?
-    "history_id": hid,
-    "ur_is_null": ur == null,
-    "ur_has_undo": ur != null and ur.has_undo(),
-    "ur_action_name": (ur.get_current_action_name() if ur != null else ""),
+var out := {
+    "has_direct_undo": m.has_method("undo"),               # does EditorUndoRedoManager expose undo() itself?
+    "has_get_object_history_id": m.has_method("get_object_history_id"),
+    "has_get_history_undo_redo": m.has_method("get_history_undo_redo"),
 }
+if m.has_method("get_object_history_id") and m.has_method("get_history_undo_redo"):
+    var hid: int = m.get_object_history_id(root) if root != null else 0
+    var ur := m.get_history_undo_redo(hid)                 # -> UndoRedo
+    out["history_id"] = hid
+    out["ur_is_null"] = ur == null
+    out["ur_has_undo"] = ur != null and ur.has_undo()
+    out["ur_action_name"] = (ur.get_current_action_name() if ur != null else "")
+return out
 ```
+
+Check `has_method` first so the probe never crashes on a renamed API; the returned booleans tell you which undo-trigger form to use in Task 2.
 
 - [ ] **Step 2: Record the verified call.** Write the confirmed snippet into this plan (below Task 2) as the canonical undo call: either `m.undo()` (if `has_direct_undo` and it targets the scene history) **or** `m.get_history_undo_redo(m.get_object_history_id(root)).undo()`. Note the exact history-id source for a scene with and without an edited root (fall back to `EditorUndoRedoManager.GLOBAL_HISTORY` when `root == null`).
 
@@ -67,13 +73,13 @@ git commit -m "docs(s4): record verified editor undo API from live-editor spike"
 	_handlers["cmd_undo"] = _cmd_undo
 ```
 
-- [ ] **Step 2: Implement `_cmd_undo`.** Add near the other `_cmd_*` handlers. Match the **return shape of existing handlers in this file** (return the plain result `Dictionary`; the router wraps it into the `{id, ok, result, error}` envelope — verify against `_cmd_get_project_info`):
+- [ ] **Step 2: Implement `_cmd_undo`.** Add near the other `_cmd_*` handlers. Handlers in this file return through the `_ok(result: Dictionary)` / `_fail(code, hint)` helpers (verified: `_cmd_get_project_info` returns `_ok({...})` at `command_router.gd:238`; `_ok`/`_fail` defined at ~`:494`/`:498`). Use the undo-trigger form confirmed by Task 1 — the snippet below assumes `get_history_undo_redo(...).undo()`:
 
 ```gdscript
 func _cmd_undo(params: Dictionary) -> Dictionary:
 	var count: int = int(params.get("count", 1))
 	if count < 1:
-		return {"error": "INVALID_PARAM", "hint": "count must be >= 1"}
+		return _fail("INVALID_PARAM", "count must be >= 1")
 	var manager := EditorInterface.get_editor_undo_redo()
 	var root := EditorInterface.get_edited_scene_root()
 	var history_id: int = manager.get_object_history_id(root) if root != null else EditorUndoRedoManager.GLOBAL_HISTORY
@@ -86,10 +92,10 @@ func _cmd_undo(params: Dictionary) -> Dictionary:
 		last_action = ur.get_current_action_name()
 		ur.undo()
 		undone += 1
-	return {"undone": undone, "requested": count, "last_action": last_action}
+	return _ok({"undone": undone, "requested": count, "last_action": last_action})
 ```
 
-(`cmd_undo` reports `undone` rather than erroring on an empty history — an empty-history undo is a no-op, not a failure; the caller decides. The Python tool converts `undone == 0` into a structured signal — Task 3.)
+(`cmd_undo` succeeds with `undone == 0` on an empty history rather than failing — an empty-history undo is a no-op, not an error; the caller decides. The Python tool turns `undone == 0` into a structured signal — Task 3. Replace `get_object_history_id`/`get_history_undo_redo`/`GLOBAL_HISTORY` with whatever Task 1 confirmed if they differ.)
 
 - [ ] **Step 3: Track the addon change.** No test runs here yet (GDScript is exercised by the Task 5 smoke). Commit:
 
@@ -104,67 +110,100 @@ git commit -m "feat(addon): cmd_undo handler pops the scene undo history N steps
 
 **Files:** Create `mcp_server/tools/undo.py`; Test `tests/contract/test_undo.py`
 
-- [ ] **Step 1: Write the failing contract test.** Mirror an existing contract test's fake-bridge setup (see `tests/contract/test_run_commands.py` for the fake wiring and `tests/fakes.py`).
+- [ ] **Step 1: Write the failing contract test.** Use the **real** harness (copy the shape of `tests/contract/test_inspection.py`): a `_responder(cmd) -> ResponseEnvelope | None` keyed on `cmd.command`, a `FakeAddonConnection(responder=...)`, `connector_for`, `Bridge`, `create_server`, and `Client(server)`; assert payload via `result.structured_content` and the sent command via `conn.last_command()`.
 
 ```python
 # tests/contract/test_undo.py
+from __future__ import annotations
+
 import pytest
-from tests.fakes import FakeBridge, build_test_server  # match the helpers used by test_run_commands.py
+from fastmcp import Client, FastMCP
 
-@pytest.mark.asyncio
-async def test_godot_undo_forwards_cmd_undo_with_count():
-    bridge = FakeBridge(result={"undone": 2, "requested": 2, "last_action": "Create Node"})
-    server = build_test_server(bridge)  # registers core tools incl. register_undo
-    result = await server.call_tool("godot_undo", {"count": 2})
-    assert bridge.last_command == "cmd_undo"
-    assert bridge.last_params == {"count": 2}
-    assert result["undone"] == 2
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
 
-@pytest.mark.asyncio
-async def test_godot_undo_reports_nothing_to_undo():
-    bridge = FakeBridge(result={"undone": 0, "requested": 1, "last_action": ""})
-    server = build_test_server(bridge)
-    result = await server.call_tool("godot_undo", {})
-    assert result["undone"] == 0
-    assert result["nothing_to_undo"] is True
+pytestmark = pytest.mark.asyncio
+
+
+def _undo_responder(undone: int):
+    def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_undo":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"undone": undone, "requested": cmd.params.get("count", 1), "last_action": "Create Node"},
+            )
+        return None  # bootstrap commands (cmd_ping/cmd_get_project_info) auto-answered by the fake
+    return _responder
+
+
+def _build(conn: FakeAddonConnection) -> FastMCP:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_godot_undo_forwards_cmd_undo_with_count() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=2))
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {"count": 2})
+    assert conn.last_command().command == "cmd_undo"
+    assert conn.last_command().params == {"count": 2}
+    assert result.structured_content["undone"] == 2
+    assert result.structured_content["nothing_to_undo"] is False
+
+
+async def test_godot_undo_reports_nothing_to_undo() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=0))
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {})
+    assert result.structured_content["undone"] == 0
+    assert result.structured_content["nothing_to_undo"] is True
 ```
 
-> Adjust the imports/harness calls to match whatever `tests/contract/test_run_commands.py` actually uses — reuse that file's exact pattern rather than inventing helpers.
+> Returning `None` from `_responder` for a non-`cmd_undo` command lets the fake's built-in bootstrap answer `cmd_ping`/`cmd_get_project_info` (see `FakeAddonConnection.send`), so the responder only handles what the test cares about.
 
 - [ ] **Step 2: Run it, verify it fails.**
 
 Run: `uv run pytest tests/contract/test_undo.py -q`
 Expected: FAIL (`godot_undo` not registered / module missing).
 
-- [ ] **Step 3: Implement the tool.**
+- [ ] **Step 3: Implement the tool.** Mirror `tools/health.py` — a core tool carries `tags={CORE_TAG}` so the #224 naming lands it as `godot_undo` and the gating model keeps it always-on (a tag-less tool would be mis-gated).
 
 ```python
 # mcp_server/tools/undo.py
-"""Core `godot_undo` tool: pop the editor undo history N steps (#S4)."""
+"""Core `godot_undo` tool: pop the editor undo history N steps (S4)."""
 from __future__ import annotations
 
+from typing import Any
+
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
+from mcp_server.categories import CORE_TAG
 from mcp_server.safety import MUTATING
 from mcp_server.tools._route import route
 
 
 def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
-    @mcp.tool(meta=MUTATING)  # core tool: no toolset tag -> always-on
-    async def godot_undo(count: int = 1) -> dict:
+    @mcp.tool(meta=MUTATING, tags={CORE_TAG})
+    async def godot_undo(count: int = 1) -> dict[str, Any]:
         """Undo the last ``count`` editor actions on the current scene's history.
 
         Returns ``{undone, requested, last_action, nothing_to_undo}``. Undoing an
         empty history is a no-op (``undone == 0``, ``nothing_to_undo == True``), not
         an error — the reversibility ledger decides what that means.
         """
+        if count < 1:
+            raise ToolError("count must be >= 1")  # structured, pre-bridge (see Task 4)
         result = await route(bridge, "cmd_undo", {"count": count})
         result["nothing_to_undo"] = result.get("undone", 0) == 0
         return result
 ```
 
-- [ ] **Step 4: Register it.** In `mcp_server/main.py`, alongside the other core registrations, add `from mcp_server.tools.undo import register_undo` and `register_undo(mcp, bridge)`.
+- [ ] **Step 4: Register it.** In `mcp_server/server.py`, inside `create_server`, add `from mcp_server.tools.undo import register_undo` (with the other tool imports) and `register_undo(mcp, bridge)` next to `register_health(mcp, bridge, config)`.
 
 - [ ] **Step 5: Run the test, verify it passes.**
 
@@ -174,36 +213,37 @@ Expected: PASS.
 - [ ] **Step 6: Commit.**
 
 ```bash
-git add mcp_server/tools/undo.py mcp_server/main.py tests/contract/test_undo.py
+git add mcp_server/tools/undo.py mcp_server/server.py tests/contract/test_undo.py
 git commit -m "feat(server): godot_undo core tool forwarding to cmd_undo"
 ```
 
 ---
 
-## Task 4: Preflight validation for `cmd_undo`
+## Task 4: `count >= 1` guard (test the tool-body precondition)
 
-**Files:** wherever command param validation lives (find via `grep -rn "cmd_run_commands" mcp_server/` — the preflight validator `_preflight_validate` in `_route.py` or a validation registry).
+The guard is already in the tool body (Task 3, Step 3: `if count < 1: raise ToolError(...)`) — a `ToolError` raised **before** the bridge round-trip. This task just pins it with a test. (Chosen over extending the `_route.py` `_preflight_validate` registry, whose validators are keyed by command name and shaped for path-containment — a tool-body guard is simpler and equally pre-bridge.)
 
-- [ ] **Step 1: Failing test** — `godot_undo(count=0)` raises a structured `ToolError` ("count must be >= 1"), not a bridge round-trip.
+- [ ] **Step 1: Failing test** — `godot_undo(count=0)` raises `ToolError` and never reaches the bridge. Add to `tests/contract/test_undo.py`:
 
 ```python
-@pytest.mark.asyncio
-async def test_godot_undo_rejects_nonpositive_count():
-    bridge = FakeBridge(result={})
-    server = build_test_server(bridge)
-    with pytest.raises(Exception) as exc:  # ToolError
-        await server.call_tool("godot_undo", {"count": 0})
-    assert "count" in str(exc.value)
-    assert bridge.last_command is None  # never reached the bridge
+from fastmcp.exceptions import ToolError
+
+async def test_godot_undo_rejects_nonpositive_count() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=0))
+    with pytest.raises(ToolError, match="count"):
+        async with Client(_build(conn)) as client:
+            await client.call_tool("godot_undo", {"count": 0})
+    # cmd_undo was never sent (only bootstrap commands, if any, reached the fake)
+    assert all(
+        CommandEnvelope.model_validate_json(m).command != "cmd_undo" for m in conn.sent
+    )
 ```
 
-- [ ] **Step 2:** Run → FAIL.
-- [ ] **Step 3:** Add a `count >= 1` precondition for `cmd_undo` following the existing validation pattern (the GDScript handler already guards, but preflight keeps it a structured `ToolError` and avoids the round-trip).
-- [ ] **Step 4:** Run → PASS.
-- [ ] **Step 5: Commit.**
+- [ ] **Step 2:** Run → confirm PASS (the guard already exists from Task 3). If it fails, the guard is missing — add `if count < 1: raise ToolError("count must be >= 1")` at the top of `godot_undo`.
+- [ ] **Step 3: Commit.**
 
 ```bash
-git add -A && git commit -m "feat(server): preflight-validate godot_undo count >= 1"
+git add tests/contract/test_undo.py && git commit -m "test(server): godot_undo rejects count < 1 pre-bridge"
 ```
 
 ---

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -927,6 +927,20 @@ internal `request_id` (constant across its poll), so the addon dispatches exactl
 full-Control scan per call and never returns a prior identical-filter request's stale
 result. The `rect` pairs with `godot_input_simulate_mouse` to click located UI.
 
+### Editor history — `mutating` (category: `core`)
+
+| Tool | Params | Returns | Safety |
+|------|--------|---------|--------|
+| `godot_undo` | `count: int = 1, dry_run: bool = False` | `UndoResult { dry_run, requested, undone?, last_action?, nothing_to_undo?, has_undo?, would_undo_next? }` | `mutating` |
+
+`godot_undo` undoes up to `count` actions on the current scene's undo history (falls
+back to the global history when no scene is open). A real undo returns
+`{ undone, requested, last_action, nothing_to_undo }`; undoing an empty history is a
+no-op (`undone == 0`, `nothing_to_undo == True`), not an error. `dry_run=True` previews
+instead — `{ has_undo, would_undo_next }` — and performs nothing. Each response carries
+only its mode's keys (a dry-run never emits `nothing_to_undo`). `count < 1` is a
+structured `ToolError`.
+
 ### Diagnostics & debug workflow — `read_only` (category: `core`)
 
 | Tool | Params | Returns | Notes |

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -204,18 +204,18 @@ func _cmd_ping(_params: Dictionary) -> Dictionary:
 func _cmd_undo(params: Dictionary) -> Dictionary:
 	var count: int = int(params.get("count", 1))
 	if count < 1:
-		return _fail("INVALID_PARAM", "count must be >= 1")
+		return _fail("VALIDATION_ERROR", "count must be >= 1")
 	var dry_run: bool = bool(params.get("dry_run", false))
 	var manager := EditorInterface.get_editor_undo_redo()
 	var root := EditorInterface.get_edited_scene_root()
 	var history_id: int = manager.get_object_history_id(root) if root != null else EditorUndoRedoManager.GLOBAL_HISTORY
 	var ur := manager.get_history_undo_redo(history_id)
-	var has_undo := ur != null and ur.has_undo()
-	var next_action := ur.get_current_action_name() if has_undo else ""
 	if dry_run:
 		# Preview only — the editor UndoRedo API can't report stack depth without
 		# popping, so a dry-run reports whether an undo is available and the next
 		# action's name, and performs nothing.
+		var has_undo := ur != null and ur.has_undo()
+		var next_action := ur.get_current_action_name() if has_undo else ""
 		return _ok({"dry_run": true, "requested": count, "has_undo": has_undo, "would_undo_next": next_action})
 	var undone := 0
 	var last_action := ""

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -95,6 +95,9 @@ func _init() -> void:
 	# tool drops the cmd_ prefix); see docs/architecture.md.
 	_handlers["cmd_ping"] = _cmd_ping
 	_handlers["cmd_get_project_info"] = _cmd_get_project_info
+	# Core: pop the current scene's undo history N steps (S4). Lives on the router
+	# (not a domain handler) because it drives EditorUndoRedoManager directly.
+	_handlers["cmd_undo"] = _cmd_undo
 	# Meta-command: execute a batch of sub-commands in one frame (issue #167).
 	# Lives on the router (not a domain handler) because it re-dispatches via _route.
 	_handlers["cmd_run_commands"] = _cmd_run_commands
@@ -190,6 +193,39 @@ func _route(envelope: Dictionary) -> Dictionary:
 
 func _cmd_ping(_params: Dictionary) -> Dictionary:
 	return _ok({"pong": true})
+
+
+## Undo the last `count` editor actions on the current scene's history (S4).
+## Succeeds with `undone == 0` on an empty history (an empty-history undo is a
+## no-op, not an error — the caller/reversibility ledger decides what that means).
+## The undo-trigger path (get_object_history_id / get_history_undo_redo /
+## GLOBAL_HISTORY) is the assumed form pending the Task-1 live spike; swap in
+## whatever that confirms if it differs.
+func _cmd_undo(params: Dictionary) -> Dictionary:
+	var count: int = int(params.get("count", 1))
+	if count < 1:
+		return _fail("INVALID_PARAM", "count must be >= 1")
+	var dry_run: bool = bool(params.get("dry_run", false))
+	var manager := EditorInterface.get_editor_undo_redo()
+	var root := EditorInterface.get_edited_scene_root()
+	var history_id: int = manager.get_object_history_id(root) if root != null else EditorUndoRedoManager.GLOBAL_HISTORY
+	var ur := manager.get_history_undo_redo(history_id)
+	var has_undo := ur != null and ur.has_undo()
+	var next_action := ur.get_current_action_name() if has_undo else ""
+	if dry_run:
+		# Preview only — the editor UndoRedo API can't report stack depth without
+		# popping, so a dry-run reports whether an undo is available and the next
+		# action's name, and performs nothing.
+		return _ok({"dry_run": true, "requested": count, "has_undo": has_undo, "would_undo_next": next_action})
+	var undone := 0
+	var last_action := ""
+	while undone < count:
+		if ur == null or not ur.has_undo():
+			break
+		last_action = ur.get_current_action_name()
+		ur.undo()
+		undone += 1
+	return _ok({"undone": undone, "requested": count, "last_action": last_action, "dry_run": false})
 
 
 ## Execute a batch of sub-commands in a single frame and return one response body

--- a/mcp_server/models/undo.py
+++ b/mcp_server/models/undo.py
@@ -1,0 +1,43 @@
+"""Typed result for the core ``godot_undo`` tool (S4).
+
+A single model covers both response shapes; the mode-specific fields default to
+``None`` and are dropped on serialization (a ``model_serializer`` skips the ``None``
+fields) so a dry-run preview never carries a ``nothing_to_undo`` key and a real undo
+never carries the preview-only ``has_undo``/``would_undo_next`` keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, model_serializer
+
+
+class UndoResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    dry_run: bool
+    requested: int
+
+    # Real-undo fields (absent on a dry-run preview).
+    undone: int | None = None
+    last_action: str | None = None
+    nothing_to_undo: bool | None = None
+
+    # Dry-run preview fields (absent on a real undo).
+    has_undo: bool | None = None
+    would_undo_next: str | None = None
+
+    @model_serializer(mode="plain")
+    def _serialize(self) -> dict[str, Any]:
+        # Drop null fields so each mode serializes only its own keys: a dry-run
+        # preview never emits ``nothing_to_undo``; a real undo never emits the
+        # preview-only ``has_undo``/``would_undo_next``. A model_serializer (not a
+        # model_dump override) is used because FastMCP builds structured_content via
+        # pydantic-core serialization, which only honors this hook.
+        data = {"dry_run": self.dry_run, "requested": self.requested}
+        for field in ("undone", "last_action", "nothing_to_undo", "has_undo", "would_undo_next"):
+            value = getattr(self, field)
+            if value is not None:
+                data[field] = value
+        return data

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -58,6 +58,7 @@ from mcp_server.tools.shader import register_shader
 from mcp_server.tools.testing import register_testing
 from mcp_server.tools.theme_ui import register_theme_ui
 from mcp_server.tools.tilemap import register_tilemap
+from mcp_server.tools.undo import register_undo
 from mcp_server.tools.visual_shader import register_visual_shader
 from mcp_server.toolset_protocol import SERVER_INSTRUCTIONS
 from mcp_server.toolsets import ToolsetManager, register_toolset_tools
@@ -124,6 +125,7 @@ def create_server(
     install_tool_naming(mcp)
 
     register_health(mcp, bridge, config)
+    register_undo(mcp, bridge)
     register_inspection(mcp, bridge)
     register_mutation(mcp, bridge, approval)
     register_scene_session(mcp, bridge, approval)

--- a/mcp_server/tools/undo.py
+++ b/mcp_server/tools/undo.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
+from mcp_server.models.undo import UndoResult
 from mcp_server.safety import MUTATING
 from mcp_server.tools._route import route
 
 
 def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
     @mcp.tool(meta=MUTATING, tags={CORE_TAG})
-    async def undo(count: int = 1, dry_run: bool = False) -> dict[str, Any]:
+    async def undo(count: int = 1, dry_run: bool = False) -> UndoResult:
         """Undo the last ``count`` editor actions on the current scene's history.
 
         With ``dry_run=True``, previews (``has_undo`` + ``would_undo_next``) without
@@ -23,10 +22,19 @@ def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
         nothing_to_undo}``. Undoing an empty history is a no-op (``undone == 0``,
         ``nothing_to_undo == True``), not an error — the reversibility ledger decides
         what that means.
+
+        No node/scene target to precondition — ``route()`` already surfaces a
+        disconnected bridge as a structured ``BRIDGE_DISCONNECTED`` error.
         """
         if count < 1:
             raise ToolError("count must be >= 1")  # structured, pre-bridge
         result = await route(bridge, "cmd_undo", {"count": count, "dry_run": dry_run})
+        # dry_run is authoritative from our own arg, not the addon echo; requested
+        # likewise falls back to count if the addon omitted it.
+        result["dry_run"] = dry_run
+        result.setdefault("requested", count)
         if not dry_run:
             result["nothing_to_undo"] = result.get("undone", 0) == 0
-        return result
+        # UndoResult(**result) validates the addon payload and drops mode-irrelevant
+        # (None) keys on serialization (see UndoResult.model_dump).
+        return UndoResult(**result)

--- a/mcp_server/tools/undo.py
+++ b/mcp_server/tools/undo.py
@@ -1,0 +1,32 @@
+"""Core `godot_undo` tool: pop the editor undo history N steps (S4)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from mcp_server.bridge import Bridge
+from mcp_server.categories import CORE_TAG
+from mcp_server.safety import MUTATING
+from mcp_server.tools._route import route
+
+
+def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
+    @mcp.tool(meta=MUTATING, tags={CORE_TAG})
+    async def undo(count: int = 1, dry_run: bool = False) -> dict[str, Any]:
+        """Undo the last ``count`` editor actions on the current scene's history.
+
+        With ``dry_run=True``, previews (``has_undo`` + ``would_undo_next``) without
+        undoing. Otherwise returns ``{undone, requested, last_action,
+        nothing_to_undo}``. Undoing an empty history is a no-op (``undone == 0``,
+        ``nothing_to_undo == True``), not an error — the reversibility ledger decides
+        what that means.
+        """
+        if count < 1:
+            raise ToolError("count must be >= 1")  # structured, pre-bridge
+        result = await route(bridge, "cmd_undo", {"count": count, "dry_run": dry_run})
+        if not dry_run:
+            result["nothing_to_undo"] = result.get("undone", 0) == 0
+        return result

--- a/mcp_server/tools/undo.py
+++ b/mcp_server/tools/undo.py
@@ -36,5 +36,5 @@ def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
         if not dry_run:
             result["nothing_to_undo"] = result.get("undone", 0) == 0
         # UndoResult(**result) validates the addon payload and drops mode-irrelevant
-        # (None) keys on serialization (see UndoResult.model_dump).
+        # (None) keys on serialization (see UndoResult's @model_serializer).
         return UndoResult(**result)

--- a/tests/contract/test_undo.py
+++ b/tests/contract/test_undo.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -79,3 +80,12 @@ async def test_godot_undo_reports_nothing_to_undo() -> None:
         result = await client.call_tool("godot_undo", {})
     assert result.structured_content["undone"] == 0
     assert result.structured_content["nothing_to_undo"] is True
+
+
+async def test_godot_undo_rejects_nonpositive_count() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=0))
+    with pytest.raises(ToolError, match="count"):
+        async with Client(_build(conn)) as client:
+            await client.call_tool("godot_undo", {"count": 0})
+    # cmd_undo was never sent (only bootstrap commands, if any, reached the fake)
+    assert all(CommandEnvelope.model_validate_json(m).command != "cmd_undo" for m in conn.sent)

--- a/tests/contract/test_undo.py
+++ b/tests/contract/test_undo.py
@@ -1,0 +1,81 @@
+"""Contract tests for the `godot_undo` core tool (S4).
+
+Drive the real FastMCP server over the in-memory client, backed by a fake addon
+peer with canned responses: verify the tool forwards to ``cmd_undo`` with the
+right params, maps the JSON-safe response through (adding ``nothing_to_undo``),
+previews on ``dry_run``, and rejects ``count < 1`` pre-bridge.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _undo_responder(undone: int):
+    def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_undo":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "undone": undone,
+                    "requested": cmd.params.get("count", 1),
+                    "last_action": "Create Node",
+                },
+            )
+        return None  # bootstrap commands (cmd_ping/cmd_get_project_info) auto-answered by the fake
+
+    return _responder
+
+
+def _build(conn: FakeAddonConnection) -> FastMCP:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_godot_undo_forwards_cmd_undo_with_count() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=2))
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {"count": 2})
+    assert conn.last_command().command == "cmd_undo"
+    assert conn.last_command().params == {"count": 2, "dry_run": False}
+    assert result.structured_content["undone"] == 2
+    assert result.structured_content["nothing_to_undo"] is False
+
+
+async def test_godot_undo_dry_run_previews_without_undoing() -> None:
+    def _preview(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_undo":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "dry_run": True,
+                    "requested": 1,
+                    "has_undo": True,
+                    "would_undo_next": "Create Node",
+                },
+            )
+        return None
+
+    conn = FakeAddonConnection(responder=_preview)
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {"dry_run": True})
+    assert conn.last_command().params == {"count": 1, "dry_run": True}
+    assert result.structured_content["would_undo_next"] == "Create Node"
+    assert "nothing_to_undo" not in result.structured_content  # not added on a dry-run
+
+
+async def test_godot_undo_reports_nothing_to_undo() -> None:
+    conn = FakeAddonConnection(responder=_undo_responder(undone=0))
+    async with Client(_build(conn)) as client:
+        result = await client.call_tool("godot_undo", {})
+    assert result.structured_content["undone"] == 0
+    assert result.structured_content["nothing_to_undo"] is True

--- a/tests/contract/test_undo.py
+++ b/tests/contract/test_undo.py
@@ -8,6 +8,8 @@ previews on ``dry_run``, and rejects ``count < 1`` pre-bridge.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
@@ -21,7 +23,7 @@ from tests.fakes import FakeAddonConnection, connector_for
 pytestmark = pytest.mark.asyncio
 
 
-def _undo_responder(undone: int):
+def _undo_responder(undone: int) -> Callable[[CommandEnvelope], ResponseEnvelope | None]:
     def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         if cmd.command == "cmd_undo":
             return ResponseEnvelope.success(

--- a/tests/integration/test_undo_e2e.py
+++ b/tests/integration/test_undo_e2e.py
@@ -1,0 +1,102 @@
+"""End-to-end undo smoke against a live editor (S4).
+
+Drives a single ``run_commands`` batch (create a uniquely-named child) then
+``cmd_undo``, asserting the node existed after creation and is gone after the
+undo, with ``undone == 1``. Skipped without a Godot binary (CI has no editor) —
+the one conditional skip the testing rules permit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import GODOT_BIN, GODOT_PROJECT, serve_and_await_editor
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+BRIDGE_URL = "ws://127.0.0.1:9098"
+SCRATCH = "res://tmp_e2e_undo.tscn"
+SCRATCH_FILE = GODOT_PROJECT / "tmp_e2e_undo.tscn"
+TARGET = "UndoProbe"
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = await bridge.send(command, params)
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+async def _wait_scene_open(bridge: Bridge) -> None:
+    for _ in range(40):
+        r = await bridge.send("cmd_get_active_scene")
+        if r.ok and (r.result or {}).get("is_open"):
+            return
+        await asyncio.sleep(0.25)
+    raise AssertionError("scene did not open")
+
+
+def _child_names(tree: dict[str, Any]) -> list[str]:
+    root = tree.get("tree") or {}
+    return [c["name"] for c in root.get("children", [])]
+
+
+async def _run() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    if not await serve_and_await_editor(bridge):
+        raise AssertionError("the addon never connected to the bridge")
+
+    try:
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node2D", "scene_path": SCRATCH})
+        await _wait_scene_open(bridge)
+
+        # Create the probe node in one batch, then verify it exists in the tree.
+        await _ok(
+            bridge,
+            "cmd_run_commands",
+            {
+                "commands": [
+                    {
+                        "command": "cmd_create_node",
+                        "params": {"parent_path": ".", "node_type": "Node2D", "name": TARGET},
+                    }
+                ]
+            },
+        )
+        before = await _ok(bridge, "cmd_get_scene_tree", {})
+        assert TARGET in _child_names(before), "probe node was not created"
+
+        # Undo the create, then assert the node is gone and exactly one action popped.
+        undone = await _ok(bridge, "cmd_undo", {"count": 1})
+        assert undone["undone"] == 1, undone
+        after = await _ok(bridge, "cmd_get_scene_tree", {})
+        assert TARGET not in _child_names(after), "undo did not revert the create"
+    finally:
+        await bridge.close()
+
+
+def test_live_undo_reverts_create() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GODOT_MCP_BRIDGE_URL": BRIDGE_URL},
+    )
+    try:
+        asyncio.run(_run())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        SCRATCH_FILE.unlink(missing_ok=True)


### PR DESCRIPTION
### **User description**
## Summary
Adds a `godot_undo` **core** / **mutating** tool that pops the current scene's editor undo history N steps — the reversibility primitive an autonomous agent needs to roll back mutations (subsystem **S4** of the godot-agents fluid-agent epic; generic, game-agnostic, so it lives here).

- **Addon** — `cmd_undo` handler (`command_router.gd`) undoes up to `count` actions on the current scene's `UndoRedo`; `dry_run` previews without undoing; `count < 1` → `VALIDATION_ERROR`; returns via `_ok`/`_fail`.
- **Server** — `godot_undo(count=1, dry_run=False) -> UndoResult` (`mcp_server/tools/undo.py`, `models/undo.py`), `tags={CORE_TAG}`, `count<1` → `ToolError` pre-bridge, registered in `create_server`. Empty history is a no-op (`nothing_to_undo`), not an error. Each response carries only its mode's keys (a `@model_serializer` drops the irrelevant ones).
- **Docs** — `docs/tool-contracts.md` gains the `godot_undo` entry.
- Includes the implementation **plan** under `docs/superpowers/plans/`.

## Acceptance criteria (issue #290)
- [x] `godot_undo` core tool, `mutating`, typed `UndoResult`.
- [x] `cmd_undo` addon handler; `count<1` → `VALIDATION_ERROR`.
- [x] Contract tests — forward+params, dry-run preview, nothing-to-undo, count<1 pre-bridge guard.
- [x] Live-editor e2e smoke (create→undo→reverted); skips without `GODOT_BIN`.
- [x] `docs/tool-contracts.md` updated.

## Test plan / preflight
- `tests/contract/test_undo.py` — 4 contract tests green; contract+unit suites **515 passed**.
- `tests/integration/test_undo_e2e.py` — actually **ran and passed against a real Godot editor** this session (node created, then reverted, `undone == 1`); skips in CI without a Godot binary.
- `ruff` clean; `ruff format --check` clean; zero-skip gate clean; `mypy mcp_server` clean (103 files, includes the new tool + model).

## Notes / deviations
- **mypy:** `uv run mypy mcp_server` is clean. The bare `uv run mypy` (which also scans `tests/`) hits a **pre-existing** environment error in `numpy/__init__.pyi` (3.12 `type` syntax under `python_version = 3.11`) unrelated to this change — no file here imports numpy.
- **Editor undo API:** the GDScript uses `get_object_history_id`/`get_history_undo_redo`/`GLOBAL_HISTORY` (the plan's assumed 4.7 form, flagged with a comment). It was **validated by the live e2e smoke passing** against the real editor; a formal API spike (plan Task 1) is still worth a confirming pass on other Godot versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
enhancement


___

### **Description**
- Adds `godot_undo` core tool for agent-driven editor undo

- Supports dry-run previews and validation

- Enables reversibility for autonomous scene mutations

- Includes contract tests and live-editor smoke test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["godot/addons/godot_mcp/command_router.gd"] -- "cmd_undo handler" --> B["EditorUndoRedoManager"]
  B -- "undo history" --> C["mcp_server/tools/undo.py"]
  C -- "forward to cmd_undo" --> D["mcp_server/server.py"]
  D -- "register_undo" --> E["FastMCP tool: godot_undo"]
  E -- "typed UndoResult" --> F["tests/contract/test_undo.py"]
  F -- "contract tests" --> G["tests/integration/test_undo_e2e.py"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>undo.py</strong><dd><code>Typed UndoResult model with mode-specific fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-d00ccbbf6a587b4dc7cc8b0b8f6b2fd20be837980e6ff6e0e0ead69849fdb459">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>undo.py</strong><dd><code>Core godot_undo tool implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-1cdfb81f3c8aa8f80638149212b1cbc3fe436be79ef00229b6dc8abf9b739f59">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>command_router.gd</strong><dd><code>GDScript cmd_undo handler for editor history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server.py</strong><dd><code>Register undo tool in server lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-f24be50e829d65c1c3626dad15c1b306dd882fc305e41024df58c9a7649f07b3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_undo.py</strong><dd><code>Contract tests for undo tool behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-f42d6e994094f349d656c689dde5eb0f153d05fcfa775e7e8a7ff11a6e2e7f18">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_undo_e2e.py</strong><dd><code>Live-editor end-to-end undo smoke test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-68c14e9c43accf207c7203f4e093d191e172e684772ab314bbf3ff3cd01fd39e">+102/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>2026-07-01-s4-godot-mcp-undo-tool.md</strong><dd><code>Implementation plan documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-f24b7b85081af7abb77d5cc92d5e593775a772803d20a10c4a5568164538cb13">+305/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Update tool contracts with godot_undo entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/291/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

