### PR TITLE
chore(ci): cancel superseded CI runs (concurrency: cancel-in-progress) (closes #309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel a superseded run when a new commit lands on the same ref (iterative PR
+# pushes) — only the latest commit's CI matters, so this saves runner minutes (#309).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python:
     name: server (lint · types · tests)


### PR DESCRIPTION
## What

Mirror godot-agents' minutes-saving CI change: a top-level `concurrency` group cancels a superseded run when a newer commit lands on the same ref, so iterative PR pushes stop stacking full suites.

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

No behavior change; pure runner-minutes saver.

## Scope

- **Only** the `concurrency` block on `ci.yml`.
- **Not** mirroring godot-agents' mypy cache — measured godot-mcp mypy at **1.1s cold / 0.9s warm**; caching would add restore/save overhead for ~0.2s of savings.
- Test parallelization (`-n auto`) stays blocked on the fixed-port e2e collision (#308).
- `eval.yml` is scheduled/manual, so cancel-in-progress isn't relevant there.

Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)