### PR TITLE
Align .graphifyignore with godot-agents and preserve grounding rules

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -35,9 +35,26 @@ godot/tests/
 # Generated graph output + its extraction cache.
 graphify-out/
 
-# CI / harness / agent meta — not the product.
+# CI / harness / agent meta — not the product. But KEEP the grounding rules
+# (.claude/rules/*.md — the addon / architecture / mcp-tools / error-handling
+# constitution): durable design rationale the graph wants (parity with
+# godot-agents). Re-include via the leaf pattern — a fully-excluded parent dir
+# can't be re-included, so exclude .claude/* then negate rules/.
 .github/
-.claude/
+.claude/*
+!.claude/rules/
+
+# Historic process artifacts — step-by-step implementation-plan checklists
+# (parity with godot-agents, which excludes docs/superpowers/plans/).
+docs/superpowers/plans/
 
 # Generated dependency lock (huge, not architecturally meaningful).
 uv.lock
+
+# Build / editor / OS junk (mostly .gitignored already; explicit for parity).
+**/.DS_Store
+**/__pycache__/
+*.pyc
+.venv/
+*.uid
+*.import


### PR DESCRIPTION
### **User description**
Closes #297.

Brings the graphify corpus to parity with godot-agents' focusing **intent** while preserving godot-mcp's existing, well-tailored exclusions (the demo game `examples/`, the `evals/` harness, and the Godot shell — keeping only `godot/addons/godot_mcp/`).

## Changes to `.graphifyignore`
- **Keep the grounding rules** — `.claude/*` + `!.claude/rules/` re-includes `.claude/rules/*.md` (the addon / architecture / mcp-tools / error-handling constitution), which was previously dropped when all of `.claude/` was excluded. This is the most valuable design rationale for the graph.
- **Exclude `docs/superpowers/plans/`** — historic step-by-step implementation-plan checklists (parity with godot-agents).
- **Add explicit build/editor-junk patterns** — `.DS_Store`, `__pycache__`, `*.pyc`, `.venv`, `*.uid`, `*.import` (mostly `.gitignore`d already; explicit for parity).

## Verification
Ran `graphify.detect` after the change:
- `.claude/rules/*.md` now included (9 files); `.claude/` non-rules (hooks, settings, worktrees) excluded.
- `docs/superpowers/plans/` excluded; `examples/`, `evals/`, `tests/` still excluded.
- `graphify-out/` remains gitignored (no graph churn).

Docs/config only — no code, no tests affected. (Contract/preflight gates N/A: no `mcp_server`/addon/test changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Aligns .graphifyignore with godot-agents focusing intent

- Re-introduces grounding rules from .claude/rules/

- Excludes historic implementation-plan checklists

- Adds explicit build/editor-junk patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".graphifyignore"] -- "Update exclusions" --> B["Keep .claude/rules/"]
  A -- "Add patterns" --> C["docs/superpowers/plans/"]
  A -- "Add patterns" --> D["Build/editor junk"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.graphifyignore</strong><dd><code>Update .graphifyignore for parity with godot-agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.graphifyignore

<ul><li>Re-introduces .claude/rules/*.md files previously excluded<br> <li> Adds exclusion for docs/superpowers/plans/<br> <li> Includes explicit build/editor-junk patterns (.DS_Store, __pycache__, <br>etc.)<br> <li> Maintains existing exclusions for examples/, evals/, tests/, and <br>graphify-out/</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/298/files#diff-22763e0d346c52e1bc2ff2e12482605434e6efe9a8312a2889f5f5cff41a2cda">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

