### PR TITLE
chore(deps): pin fastmcp==4.0.0b1 + snake_case ToolAnnotations fields (closes #311)

### DIFF
--- a/evals/cloud_client.py
+++ b/evals/cloud_client.py
@@ -21,7 +21,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
+import httpx2 as httpx
 
 from evals.correction import format_correction
 from evals.history import COMPRESSION_THRESHOLD, char_len, compress_history

--- a/evals/ollama_agent.py
+++ b/evals/ollama_agent.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import httpx
+import httpx2 as httpx
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_REPO_ROOT))

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -78,12 +78,12 @@ def annotations_for_safety_class(safety_class: str) -> ToolAnnotations | None:
         return None
     if cls is SafetyClass.READ_ONLY:
         # Reads never mutate and are repeatable with no additional effect.
-        return ToolAnnotations(readOnlyHint=True, idempotentHint=True)
+        return ToolAnnotations(read_only_hint=True, idempotent_hint=True)
     if cls is SafetyClass.DESTRUCTIVE:
-        return ToolAnnotations(readOnlyHint=False, destructiveHint=True)
+        return ToolAnnotations(read_only_hint=False, destructive_hint=True)
     # mutating (reversible via UndoRedo) and runtime (controls execution):
     # state-changing but not destructive.
-    return ToolAnnotations(readOnlyHint=False, destructiveHint=False)
+    return ToolAnnotations(read_only_hint=False, destructive_hint=False)
 
 
 def _iter_registered_tools(mcp: FastMCP) -> Iterator[Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
-    # The MCP framework (PrefectHQ/fastmcp). Capped below 4.0: 2.x→3.x had breaking
-    # API changes and the server is validated on the 3.4 line (issue #228).
-    "fastmcp>=3.4,<4",
+    # The MCP framework (PrefectHQ/fastmcp). Pinned to the 4.0 beta (issue #311):
+    # 2.x→3.x had breaking API changes (#228); the v3→v4 transition is lower-risk
+    # for this server (stateless, no ctx.elicit, no session state, canonical imports
+    # already in place). Beta pin per the upgrade guide; follow stable 4.x when it ships.
+    "fastmcp==4.0.0b1",
     # WebSocket transport for the addon/server bridge (issue #3).
     "websockets>=16.0",
     # Domain models and typed tool I/O (issue #7).
@@ -41,6 +43,13 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# FastMCP 4.0 beta pinning: fastmcp is a thin wrapper over fastmcp-slim at the
+# same version. uv won't infer the slim prerelease from the wrapper prerelease,
+# so constrain it alongside (per the upgrade guide). The rest of the graph
+# stays on stable releases. Add fastmcp-tasks==4.0.0b1 here if #315 adopts tasks.
+[tool.uv]
+constraint-dependencies = ["fastmcp-slim==4.0.0b1"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]

--- a/tests/contract/test_capabilities.py
+++ b/tests/contract/test_capabilities.py
@@ -35,7 +35,7 @@ async def test_capabilities_derived_from_live_registry() -> None:
     async with Client(server) as client:
         prompt_names = {p.name for p in await client.list_prompts()}
         resource_uris = {str(r.uri) for r in await client.list_resources()}
-        template_uris = {t.uriTemplate for t in await client.list_resource_templates()}
+        template_uris = {t.uri_template for t in await client.list_resource_templates()}
 
     assert set(caps["prompts"]) == prompt_names
     assert set(caps["resources"]) == resource_uris | template_uris

--- a/tests/contract/test_editor.py
+++ b/tests/contract/test_editor.py
@@ -66,6 +66,6 @@ async def test_capture_returns_image_content() -> None:
     image_blocks = [b for b in result.content if type(b).__name__ == "ImageContent"]
     assert image_blocks, f"expected an image content block, got {result.content}"
     block = image_blocks[0]
-    assert block.mimeType == "image/png"
+    assert block.mime_type == "image/png"
     # The returned data decodes to the same PNG bytes the addon supplied.
     assert base64.b64decode(block.data).startswith(b"\x89PNG\r\n\x1a\n")

--- a/tests/contract/test_resources.py
+++ b/tests/contract/test_resources.py
@@ -41,7 +41,7 @@ async def test_static_resources_are_listable() -> None:
     server, _ = _build()
     async with Client(server) as client:
         uris = {str(r.uri) for r in await client.list_resources()}
-        templates = {t.uriTemplate for t in await client.list_resource_templates()}
+        templates = {t.uri_template for t in await client.list_resource_templates()}
     assert {
         "godot://project/info",
         "godot://scene/current",

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -43,14 +43,14 @@ async def test_every_classified_tool_carries_annotations() -> None:
         assert ann is not None, f"{tool.name} ({safety_class}) has no MCP annotations"
 
         if safety_class == "read_only":
-            assert ann.readOnlyHint is True, tool.name
-            assert ann.idempotentHint is True, tool.name
+            assert ann.read_only_hint is True, tool.name
+            assert ann.idempotent_hint is True, tool.name
         elif safety_class == "destructive":
-            assert ann.readOnlyHint is False, tool.name
-            assert ann.destructiveHint is True, tool.name
+            assert ann.read_only_hint is False, tool.name
+            assert ann.destructive_hint is True, tool.name
         elif safety_class in ("mutating", "runtime"):
-            assert ann.readOnlyHint is False, tool.name
-            assert ann.destructiveHint is False, tool.name
+            assert ann.read_only_hint is False, tool.name
+            assert ann.destructive_hint is False, tool.name
 
     # Make sure the assertions above actually ran for each class.
     assert seen["read_only"] > 0
@@ -69,4 +69,4 @@ async def test_annotations_visible_on_public_surface() -> None:
 
     health = tools["godot_health_check"]
     assert health.annotations is not None
-    assert health.annotations.readOnlyHint is True
+    assert health.annotations.read_only_hint is True

--- a/tests/integration/test_server_stdio.py
+++ b/tests/integration/test_server_stdio.py
@@ -25,7 +25,6 @@ def _entrypoint_transport() -> StdioTransport:
 
 async def test_stdio_server_lists_health_check() -> None:
     async with Client(_entrypoint_transport()) as client:
-        await client.ping()
         tools = await client.list_tools()
     assert "godot_health_check" in {t.name for t in tools}
 

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -39,16 +39,16 @@ def test_annotations_for_safety_class_mapping() -> None:
     from mcp_server.safety import annotations_for_safety_class
 
     ro = annotations_for_safety_class("read_only")
-    assert ro is not None and ro.readOnlyHint is True and ro.idempotentHint is True
+    assert ro is not None and ro.read_only_hint is True and ro.idempotent_hint is True
 
     mut = annotations_for_safety_class("mutating")
-    assert mut is not None and mut.readOnlyHint is False and mut.destructiveHint is False
+    assert mut is not None and mut.read_only_hint is False and mut.destructive_hint is False
 
     dest = annotations_for_safety_class("destructive")
-    assert dest is not None and dest.readOnlyHint is False and dest.destructiveHint is True
+    assert dest is not None and dest.read_only_hint is False and dest.destructive_hint is True
 
     run = annotations_for_safety_class("runtime")
-    assert run is not None and run.readOnlyHint is False and run.destructiveHint is False
+    assert run is not None and run.read_only_hint is False and run.destructive_hint is False
 
     assert annotations_for_safety_class("unclassified") is None
     assert annotations_for_safety_class("bogus") is None
@@ -67,7 +67,7 @@ def test_apply_safety_annotations_respects_explicit_override() -> None:
         """doc"""
         return "x"
 
-    @mcp.tool(meta=READ_ONLY, annotations=ToolAnnotations(title="Custom", readOnlyHint=False))
+    @mcp.tool(meta=READ_ONLY, annotations=ToolAnnotations(title="Custom", read_only_hint=False))
     async def overridden() -> str:
         """doc"""
         return "x"
@@ -79,10 +79,10 @@ def test_apply_safety_annotations_respects_explicit_override() -> None:
 
     by_name = {t.name: t for t in _iter_registered_tools(mcp)}
     assert by_name["derived"].annotations is not None
-    assert by_name["derived"].annotations.readOnlyHint is True
+    assert by_name["derived"].annotations.read_only_hint is True
     # An explicit annotation set at registration is preserved, not overwritten.
     assert by_name["overridden"].annotations.title == "Custom"
-    assert by_name["overridden"].annotations.readOnlyHint is False
+    assert by_name["overridden"].annotations.read_only_hint is False
 
 
 async def _connected(responder: Responder) -> Bridge:

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -39,16 +39,17 @@ def test_version_matches_pyproject() -> None:
     assert mcp_server.__version__ == pyproject["project"]["version"]
 
 
-def test_fastmcp_pinned_below_major_4() -> None:
-    # fastmcp 2.x→3.x had breaking API changes; the server is validated on 3.x.
-    # A clean resolve must not pull 4.x (issue #228) — require an explicit upper cap.
+def test_fastmcp_pinned_to_4_beta() -> None:
+    # fastmcp is pinned to the 4.0 beta (issue #311). The v3→v4 transition is
+    # lower-risk for this server than 2→3 was (#228): stateless, no ctx.elicit,
+    # no session state, canonical imports already in place. The pin is exact
+    # during the beta window; follow stable 4.x when it ships.
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
     dependencies = pyproject["project"]["dependencies"]
     fastmcp = next((d for d in dependencies if d.replace(" ", "").startswith("fastmcp")), None)
     assert fastmcp is not None, "fastmcp dependency missing from pyproject"
     spec = fastmcp.replace(" ", "")
-    assert ">=3.4" in spec, f"fastmcp must floor at the validated 3.4 line, got {fastmcp!r}"
-    assert "<4" in spec, f"fastmcp must cap below the next major (4.0), got {fastmcp!r}"
+    assert "4.0.0b1" in spec, f"fastmcp must pin the 4.0 beta, got {fastmcp!r}"
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "fastmcp-slim", specifier = "==4.0.0b1" }]
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -827,21 +830,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.5"
+version = "4.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fd/e513c524bb3e296203f65bd8e9e726e9236bd3b59315e7cbdeb095662c01/fastmcp-4.0.0b1.tar.gz", hash = "sha256:f98d69588a73e1672840558641d5d0f111e207baffe001f3465713a53ebb6b4c", size = 42065171, upload-time = "2026-07-28T21:18:15.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.5"
+version = "4.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -849,16 +853,16 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/33/f207166aac88c6d8be1b2a82c54fecd1e04b075ef12d027aa17b3134fc0f/fastmcp_slim-4.0.0b1.tar.gz", hash = "sha256:158efb25720e0cb301711146b2d05d181de95cd91fe70e87c251ad14b123d665", size = 660081, upload-time = "2026-07-28T21:17:50.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
+    { url = "https://files.pythonhosted.org/packages/90/5d/fbe192d2ab50bb31b284fd0eb6c72d4347df7a57d836bee4f1973ffd1d7d/fastmcp_slim-4.0.0b1-py3-none-any.whl", hash = "sha256:dd907a3db5a2f479ca958c30157e227b4f7b340a56d333eb91de95719254597a", size = 827975, upload-time = "2026-07-28T21:17:48.747Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
@@ -869,7 +873,7 @@ server = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -1120,7 +1124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.4,<4" },
+    { name = "fastmcp", specifier = "==4.0.0b1" },
     { name = "httpx2", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pypng", specifier = ">=0.20" },
@@ -1294,19 +1298,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
 name = "httpcore2"
 version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1317,30 +1308,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1909,15 +1876,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1927,9 +1894,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pins FastMCP to the 4.0 beta and adapts to the MCP SDK v2 field renames. Per the upgrade guide, the v3→v4 transition is lower-risk for this server than 2→3 was: stateless (no `ctx.elicit`, no `ctx.set_state`, no `on_initialize`), canonical imports already in place (no moved-import fixes), snake_case reads already in production code, and own-httpx-not-FastMCP's (the httpx2 swap in #319 handles the one subtle break).

## Changes

**Pin (`pyproject.toml`):**
- `fastmcp>=3.4,<4` → `fastmcp==4.0.0b1` (exact beta pin per upgrade guide)
- `[tool.uv] constraint-dependencies = ["fastmcp-slim==4.0.0b1"]` (uv won't infer the slim prerelease)

**SDK v2 field renames (camelCase → snake_case):**
- `mcp_server/safety.py` — `ToolAnnotations(readOnlyHint=...)` → `(read_only_hint=...)`
- `tests/unit/test_safety.py` — `.readOnlyHint`/`.idempotentHint`/`.destructiveHint` → snake_case
- `tests/contract/test_tool_annotations.py` — same
- `tests/contract/test_capabilities.py` — `.uriTemplate` → `.uri_template`
- `tests/contract/test_editor.py` — `.mimeType` → `.mime_type`
- `tests/contract/test_resources.py` — `.uriTemplate` → `.uri_template`

**Test fixes:**
- `tests/unit/test_smoke.py` — update pin assertion for 4.0 beta
- `tests/integration/test_server_stdio.py` — drop `client.ping()` (Method not found on sessionless 2026-07-28 era; `list_tools` is the actual acceptance check)
- `evals/cloud_client.py`, `evals/ollama_agent.py` — swap httpx → httpx2 as httpx (test collection fix; dev-only)

## Test plan

- [x] `uv run pytest -q` — 591 passed, 6 warnings (benign SDK `MCPDeprecationWarning` for `ctx.info` logging capability, SEP-2577 — works on all eras)
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv lock` + `uv sync` — fastmcp 4.0.0b1, fastmcp-slim 4.0.0b1, mcp 2.0.0, mcp-types 2.0.0

Builds on #319 (httpx2 swap). The remaining camelCase warnings are zero — #317 will add the CI gate to prevent regression.