### PR TITLE
Fix graceful shutdown to suppress CancelledError on Ctrl-C teardown

### DIFF
--- a/mcp_server/bridge.py
+++ b/mcp_server/bridge.py
@@ -160,16 +160,23 @@ class Bridge:
             logger.debug("bridge peer connected")
 
     async def close(self) -> None:
-        """Stop listening, drop the peer, and fail any in-flight requests."""
+        """Stop listening, drop the peer, and fail any in-flight requests.
+
+        Runs on the lifespan-teardown path, so a Ctrl-C / shutdown can cancel the task
+        while we await the peer's or listener's close. Suppress that ``CancelledError``
+        so teardown still completes (server dropped, pending requests failed) instead of
+        escaping as a traceback — the process is already on its way down."""
         if self._reader is not None:
             self._reader.cancel()
             self._reader = None
         if self._conn is not None:
-            await self._conn.close()
+            with suppress(asyncio.CancelledError):
+                await self._conn.close()
             self._conn = None
         if self._server is not None:
             self._server.close()
-            await self._server.wait_closed()
+            with suppress(asyncio.CancelledError):
+                await self._server.wait_closed()
             self._server = None
         self._fail_pending("BRIDGE_DISCONNECTED", "Bridge closed.")
 

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -25,10 +25,15 @@ def main() -> None:
     logger.info("starting godot-mcp", extra={"transport": config.transport})
 
     server = create_server(config)
-    if config.transport == "http":
-        server.run(transport="http", host=config.host, port=config.port)
-    else:
-        server.run(transport="stdio")
+    try:
+        if config.transport == "http":
+            server.run(transport="http", host=config.host, port=config.port)
+        else:
+            server.run(transport="stdio")
+    except KeyboardInterrupt:
+        # Ctrl-C is the ordinary way to stop a long-lived server; exit quietly rather
+        # than dumping the runtime's shutdown traceback to the console.
+        logger.info("godot-mcp interrupted; shutting down")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_bridge_close_cancel.py
+++ b/tests/unit/test_bridge_close_cancel.py
@@ -1,0 +1,45 @@
+"""Shutdown resilience: ``Bridge.close()`` must survive a cancellation landing on the
+listener's ``wait_closed()`` (a Ctrl-C / lifespan teardown), tearing the bridge down and
+failing in-flight requests rather than surfacing a ``CancelledError`` traceback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import ErrorCode
+
+
+class _CancellingServer:
+    """Stand-in listener whose ``wait_closed()`` is cancelled mid-await, the way a
+    Ctrl-C-driven lifespan teardown cancels the task awaiting it."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_close_tolerates_cancelled_wait_closed() -> None:
+    bridge = Bridge(BridgeConfig())
+    server = _CancellingServer()
+    bridge._server = server  # type: ignore[assignment]
+    pending: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+    bridge._pending["1"] = pending  # type: ignore[assignment]
+
+    await bridge.close()  # must not raise CancelledError
+
+    assert server.closed is True
+    assert bridge._server is None
+    resp = pending.result()
+    assert resp.ok is False  # type: ignore[attr-defined]
+    assert resp.error == ErrorCode.BRIDGE_DISCONNECTED  # type: ignore[attr-defined]

--- a/tests/unit/test_bridge_close_cancel.py
+++ b/tests/unit/test_bridge_close_cancel.py
@@ -32,7 +32,7 @@ class _CancellingServer:
 async def test_close_tolerates_cancelled_wait_closed() -> None:
     bridge = Bridge(BridgeConfig())
     server = _CancellingServer()
-    bridge._server = server  # type: ignore[assignment]
+    bridge._server = server
     pending: asyncio.Future[object] = asyncio.get_running_loop().create_future()
     bridge._pending["1"] = pending  # type: ignore[assignment]
 
@@ -41,5 +41,5 @@ async def test_close_tolerates_cancelled_wait_closed() -> None:
     assert server.closed is True
     assert bridge._server is None
     resp = pending.result()
-    assert resp.ok is False  # type: ignore[attr-defined]
-    assert resp.error == ErrorCode.BRIDGE_DISCONNECTED  # type: ignore[attr-defined]
+    assert resp.ok is False
+    assert resp.error == ErrorCode.BRIDGE_DISCONNECTED


### PR DESCRIPTION
### **User description**
## Summary
On Ctrl-C / lifespan teardown the runtime cancels the task while `Bridge.close()` awaits the peer close or the listener's `wait_closed()`, so a `CancelledError` escaped as a traceback and `server.run()` dumped the runtime's shutdown trace.

- `Bridge.close()` wraps `await _conn.close()` and `await _server.wait_closed()` in `suppress(asyncio.CancelledError)` — teardown completes (server dropped, in-flight requests failed with `BRIDGE_DISCONNECTED`) instead of surfacing a traceback.
- `main()` catches `KeyboardInterrupt` around `server.run(...)` and logs a quiet shutdown line.

## Acceptance criteria (#292)
- [x] `Bridge.close()` tolerates a `CancelledError` on `wait_closed()`: server closed, `_server` cleared, pending requests failed with `BRIDGE_DISCONNECTED`.
- [x] Ctrl-C exits without a traceback.
- [x] Regression test pins the cancellation path (`tests/unit/test_bridge_close_cancel.py`).

## Test plan
- `tests/unit/test_bridge_close_cancel.py` — a listener whose `wait_closed()` raises `CancelledError`; `close()` must not raise, must clear `_server`, and must fail the pending request with `BRIDGE_DISCONNECTED`.
- Bridge suite + new test: 9 passed; ruff / ruff format / `mypy mcp_server` / zero-skip all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Suppresses CancelledError during bridge shutdown

- Handles Ctrl-C gracefully without tracebacks

- Ensures in-flight requests are failed properly on teardown

- Adds regression test for cancellation path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bridge.close()"] -- "suppress CancelledError" --> B["Server dropped"]
  C["main()"] -- "catch KeyboardInterrupt" --> D["Quiet shutdown"]
  B -- "fail in-flight requests" --> E["BRIDGE_DISCONNECTED"]
  D -- "no traceback" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bridge.py</strong><dd><code>Suppress CancelledError in bridge close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/bridge.py

<ul><li>Added <code>suppress(asyncio.CancelledError)</code> around <code>_conn.close()</code> and <br><code>_server.wait_closed()</code><br> <li> Updated docstring to explain cancellation context during teardown<br> <li> Ensures graceful shutdown completes without surfacing CancelledError <br>tracebacks</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/293/files#diff-155e02944cb4f2f6f7fdc1c90c4f439d6e4216c871d520eabc9818612cd816d7">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Handle KeyboardInterrupt gracefully in main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/main.py

<ul><li>Wrapped <code>server.run()</code> call in try/except to catch <code>KeyboardInterrupt</code><br> <li> Logs quiet shutdown message instead of dumping runtime traceback<br> <li> Provides clean exit on Ctrl-C interruption</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/293/files#diff-16437add317a8ba647a2b45040d67dfabf76fe53add6c4a31e4331be0b44d742">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bridge_close_cancel.py</strong><dd><code>Add regression test for bridge close cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_bridge_close_cancel.py

<ul><li>Added new test file for cancellation resilience<br> <li> Tests <code>Bridge.close()</code> with cancelled <code>wait_closed()</code><br> <li> Verifies server is closed, <code>_server</code> cleared, and pending requests <br>failed</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/293/files#diff-0cddcf37eefeb8e17b7f26888a0fa08380135629c764d8c6394fc84f334d0dca">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

