### PR TITLE
feat(tasks): background task spike for long-running tools (closes #315)

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -15,7 +15,9 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import fastmcp_tasks  # noqa: F401  — importing enables Client-side task support (issue #315)
 from fastmcp import FastMCP
+from fastmcp_tasks import TasksExtension
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -120,6 +122,14 @@ def create_server(
             }
         },
     )
+    # Background-tasks spike (issue #315): register the in-process TasksExtension
+    # so tools marked ``task=True`` can return a handle immediately instead of
+    # holding the MCP request open for the whole (potentially long) bridge op. The
+    # in-memory single-process backend is sufficient for a local dev tool. No tool
+    # is marked ``task=True`` yet — see tests/contract/test_background_tasks.py for
+    # the spike finding (ctx-progress calls are incompatible with the detached task
+    # session) that blocks adopting tasks for the four long-running tools as-is.
+    mcp.add_extension(TasksExtension())
     # Expose every tool as godot_<toolset>_<action> (issue #224). Installed before any
     # registration so tools register under their final name; tag-based gating is unaffected.
     install_tool_naming(mcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # 2.x→3.x had breaking API changes (#228); the v3→v4 transition is lower-risk
     # for this server (stateless, no ctx.elicit, no session state, canonical imports
     # already in place). Beta pin per the upgrade guide; follow stable 4.x when it ships.
-    "fastmcp==4.0.0b1",
+    "fastmcp[tasks]==4.0.0b1",
     # WebSocket transport for the addon/server bridge (issue #3).
     "websockets>=16.0",
     # Domain models and typed tool I/O (issue #7).
@@ -47,9 +47,13 @@ build-backend = "hatchling.build"
 # FastMCP 4.0 beta pinning: fastmcp is a thin wrapper over fastmcp-slim at the
 # same version. uv won't infer the slim prerelease from the wrapper prerelease,
 # so constrain it alongside (per the upgrade guide). The rest of the graph
-# stays on stable releases. Add fastmcp-tasks==4.0.0b1 here if #315 adopts tasks.
+# stays on stable releases. The background-tasks spike (#315) adds fastmcp-tasks
+# at the same prerelease; fastmcp-slim 4.0.0b1 already depends on the *final*
+# mcp-types 2.0.0 / mcp 2.0.0 (not the 2.0.0b2 prerelease the upgrade guide lists —
+# that pin is unsatisfiable: slim declares mcp-types>=2.0.0 which excludes b2),
+# so only fastmcp-tasks needs the prerelease pin here.
 [tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b1"]
+constraint-dependencies = ["fastmcp-slim==4.0.0b1", "fastmcp-tasks==4.0.0b1"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]

--- a/tests/contract/test_background_tasks.py
+++ b/tests/contract/test_background_tasks.py
@@ -1,0 +1,236 @@
+"""Contract tests for the FastMCP 4.0 background-tasks spike (issue #315).
+
+Spike scope: verify that a background task awaiting a bridge operation does not
+race with a concurrent MCP request that touches the same single-active-peer
+bridge, and surface what the 4.0b1 API shape actually is.
+
+Findings encoded here (the PR body mirrors these):
+  * The TasksExtension installs cleanly via ``fastmcp[tasks]==4.0.0b1`` +
+    ``constraint-dependencies = ["fastmcp-tasks==4.0.0b1"]``. The upgrade-guide
+    suggestion to also pin ``mcp==2.0.0b2`` / ``mcp-types==2.0.0b2`` is
+    *unsatisfiable*: fastmcp-slim 4.0.0b1 declares ``mcp-types>=2.0.0`` (final),
+    which excludes the 2.0.0b2 prerelease. The final 2.0.0 versions already in
+    the graph are correct; only ``fastmcp-tasks`` needs the prerelease pin.
+  * The 4.0b1 server API: ``mcp.add_extension(TasksExtension())`` then
+    ``@mcp.tool(task=True)``. The client API: ``import fastmcp_tasks`` (enables
+    client-side task support) then ``call_tool_task(client, name, args)`` ->
+    ``ToolTask`` with ``.task_id``, ``.status()``, ``.result()``, ``.wait()``,
+    ``.cancel()``. A task tool carries ``tool.task_config.mode == 'optional'``;
+    a normal tool is ``'forbidden'``.
+  * Concurrent bridge access is SAFE: the bridge's per-``id`` future map means
+    multiple in-flight ``send()`` calls on the same active peer resolve
+    independently via the shared read loop. The ``_attach_lock`` only serialises
+    *peer swap*, not sends, so a background task awaiting a bridge response does
+    not block or race a concurrent ``send``. This is the spike's main answer.
+  * LIMITATION (the blocker): a tool body that uses ``ctx.info`` /
+    ``ctx.report_progress`` (as ``run_and_capture``, ``run_tests``,
+    ``export_project`` and ``bake_navigation_mesh`` all do) CANNOT run as a
+    background task as-is. ``task=True`` is not opt-in per call — it routes
+    *every* invocation (plain ``call_tool`` included) through the task input
+    loop, which runs detached from the MCP request session, so ``ctx.session``
+    is ``None`` and ``ctx.info`` raises ``RuntimeError: session is not
+    available``. Adopting ``task=True`` for those four tools requires first
+    refactoring them to drop or guard the ctx-progress calls. The spike
+    therefore leaves them all un-tasked and documents the finding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import fastmcp_tasks  # noqa: F401  — enables Client-side task support
+import pytest
+from fastmcp import Client, Context, FastMCP
+from fastmcp_tasks import TasksExtension, call_tool_task
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig, ServerConfig
+from mcp_server.runtime import RunOutput
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+TASKS_EXT_KEY = "io.modelcontextprotocol/tasks"
+
+
+class SlowRunner:
+    """A Runner double whose ``run`` awaits ``delay`` before returning, so the
+    tool call is genuinely in-flight (and the MCP request held open) for a
+    measurable window — the condition the spike wants to background."""
+
+    def __init__(self, output: RunOutput, delay: float, binary: str | None = "fake-godot") -> None:
+        self.binary = binary
+        self._output = output
+        self._delay = delay
+        self.started = asyncio.Event()
+        self.finished = asyncio.Event()
+
+    async def run(self, project_dir: str, scene: str | None, timeout: float) -> RunOutput:
+        self.started.set()
+        await asyncio.sleep(self._delay)
+        self.finished.set()
+        return self._output
+
+    async def check_script(self, project_dir: str, script_path: str, timeout: float) -> RunOutput:
+        return self._output
+
+    async def export(
+        self, project_dir: str, preset: str, output_path: str, debug: bool, timeout: float
+    ) -> RunOutput:
+        return self._output
+
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
+        return self._output
+
+
+async def test_tasks_extension_is_registered_on_the_server() -> None:
+    """``create_server`` registers the TasksExtension (spike artifact) so the
+    server is ready to host ``task=True`` tools once a tool is refactored to be
+    task-safe. No tool is currently marked ``task=True`` — see the reproducers
+    below for why."""
+    server = create_server()
+    extensions = server._extensions
+    assert TASKS_EXT_KEY in extensions
+    assert isinstance(extensions[TASKS_EXT_KEY], TasksExtension)
+
+
+async def test_run_and_capture_is_not_marked_task_to_avoid_ctx_session_breakage() -> None:
+    """The spike reverted ``task=True`` on ``run_and_capture``: marking it
+    task-capable routes *all* calls (not just ``call_tool_task``) through the
+    task input loop, which runs detached from the MCP session — so the tool
+    body's ``ctx.info`` / ``ctx.report_progress`` raise ``session is not
+    available``. ``task_config.mode`` is therefore ``'forbidden'`` (the default),
+    confirming the revert. See ``test_ctx_progress_in_task_body_raises`` for the
+    reproducer of the underlying mechanism."""
+    runner = SlowRunner(RunOutput(command=["fake"]), delay=0.01)
+    config = ServerConfig(godot_project_dir="/tmp/proj")
+    bridge = Bridge(config.bridge, connector=connector_for(FakeAddonConnection()))
+    server = create_server(config, bridge=bridge, runner=runner)
+    # The runtime toolset is gated off by default; enable it so the tool is
+    # registered (and thus introspectable via get_tool).
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+    tool = await server.get_tool("godot_runtime_run_and_capture")
+    assert tool is not None
+    assert tool.task_config is not None
+    assert tool.task_config.mode == "forbidden"
+
+
+async def test_ctx_free_task_runs_as_background_task_and_polls_to_result() -> None:
+    """Control case: a task-enabled tool that does NOT touch ``ctx`` runs as a
+    background task — ``call_tool_task`` returns a handle immediately and
+    ``task.result()`` resolves to the structured output. This confirms the
+    TasksExtension + 4.0b1 API works end-to-end in-process; the reason
+    ``run_and_capture`` itself isn't task-enabled is the ctx-session reproducer
+    below, not a problem with the tasks machinery."""
+    server = FastMCP("control")
+    server.add_extension(TasksExtension())
+
+    @server.tool(task=True)
+    async def double(x: int) -> int:
+        await asyncio.sleep(0.02)
+        return x * 2
+
+    async with Client(server) as client:
+        task = await call_tool_task(client, "double", {"x": 21})
+        assert task.task_id  # a real handle, not None
+        result = await task.result()
+    assert result.is_error is False
+    assert result.structured_content == {"result": 42}
+
+
+async def test_concurrent_bridge_access_works_while_background_task_in_flight() -> None:
+    """The spike's central question: while a background task is awaiting a slow
+    bridge operation, can a second concurrent ``bridge.send`` proceed and complete
+    correctly on the same single-active-peer bridge?
+
+    Answer: YES. The bridge's per-``id`` future map means concurrent in-flight
+    sends resolve independently via the shared read loop; the ``_attach_lock``
+    only serialises peer *swap*, not sends. A background task awaiting a bridge
+    response does not block or race a concurrent send on the same active peer.
+
+    This uses a ctx-free task tool so the mechanism is exercised (a real bridge
+    send in flight) without the ctx.session failure short-circuiting the probe.
+    """
+    bridge = Bridge(BridgeConfig(), connector=connector_for(FakeAddonConnection()))
+    server = FastMCP("probe")
+    server.add_extension(TasksExtension())
+
+    in_flight = asyncio.Event()
+
+    @server.tool(task=True)
+    async def slow_bridge_op() -> str:
+        # A real bridge.send on the shared bridge — the exact pattern
+        # bake/export/run_tests use, awaited while we fire concurrent sends.
+        in_flight.set()
+        env = await bridge.send("cmd_get_project_info")
+        return f"task:{env.ok}"
+
+    await bridge.serve()
+    async with Client(server) as client:
+        task = await call_tool_task(client, "slow_bridge_op", {})
+        await asyncio.wait_for(in_flight.wait(), timeout=1.0)
+        # While the task's bridge.send is in flight, fire two concurrent direct
+        # sends on the SAME bridge the task is using.
+        ping_p, info_p = await asyncio.gather(
+            bridge.send("cmd_ping"),
+            bridge.send("cmd_get_project_info"),
+        )
+        assert ping_p.ok and ping_p.result == {"pong": True}
+        assert info_p.ok
+        assert info_p.result is not None
+        assert info_p.result["project_path"] == "/tmp/test_project"
+        result = await task.result()
+    assert result.is_error is False
+    assert result.structured_content == {"result": "task:True"}
+
+
+async def test_ctx_progress_in_task_body_raises_session_unavailable() -> None:
+    """Spike finding reproducer: a task-enabled tool whose body calls
+    ``ctx.info`` / ``ctx.report_progress`` raises at runtime because the
+    detached background task runs outside the MCP request session
+    (``ctx.session`` is ``None``). Marking such a tool ``task=True`` routes
+    *all* calls (not just ``call_tool_task``) through the task input loop, so
+    even a plain ``call_tool`` breaks the same way — this is why the spike
+    reverted ``task=True`` on ``run_and_capture``, ``run_tests``,
+    ``export_project`` and ``bake_navigation_mesh`` (all use ctx progress).
+    Adopting background tasks for them requires first refactoring away the
+    ctx-progress calls or guarding them for the task path.
+    """
+    server = FastMCP("ctx-probe")
+    server.add_extension(TasksExtension())
+
+    @server.tool(task=True)
+    async def uses_ctx_progress(x: int, *, ctx: Context) -> int:
+        # Mirrors run_and_capture's `await ctx.info(...)` / `ctx.report_progress`.
+        await ctx.info("working")  # raises: session is not available
+        return x
+
+    async with Client(server) as client:
+        task = await call_tool_task(client, "uses_ctx_progress", {"x": 1}, raise_on_error=False)
+        result = await task.result()
+    assert result.is_error is True
+    content = str(result.content)
+    assert "session is not available" in content or "session has not been established" in content
+
+
+async def test_ctx_progress_task_also_breaks_plain_call_tool() -> None:
+    """The decisive spike finding: ``task=True`` is not opt-in per call. It routes
+    *every* invocation (plain ``call_tool`` included) through the task input loop,
+    so the ctx-session failure isn't limited to ``call_tool_task`` — the tool is
+    broken for normal callers too. This is why the spike reverts ``task=True``
+    rather than leaving it on with a "use call_tool, not call_tool_task" caveat."""
+    server = FastMCP("ctx-probe2")
+    server.add_extension(TasksExtension())
+
+    @server.tool(task=True)
+    async def uses_ctx_progress2(x: int, *, ctx: Context) -> int:
+        await ctx.info("working")
+        return x
+
+    async with Client(server) as client:
+        result = await client.call_tool("uses_ctx_progress2", {"x": 1}, raise_on_error=False)
+    assert result.is_error
+    content = str(result.content)
+    assert "session is not available" in content or "session has not been established" in content

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,10 @@ resolution-markers = [
 ]
 
 [manifest]
-constraints = [{ name = "fastmcp-slim", specifier = "==4.0.0b1" }]
+constraints = [
+    { name = "fastmcp-slim", specifier = "==4.0.0b1" },
+    { name = "fastmcp-tasks", specifier = "==4.0.0b1" },
+]
 
 [[package]]
 name = "aiofile"
@@ -253,6 +256,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +339,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/37/3712a70796583570a5a2e426163e13762ba5ec615a73e966ad18e5933954/botocore-1.43.59.tar.gz", hash = "sha256:8016da69ecc1d705249a8ef13548d3c95eec87ac1cd26133a8bdfa73ca175be0", size = 15788291, upload-time = "2026-07-29T19:33:14.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/cd/62d749f824b25c152144665f7c5eb8b5ca8be967a87e0c63577b7d4501ae/botocore-1.43.59-py3-none-any.whl", hash = "sha256:21393c35d23b19d7ba95cc4156b59f4013f80696d667997e1abd9d4e29651708", size = 15471171, upload-time = "2026-07-29T19:33:10.864Z" },
+]
+
+[[package]]
+name = "burner-redis"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/6f/ec3eeb9e3e9d7fedc51fcb56dd09da0f164495ab6fdf4caaa3754ceed659/burner_redis-0.1.6.tar.gz", hash = "sha256:362091d98c09953ef99be8bd026d75fad42599a0f153211e1a22d3e3029c7cfb", size = 843118, upload-time = "2026-04-27T17:11:41.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/cc/061897380b88c637e4bea1f6715ffba851d10b16d6610f2832ab61fa15b5/burner_redis-0.1.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5dc9c170b9994b8d57958041857f240d1b0b9ac1559d0d35473f03fb62386dea", size = 1275400, upload-time = "2026-04-27T17:11:27.07Z" },
+    { url = "https://files.pythonhosted.org/packages/db/24/e4c6fb37d059b268c2a26b173d3f84b49547e837340983d3d018c08191c6/burner_redis-0.1.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f29caae7f80fea2e47350df24264a049aeaa934454210cddcadc2336ee8b423a", size = 1223570, upload-time = "2026-04-27T17:11:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/be/718af7f42bbebbfbfd771ba43697526c922dff54d1b0d62654e21418b25e/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ce82edea4ed1ec34448a8610c62665517b3d2030254f31af32828b070a92a8", size = 1325624, upload-time = "2026-04-27T17:11:30.648Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/4f72de7f967532d3739caa461625dc9122f0ca0d46faa883c153a10d0117/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e3dff7d691ab0035468c17f51632e452b075065a30e026278ed1b297441ce93", size = 1356531, upload-time = "2026-04-27T17:11:32.201Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/22/369338d6372abd12dee51965566428c06f3badd95f668ff1c11680b99b30/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3b43f983b6e8fbc208734f04b0bae8cf95323fc43105f977d20f0993fc28c1b3", size = 1526049, upload-time = "2026-04-27T17:11:33.93Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/23/0651cf86bc5ed390fef09e30ff4a4664cc3c5b88ddf4c6b8d905acc0d60e/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b6ba097d910effff00a4610160a4a759503ad590e2c47a580bdcdac9a325823", size = 1579068, upload-time = "2026-04-27T17:11:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8c/302638fdad4476d4760d477b0f3c6b96c0f88d3f278e5f14d06eb048f788/burner_redis-0.1.6-cp310-abi3-win_amd64.whl", hash = "sha256:98c6b6fc397617cd5a6778ac020e4ed9985c393ad204f9f5cf524b68ae16070b", size = 1103735, upload-time = "2026-04-27T17:11:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ba/18668d92e18210150f7f93e2930264ad77a82e4d3e5f74ca1aecc002f78f/burner_redis-0.1.6-cp310-abi3-win_arm64.whl", hash = "sha256:c2583e98f9a3836ac2c6243ea0c8d56b40e7017b46617991e329bc807c544bad", size = 1029386, upload-time = "2026-04-27T17:11:40.266Z" },
 ]
 
 [[package]]
@@ -658,6 +686,14 @@ wheels = [
 ]
 
 [[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -840,6 +876,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
 ]
 
+[package.optional-dependencies]
+tasks = [
+    { name = "fastmcp-tasks" },
+]
+
 [[package]]
 name = "fastmcp-slim"
 version = "4.0.0b1"
@@ -890,6 +931,20 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "fastmcp-tasks"
+version = "4.0.0b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis", marker = "sys_platform == 'win32'" },
+    { name = "fastmcp-slim", extra = ["server"] },
+    { name = "pydocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0a5613519eddd08fe674635ecd88ddae3f435f643141b725bb32834d7945/fastmcp_tasks-4.0.0b1.tar.gz", hash = "sha256:44f3a70a4241f82ff81c9fce477969aeb8cc06430985d7c37cb393eba791360e", size = 50552, upload-time = "2026-07-28T21:18:08.329Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/d3/48a891e14819d7b94304a0f360ceef5731e6d69477a28ded54fc43c3e286/fastmcp_tasks-4.0.0b1-py3-none-any.whl", hash = "sha256:221f1cca93213baeeea79a02fe70a69fea7c1902ed42e3f7a0f7f01d0c704869", size = 61363, upload-time = "2026-07-28T21:18:07.396Z" },
 ]
 
 [[package]]
@@ -1105,7 +1160,7 @@ name = "godot-mcp"
 version = "2026.6.1"
 source = { editable = "." }
 dependencies = [
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx2" },
     { name = "pydantic" },
     { name = "pypng" },
@@ -1124,7 +1179,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = "==4.0.0b1" },
+    { name = "fastmcp", extras = ["tasks"], specifier = "==4.0.0b1" },
     { name = "httpx2", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pypng", specifier = ">=0.20" },
@@ -2602,6 +2657,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2750,6 +2814,9 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -2969,6 +3036,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/bf/7f1134e990855f373e5ee6ba316db8fe654a2d7dd852b41ab890fcfb91e3/pydocket-0.20.1.tar.gz", hash = "sha256:d72b3784e4b5069b39e5f49f599d54a891e1b6222c27a8bcfbd4dee0f57d4895", size = 361993, upload-time = "2026-05-06T14:06:25.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/9d/1bd873a0ea480dec388c40ac1a7500c129efbb9d61e2fef6b97236703458/pydocket-0.20.1-py3-none-any.whl", hash = "sha256:c886ece90ac93018f069d1eef9443f888404081d7258955e16847752575c95ae", size = 102774, upload-time = "2026-05-06T14:06:24.548Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3066,6 +3157,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -3170,6 +3270,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -3581,6 +3693,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3715,6 +3836,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces #323 (closed due to deleted base branch). Same branch, rebased onto current main.

## Summary
Spike: registers `TasksExtension()` and tests concurrent bridge access during background task execution. **Finding: `task=True` is not opt-in per call** — it routes every invocation through a detached session where `ctx.info`/`ctx.report_progress` raise `RuntimeError: session is not available`. All four long-running tools use ctx-progress, so none can be marked `task=True` without first refactoring away the progress calls. The `TasksExtension` registration is left inert; 6 contract tests document the finding.

## Test plan
- [x] 6 contract tests in `tests/contract/test_background_tasks.py`
- [x] mypy + ruff clean