### PR TITLE
chore(ci): self-hosted runners + bump Actions to current majors (closes #306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ on:
 jobs:
   python:
     name: server (lint · types · tests)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, hybridindie]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.1
         with:
           enable-cache: true
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,12 +15,12 @@ on:
 jobs:
   variants:
     name: validate variant machinery
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, hybridindie]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.1
         with:
           enable-cache: true
 
@@ -56,7 +56,7 @@ jobs:
   #   env:
   #     MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #     - run: uv sync --frozen
   #     - run: >-
   #         uv run python -m evals.llm_eval_v2 --variant ${{ matrix.variant }}


### PR DESCRIPTION
## What

Brings godot-mcp CI in line with the pattern just applied to godot-agents:

1. **Self-hosted runners** — active jobs move off `ubuntu-latest` to `runs-on: [self-hosted, linux, hybridindie]`:
   - `ci.yml` → the `python` job (lint / mypy / zero-skip / pytest)
   - `eval.yml` → the `variants` job (nightly variant-machinery validation)
   - the commented `live-eval` job keeps its Godot-specific `[self-hosted, godot-eval]` label.
2. **Actions bumped to current majors** (clears the `actions/checkout@v4` deprecation — older Node runtime):
   - `actions/checkout` v4 → **v7**
   - `astral-sh/setup-uv` v5 → **v8.3.1** (no moving `v8` tag published; pin the exact release)

No Godot-binary `actions/cache` here — unlike godot-agents' `gdscript-parse`, neither active godot-mcp job downloads a Godot binary; the uv package cache is already handled by `setup-uv`'s `enable-cache`.

## Prerequisite (⚠️ do not merge yet)

A self-hosted runner must be registered to **hybridindie/godot-mcp** with labels `self-hosted, linux, hybridindie`. Runners are repo-scoped, so the godot-agents runner does not serve this repo. Until one is Idle/Online here, CI will queue. This PR's own CI run is the validation — merge only once it's green on the runner.

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)