### PR TITLE
feat(inspection): list_scenes + actionable no-scene recovery hint (closes #304)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -159,14 +159,16 @@ never a Python traceback. The structured precondition shape (matching the bridge
 {
   "ok": false,
   "error": "PRECONDITION_FAILED",
-  "hint": "No scene is currently open. Open a scene before creating nodes.",
+  "hint": "No scene is open. Recover, don't fail: call list_scenes() … then open_scene(path) or create_scene(root_type, scene_path).",
   "required": "active_scene"
 }
 ```
 
 - `require_bridge_connected(bridge)` — Godot reachable (else `BRIDGE_DISCONNECTED`,
   `required="bridge_connected"`).
-- `require_active_scene(bridge)` — a scene is open (`required="active_scene"`).
+- `require_active_scene(bridge)` — a scene is open (`required="active_scene"`). Its hint
+  names the recovery path (`list_scenes` → `open_scene` / `create_scene`) so an agent
+  can act on the failure rather than treating no-scene as a dead-end (#304).
 - `require_node_exists(bridge, path)` — the target node path resolves (else
   `RESOURCE_NOT_FOUND`, `required="node_exists"`).
 - `require_confirmation(confirm, action)` — destructive guard (`required="confirm"`).
@@ -195,6 +197,7 @@ states return an empty model (`is_open=False` / `tree=None` / `selected=None`), 
 |------|--------|---------|----------------|
 | `godot_inspection_get_project_info` | — | `ProjectInfo { name, godot_version, main_scene?, autoloads, input_actions }` | `cmd_get_project_info` |
 | `godot_inspection_get_active_scene` | — | `ActiveScene { is_open, path?, name? }` | `cmd_get_active_scene` |
+| `godot_inspection_list_scenes` | — | `ScenesResult { scenes: [SceneEntry { path, is_main, is_open, is_active }], main_scene? }` | `cmd_list_scenes` |
 | `godot_inspection_get_scene_tree` | `max_depth: int = -1, lightweight: bool = False` | `SceneTree { tree: SceneNode? }` | `cmd_get_scene_tree` |
 | `godot_inspection_get_selected_node` | — | `SelectedNode { selected: NodeInfo? }` | `cmd_get_selected_node` |
 | `godot_inspection_get_node_properties` | `node_path: str` | `NodeInfo { node_path, type, script?, properties, children }` | `cmd_get_node_properties` |

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -17,6 +17,7 @@ func _init(router: MCPCommandRouter) -> void:
 
 func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_active_scene"] = _cmd_get_active_scene
+	handlers["cmd_list_scenes"] = _cmd_list_scenes
 	handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
 	handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
@@ -32,6 +33,53 @@ func _cmd_get_active_scene(_params: Dictionary) -> Dictionary:
 	if root == null:
 		return _router._ok({"is_open": false, "path": null, "name": null})
 	return _router._ok({"is_open": true, "path": root.scene_file_path, "name": _router._scene_name(root)})
+
+
+## List every res://*.tscn in the project + which is main / open / active (#304), so an
+## agent can decide open-vs-create when no scene is open. Read-only; JSON-safe.
+func _cmd_list_scenes(_params: Dictionary) -> Dictionary:
+	var main_scene: String = str(ProjectSettings.get_setting("application/run/main_scene", ""))
+	var open_set: Dictionary = {}
+	for p in EditorInterface.get_open_scenes():
+		open_set[p] = true
+	var active_root: Node = EditorInterface.get_edited_scene_root()
+	var active_path: String = active_root.scene_file_path if active_root != null else ""
+
+	var paths: Array = []
+	_collect_scene_files("res://", paths)
+	paths.sort()
+
+	var scenes: Array = []
+	for path in paths:
+		scenes.append({
+			"path": path,
+			"is_main": path == main_scene,
+			"is_open": open_set.has(path),
+			"is_active": active_path != "" and path == active_path,
+		})
+	return _router._ok({
+		"scenes": scenes,
+		"main_scene": (main_scene if main_scene != "" else null),
+	})
+
+
+## Recursively collect res://*.tscn / *.scn paths (skips hidden dirs like .godot),
+## mirroring the DirAccess walk in project_fs.gd.
+func _collect_scene_files(dir_path: String, out: Array) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if not name.begins_with("."):
+			var full := dir_path.path_join(name)
+			if dir.current_is_dir():
+				_collect_scene_files(full, out)
+			elif name.ends_with(".tscn") or name.ends_with(".scn"):
+				out.append(full)
+		name = dir.get_next()
+	dir.list_dir_end()
 
 
 func _cmd_get_scene_tree(params: Dictionary) -> Dictionary:

--- a/mcp_server/models/inspection.py
+++ b/mcp_server/models/inspection.py
@@ -29,6 +29,25 @@ class ActiveScene(BaseModel):
     name: str | None = None
 
 
+class SceneEntry(BaseModel):
+    """One project scene file and its editor state (#304)."""
+
+    path: str
+    is_main: bool = False  # the project's configured main scene
+    is_open: bool = False  # currently open in an editor tab
+    is_active: bool = False  # the currently edited (foreground) scene
+
+
+class ScenesResult(BaseModel):
+    """The project's scene files + which is main, for open-vs-create decisions (#304).
+
+    ``scenes`` is empty for a project with no scenes yet (a net-new signal, not an error).
+    """
+
+    scenes: list[SceneEntry] = Field(default_factory=list)
+    main_scene: str | None = None
+
+
 class SceneNode(BaseModel):
     """A node in the recursive scene-tree serialization.
 

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -164,7 +164,10 @@ async def require_active_scene(bridge: Bridge) -> None:
     _raise_if_failed(response)
     if not (response.result or {}).get("is_open"):
         raise PreconditionError(
-            "No scene is currently open. Open a scene before this action.",
+            "No scene is open. Recover, don't fail: call list_scenes() to see the "
+            "project's scenes — then open_scene(path) to edit an existing one, or "
+            "create_scene(root_type, scene_path) to start a new one (create_scene works "
+            "with no scene open). Re-run this action once a scene is open.",
             required="active_scene",
         )
 

--- a/mcp_server/tools/inspection.py
+++ b/mcp_server/tools/inspection.py
@@ -19,6 +19,7 @@ from mcp_server.models.inspection import (
     NodeProperty,
     NodePropertyList,
     ProjectInfo,
+    ScenesResult,
     SceneTree,
     SelectedNode,
 )
@@ -45,6 +46,21 @@ def register_inspection(mcp: FastMCP, bridge: Bridge) -> None:
         when no scene is open (not an error).
         """
         return ActiveScene(**await route(bridge, "cmd_get_active_scene"))
+
+    @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
+    async def list_scenes() -> ScenesResult:
+        """List the project's scene files (``res://*.tscn``) and their editor state —
+        which is the ``main_scene``, which are open, and which is active.
+
+        Call this to decide, when no scene is open, whether to OPEN an existing scene
+        (a modification / enhancement / bugfix of something already there) or CREATE a
+        net-new one:
+          - no scenes at all -> the project is empty; create_scene(root_type, path).
+          - exactly one scene -> open_scene(that path).
+          - several scenes -> open the one the request targets, or ask which to use.
+        Returns an empty ``scenes`` list for a project with no scenes yet (not an error).
+        """
+        return ScenesResult(**await route(bridge, "cmd_list_scenes"))
 
     @mcp.tool(meta=READ_ONLY, tags=INSPECTION)
     async def get_scene_tree(max_depth: MaxDepth = -1, lightweight: bool = False) -> SceneTree:

--- a/tests/contract/test_inspection.py
+++ b/tests/contract/test_inspection.py
@@ -120,6 +120,27 @@ def _populated(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 cmd.id,
                 {"node_path": cmd.params["node_path"], "groups": ["enemies", "spawnable"]},
             )
+        case "cmd_list_scenes":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "scenes": [
+                        {
+                            "path": "res://main.tscn",
+                            "is_main": True,
+                            "is_open": True,
+                            "is_active": True,
+                        },
+                        {
+                            "path": "res://enemy.tscn",
+                            "is_main": False,
+                            "is_open": False,
+                            "is_active": False,
+                        },
+                    ],
+                    "main_scene": "res://main.tscn",
+                },
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 
 
@@ -131,6 +152,8 @@ def _empty(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             return ResponseEnvelope.success(cmd.id, {"tree": None})
         case "cmd_get_selected_node":
             return ResponseEnvelope.success(cmd.id, {"selected": None})
+        case "cmd_list_scenes":
+            return ResponseEnvelope.success(cmd.id, {"scenes": [], "main_scene": None})
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
 
 
@@ -154,6 +177,27 @@ async def test_get_active_scene() -> None:
         result = await client.call_tool("godot_inspection_get_active_scene", {})
     assert result.structured_content["is_open"] is True
     assert result.structured_content["name"] == "main.tscn"
+
+
+async def test_list_scenes() -> None:
+    async with Client(_build(FakeAddonConnection(responder=_populated))) as client:
+        result = await client.call_tool("godot_inspection_list_scenes", {})
+    sc = result.structured_content
+    assert sc["main_scene"] == "res://main.tscn"
+    assert [s["path"] for s in sc["scenes"]] == ["res://main.tscn", "res://enemy.tscn"]
+    main = sc["scenes"][0]
+    assert main["is_main"] is True and main["is_open"] is True and main["is_active"] is True
+    other = sc["scenes"][1]
+    assert other["is_main"] is False and other["is_open"] is False
+
+
+async def test_list_scenes_empty_project() -> None:
+    # A net-new project (no scenes yet) returns an empty list, not an error — the agent
+    # reads this as "create a scene", not "fail".
+    async with Client(_build(FakeAddonConnection(responder=_empty))) as client:
+        result = await client.call_tool("godot_inspection_list_scenes", {})
+    assert result.structured_content["scenes"] == []
+    assert result.structured_content["main_scene"] is None
 
 
 async def test_get_scene_tree_passes_max_depth() -> None:

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -125,6 +125,7 @@ def test_router_registers_inspection_commands() -> None:
     for command in (
         "cmd_get_project_info",
         "cmd_get_active_scene",
+        "cmd_list_scenes",
         "cmd_get_scene_tree",
         "cmd_get_selected_node",
         "cmd_get_node_properties",

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -118,6 +118,9 @@ async def test_require_active_scene_fails_when_closed() -> None:
         await require_active_scene(bridge)
     assert exc.value.required == "active_scene"
     assert exc.value.error == "PRECONDITION_FAILED"
+    # The hint must name the recovery path so an agent (no human) can act (#304).
+    hint = exc.value.args[0]
+    assert "create_scene" in hint and "open_scene" in hint and "list_scenes" in hint
     await bridge.close()
 
 


### PR DESCRIPTION
## Why

"No scene open" shouldn't be a dead-end — it's a normal Godot state (and the entry point for multi-scene / net-new projects). The recovery tools already exist (`create_scene` works with no scene open; `open_scene`, `list_open_scenes`), but an agent couldn't:
1. **see what scenes exist** to decide open-vs-create, and
2. **learn the recovery path** from the failure (the `require_active_scene` hint didn't name any tool).

This adds the neutral primitives that make the state observable + the failure actionable. The *judgment* (open an existing scene for a modification, vs create a net-new one) stays in the agent, per the server's neutral-primitives boundary.

## What

- **`list_scenes()`** — read-only, `inspection` toolset (default-exposed). Returns the project's `res://*.tscn` with per-scene flags so the agent decides in **one call**:
  - `ScenesResult { scenes: [SceneEntry { path, is_main, is_open, is_active }], main_scene? }`
  - **empty list ⇒ net-new** (create) · **one scene ⇒ open it** · **several ⇒ open the targeted one or ask**.
  - Addon `cmd_list_scenes` walks `res://` via `DirAccess` (mirrors `project_fs`), + `EditorInterface.get_open_scenes()` / edited-root / `application/run/main_scene`.
- **Actionable `require_active_scene` hint** — now names the recovery path (`list_scenes` → `open_scene` / `create_scene`, noting create_scene works with no scene open), so every scene-dependent tool guides recovery instead of dead-ending.

## Tests / docs
- Contract tests (populated + empty-project), safety-hint test, addon-registration check, `docs/tool-contracts.md` entry.
- **Preflight:** `pytest` → **591 passed**; ruff + mypy clean; zero-skip clean.
- **Addon:** verified statically + by the registration test; in-editor plugin load is the manual addon preflight (per `.claude/rules/workflow.md`) — all Godot APIs used (`get_open_scenes`, `get_edited_scene_root`, `ProjectSettings` main_scene, `DirAccess`) are already used elsewhere in the addon on the pinned version.

## Non-goals
- Auto-creating/opening a scene inside a mutation tool — that workflow judgment belongs to the agent, not the neutral primitive. (Agent-side "scene resolution" — classify modify-existing vs net-new vs new-scene-for-architecture, with HITL on ambiguity — is the follow-up in godot-agents.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)