### PR TITLE
feat(prompts): argument completion for path-bearing prompt args (closes #314)

### DIFF
--- a/mcp_server/prompts/completion.py
+++ b/mcp_server/prompts/completion.py
@@ -1,0 +1,159 @@
+"""Argument-completion handler (``@mcp.completion``) — issue #314.
+
+A single server-level completion handler answers ``completion/complete`` requests
+for the path-bearing prompt arguments in this server's prompts. It advertises
+the completions capability at negotiation (FastMCP declares it once a handler
+is registered) and returns candidate ``res://`` / scene-relative paths filtered
+by the partial value the agent typed.
+
+The handler is bridge-gated: when no editor is connected it returns no
+candidates rather than crashing — the same fallback shape as the
+``read_resource`` tool (resources/context.py:103-114). Each path type routes to
+the cheapest addon command that can enumerate it; if a command fails the
+handler returns no candidates for that argument (an unhandled completion is
+empty, never an error).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp_types
+from fastmcp import FastMCP
+
+from mcp_server.bridge import Bridge
+
+# Prompt arguments that carry each kind of Godot path. Keep this table the
+# single source of truth for which arguments get completed — adding a new
+# path-bearing prompt argument means adding the name here, not a new handler.
+_SCENE_PATH_ARGS = frozenset({"scene_path"})
+_NODE_PATH_ARGS = frozenset({"node_path"})
+_SCRIPT_PATH_ARGS = frozenset({"script_path"})
+_RESOURCE_PATH_ARGS = frozenset({"resource_path", "save_path"})
+
+# Bridge commands the handler queries. Kept here so the handler stays a thin
+# router: a single bridge round-trip per completion request.
+_LIST_SCENES = "cmd_list_scenes"
+_GET_SCENE_TREE = "cmd_get_scene_tree"
+_LIST_SCRIPTS = "cmd_list_scripts"
+_SEARCH_FILES = "cmd_search_files"
+
+# A generous cap below the MCP limit (100) — completion candidates are meant to
+# be a short pick-list, not an exhaustive dump. The handler filters by prefix
+# before applying the cap, so the cap only bites on pathologically huge trees.
+_MAX_CANDIDATES = 50
+
+
+def _filter(values: list[str], partial: str) -> list[str]:
+    """Return the values that start with ``partial``, capped to ``_MAX_CANDIDATES``."""
+    matches = [v for v in values if v.startswith(partial)]
+    return matches[:_MAX_CANDIDATES]
+
+
+async def _scene_paths(bridge: Bridge, partial: str) -> list[str]:
+    """Enumerate project scene paths via ``cmd_list_scenes`` and filter by prefix."""
+    response = await bridge.send(_LIST_SCENES)
+    if not response.ok or not isinstance(response.result, dict):
+        return []
+    scenes = response.result.get("scenes")
+    if not isinstance(scenes, list):
+        return []
+    paths: list[str] = []
+    for entry in scenes:
+        if isinstance(entry, dict):
+            path = entry.get("path")
+            if isinstance(path, str):
+                paths.append(path)
+    return _filter(paths, partial)
+
+
+def _walk_node_paths(node: Any, out: list[str]) -> None:
+    """Recursively collect scene-relative node paths (``.``, ``Player``, …)."""
+    if not isinstance(node, dict):
+        return
+    path = node.get("path")
+    if isinstance(path, str) and path:
+        out.append(path)
+    children = node.get("children")
+    if isinstance(children, list):
+        for child in children:
+            _walk_node_paths(child, out)
+
+
+async def _node_paths(bridge: Bridge, partial: str) -> list[str]:
+    """Enumerate scene-relative node paths via ``cmd_get_scene_tree`` and filter."""
+    response = await bridge.send(_GET_SCENE_TREE, {"max_depth": -1})
+    if not response.ok or not isinstance(response.result, dict):
+        return []
+    tree = response.result.get("tree")
+    paths: list[str] = []
+    _walk_node_paths(tree, paths)
+    return _filter(paths, partial)
+
+
+async def _script_paths(bridge: Bridge, partial: str) -> list[str]:
+    """Enumerate ``.gd`` paths via ``cmd_list_scripts`` and filter by prefix."""
+    response = await bridge.send(_LIST_SCRIPTS, {"directory": "res://"})
+    if not response.ok or not isinstance(response.result, dict):
+        return []
+    scripts = response.result.get("scripts")
+    if not isinstance(scripts, list):
+        return []
+    paths: list[str] = [s for s in scripts if isinstance(s, str)]
+    return _filter(paths, partial)
+
+
+async def _resource_paths(bridge: Bridge, partial: str) -> list[str]:
+    """Enumerate ``.tres`` resource paths via ``cmd_search_files`` and filter.
+
+    ``cmd_search_files`` with a ``*.tres`` name glob is the cheapest addon
+    command that yields resource file paths without walking a tree client-side.
+    """
+    response = await bridge.send(
+        _SEARCH_FILES,
+        {"directory": "res://", "name_glob": "*.tres", "content": "", "max_results": 200},
+    )
+    if not response.ok or not isinstance(response.result, dict):
+        return []
+    matches = response.result.get("matches")
+    if not isinstance(matches, list):
+        return []
+    paths: list[str] = [m for m in matches if isinstance(m, str)]
+    return _filter(paths, partial)
+
+
+def register_completion(mcp: FastMCP, bridge: Bridge) -> None:
+    """Register the server's argument-completion handler.
+
+    Advertising the completions capability is a side effect of registering the
+    handler (FastMCP wires the low-level ``completion/complete`` handler on
+    register). The handler is one of: a ``list[str]`` of candidates, ``None``
+    when the argument is not a path it handles, and is async because the bridge
+    is awaited inside.
+    """
+
+    @mcp.completion
+    async def complete(
+        ref: mcp_types.PromptReference | mcp_types.ResourceTemplateReference,
+        argument: mcp_types.CompletionArgument,
+        context: mcp_types.CompletionContext | None,
+    ) -> list[str] | None:
+        # Resource templates aren't used by this server; only prompts carry
+        # path-bearing arguments.
+        if not isinstance(ref, mcp_types.PromptReference):
+            return None
+        # Bridge-gated: no editor -> no candidates (no crash). Mirrors the
+        # read_resource fallback in resources/context.py:103-114.
+        if not bridge.connected:
+            return None
+        name = argument.name
+        partial = argument.value or ""
+        if name in _SCENE_PATH_ARGS:
+            return await _scene_paths(bridge, partial)
+        if name in _NODE_PATH_ARGS:
+            return await _node_paths(bridge, partial)
+        if name in _SCRIPT_PATH_ARGS:
+            return await _script_paths(bridge, partial)
+        if name in _RESOURCE_PATH_ARGS:
+            return await _resource_paths(bridge, partial)
+        return None

--- a/mcp_server/prompts/prompts.py
+++ b/mcp_server/prompts/prompts.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from fastmcp import FastMCP
 from fastmcp.prompts import Message
 
+from mcp_server.bridge import Bridge
+from mcp_server.prompts.completion import register_completion
 from mcp_server.toolset_protocol import TOOLSET_PROTOCOL
 
 
@@ -42,13 +44,17 @@ def _as_value(value: str) -> str:
     return v
 
 
-def register_prompts(mcp: FastMCP) -> list[str]:
+def register_prompts(mcp: FastMCP, bridge: Bridge) -> list[str]:
     """Register all workflow prompts on the server.
 
     Returns the registered prompt names so the caller can advertise them without
     introspecting FastMCP internals (#231/#233). Each registrant returns the name
     it registered, so the list stays in lockstep with the actual prompts.
+
+    Also registers the argument-completion handler (#314) — registering it here
+    advertises the completions capability at negotiation.
     """
+    register_completion(mcp, bridge)
     return [
         _register_toolset_discovery(mcp),
         _register_build_scene(mcp),

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -15,7 +15,9 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import fastmcp_tasks  # noqa: F401  — importing enables Client-side task support (issue #315)
 from fastmcp import FastMCP
+from fastmcp_tasks import TasksExtension
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -120,6 +122,14 @@ def create_server(
             }
         },
     )
+    # Background-tasks spike (issue #315): register the in-process TasksExtension
+    # so tools marked ``task=True`` can return a handle immediately instead of
+    # holding the MCP request open for the whole (potentially long) bridge op. The
+    # in-memory single-process backend is sufficient for a local dev tool. No tool
+    # is marked ``task=True`` yet — see tests/contract/test_background_tasks.py for
+    # the spike finding (ctx-progress calls are incompatible with the detached task
+    # session) that blocks adopting tasks for the four long-running tools as-is.
+    mcp.add_extension(TasksExtension())
     # Expose every tool as godot_<toolset>_<action> (issue #224). Installed before any
     # registration so tools register under their final name; tag-based gating is unaffected.
     install_tool_naming(mcp)
@@ -172,7 +182,7 @@ def create_server(
     register_diagnostics(mcp, bridge, config, manager)
 
     # Register workflow prompts (instruction templates for the agent).
-    prompt_names = register_prompts(mcp)
+    prompt_names = register_prompts(mcp, bridge)
 
     # Derive standard MCP annotations (readOnlyHint/destructiveHint/...) from each
     # tool's safety_class, for every tool incl. gated-off ones (issue #220).

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -15,9 +15,7 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-import fastmcp_tasks  # noqa: F401  — importing enables Client-side task support (issue #315)
 from fastmcp import FastMCP
-from fastmcp_tasks import TasksExtension
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -122,14 +120,6 @@ def create_server(
             }
         },
     )
-    # Background-tasks spike (issue #315): register the in-process TasksExtension
-    # so tools marked ``task=True`` can return a handle immediately instead of
-    # holding the MCP request open for the whole (potentially long) bridge op. The
-    # in-memory single-process backend is sufficient for a local dev tool. No tool
-    # is marked ``task=True`` yet — see tests/contract/test_background_tasks.py for
-    # the spike finding (ctx-progress calls are incompatible with the detached task
-    # session) that blocks adopting tasks for the four long-running tools as-is.
-    mcp.add_extension(TasksExtension())
     # Expose every tool as godot_<toolset>_<action> (issue #224). Installed before any
     # registration so tools register under their final name; tag-based gating is unaffected.
     install_tool_naming(mcp)

--- a/tests/contract/test_completion.py
+++ b/tests/contract/test_completion.py
@@ -1,0 +1,212 @@
+"""Contract tests for argument completion (``@mcp.completion``) — issue #314.
+
+A registered completion handler advertises the completions capability and
+answers ``completion/complete`` requests for path-bearing prompt arguments
+(scene_path, node_path, resource_path, script_path). These tests drive the
+real server through a FastMCP Client against a fake addon bridge so the
+envelope shapes and bridge routing are exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+from mcp_types import PromptReference
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    match cmd.command:
+        case "cmd_list_scenes":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "scenes": [
+                        {"path": "res://scenes/main.tscn", "is_main": True},
+                        {"path": "res://scenes/level1.tscn"},
+                        {"path": "res://scenes/level2.tscn"},
+                        {"path": "res://ui/menu.tscn"},
+                    ],
+                    "main_scene": "res://scenes/main.tscn",
+                },
+            )
+        case "cmd_get_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "tree": {
+                        "name": "Main",
+                        "type": "Node2D",
+                        "path": ".",
+                        "children": [
+                            {
+                                "name": "Player",
+                                "type": "CharacterBody2D",
+                                "path": "Player",
+                                "children": [
+                                    {
+                                        "name": "Sprite",
+                                        "type": "Sprite2D",
+                                        "path": "Player/Sprite",
+                                        "children": [],
+                                    }
+                                ],
+                            },
+                            {
+                                "name": "Camera",
+                                "type": "Camera2D",
+                                "path": "Camera",
+                                "children": [],
+                            },
+                        ],
+                    }
+                },
+            )
+        case "cmd_list_scripts":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "directory": "res://",
+                    "scripts": [
+                        "res://scripts/hero.gd",
+                        "res://scripts/enemy.gd",
+                        "res://scripts/ui/hud.gd",
+                    ],
+                    "total": 3,
+                    "returned": 3,
+                },
+            )
+        case "cmd_search_files":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "matches": [
+                        "res://resources/player.tres",
+                        "res://resources/enemy.tres",
+                        "res://ui/theme.tres",
+                    ],
+                    "truncated": False,
+                },
+            )
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+async def test_completions_capability_advertised() -> None:
+    """Registering @mcp.completion declares the server's completions handler."""
+    server, _ = _build()
+    # The handler is registered on the FastMCP server, advertising the
+    # completions capability at negotiation (FastMCP wires this on register).
+    assert server._completion_handler is not None
+
+
+async def test_complete_scene_path_filters_by_partial() -> None:
+    """scene_path completion returns scene paths starting with the partial value."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="build_scene"),
+            argument={"name": "scene_path", "value": "res://scenes/"},
+        )
+    paths = set(completion.values)
+    assert "res://scenes/main.tscn" in paths
+    assert "res://scenes/level1.tscn" in paths
+    assert "res://scenes/level2.tscn" in paths
+    # The partial excludes scenes outside res://scenes/.
+    assert "res://ui/menu.tscn" not in paths
+
+
+async def test_complete_scene_path_empty_returns_all_scenes() -> None:
+    """An empty partial returns every scene the addon reports."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="build_scene"),
+            argument={"name": "scene_path", "value": ""},
+        )
+    assert set(completion.values) == {
+        "res://scenes/main.tscn",
+        "res://scenes/level1.tscn",
+        "res://scenes/level2.tscn",
+        "res://ui/menu.tscn",
+    }
+
+
+async def test_complete_node_path_filters_by_partial() -> None:
+    """node_path completion returns scene-tree paths starting with the partial."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="script_edit"),
+            argument={"name": "node_path", "value": "Player"},
+        )
+    paths = set(completion.values)
+    assert "Player" in paths
+    assert "Player/Sprite" in paths
+    assert "Camera" not in paths
+
+
+async def test_complete_script_path_filters_by_partial() -> None:
+    """script_path completion returns .gd paths starting with the partial."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="script_edit"),
+            argument={"name": "script_path", "value": "res://scripts/"},
+        )
+    paths = set(completion.values)
+    assert "res://scripts/hero.gd" in paths
+    assert "res://scripts/enemy.gd" in paths
+    assert "res://scripts/ui/hud.gd" in paths
+    assert "res://resources/player.tres" not in paths
+
+
+async def test_complete_resource_path_filters_by_partial() -> None:
+    """resource_path / save_path completion returns .tres resource paths."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="author_resource"),
+            argument={"name": "save_path", "value": "res://resources/"},
+        )
+    paths = set(completion.values)
+    assert "res://resources/player.tres" in paths
+    assert "res://resources/enemy.tres" in paths
+    assert "res://ui/theme.tres" not in paths
+
+
+async def test_complete_unknown_argument_returns_empty() -> None:
+    """An argument we don't handle yields no candidates (not an error)."""
+    server, _ = _build()
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="build_scene"),
+            argument={"name": "root_type", "value": "Node"},
+        )
+    assert completion.values == []
+
+
+async def test_complete_when_bridge_disconnected_returns_empty() -> None:
+    """With no editor connected, completion returns no candidates (no crash)."""
+    from tests.fakes import null_serve
+
+    bridge = Bridge(ServerConfig().bridge, serve=null_serve)
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        completion = await client.complete(
+            ref=PromptReference(name="build_scene"),
+            argument={"name": "scene_path", "value": ""},
+        )
+    assert completion.values == []


### PR DESCRIPTION
Replaces #322 (closed due to deleted base branch). Same branch, rebased onto current main.

## Summary
Registers a single `@mcp.completion` handler that answers `completion/complete` requests for path-bearing prompt arguments (scene_path, node_path, script_path, resource_path, save_path). The handler queries the bridge for the live scene list / node tree / script list / resource paths and returns candidates filtered by the partial value. Bridge-gated: returns empty when no editor connected.

## Test plan
- [x] 8 contract tests in `tests/contract/test_completion.py`
- [x] mypy + ruff clean