### PR TITLE
stabilize(server): public provider surface + test migrations (closes #313)

### DIFF
--- a/mcp_server/capabilities.py
+++ b/mcp_server/capabilities.py
@@ -1,0 +1,84 @@
+"""The ``godot_mcp`` experimental capability snapshot (issue #231/#313).
+
+FastMCP 4.0 introduced the ``ServerExtension`` API (SEP-2133) for structured
+opt-in server capabilities. A ``ServerExtension`` advertises its settings under
+``ServerCapabilities.extensions[identifier]`` — a *distinct* field from
+``ServerCapabilities.experimental``. The existing ``godot_mcp`` capability is
+advertised under ``experimental`` (consumed by clients reading
+``experimental.godot_mcp``), and the contract test
+(``tests/contract/test_capabilities.py``) pins that location.
+
+Migrating ``godot_mcp`` to ``ServerExtension.settings()`` would relocate it to
+``capabilities.extensions["dev.godot/godot_mcp"]`` — a wire-level
+capability-location change that breaks existing clients and the contract test.
+That relocation is a backwards-incompatible contract change, out of scope for
+this stabilization issue (which only replaces private-API reaches with the
+public provider surface). When the contract is intentionally revised to move
+``godot_mcp`` from ``experimental`` to the extensions slot, the natural
+expression is a ``GodotMcpExtension(ServerExtension)`` whose ``settings()``
+returns the snapshot below; the structure of this module is shaped so that
+migration is a one-step move.
+
+For now the snapshot is built from the public provider surface
+(``manager.status()`` for toolset_count, and the registrant-reported prompt /
+resource names) and written into ``experimental_capabilities["godot_mcp"]`` via
+the FastMCP constructor / ``_apply_capabilities``. No ``_components`` reach is
+required: the counts already come from the registry, not from introspecting
+FastMCP internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from mcp_server.toolsets import ToolsetManager
+
+CAPABILITY_KEY = "godot_mcp"
+
+STATIC_CAPABILITY: dict[str, Any] = {
+    "version": "2026.06.01",
+    "min_godot": "4.4",
+    "docs": {
+        "tutorial": "https://github.com/hybridindie/godot-mcp/blob/main/TUTORIAL.md",
+        "tool_contracts": "https://github.com/hybridindie/godot-mcp/blob/main/docs/tool-contracts.md",
+        "architecture": "https://github.com/hybridindie/godot-mcp/blob/main/docs/architecture.md",
+    },
+}
+
+
+def build_capability(
+    manager: ToolsetManager, prompts: list[str], resources: list[str]
+) -> dict[str, Any]:
+    """Build the live ``godot_mcp`` capability snapshot from the registry.
+
+    ``toolset_count`` comes from ``manager.status()`` (the gated toolsets plus
+    the always-on ``core`` toolset — everything ``list_toolsets`` reports);
+    ``prompts`` and ``resources`` are the names/URIs the registration functions
+    report, so the snapshot tracks the catalog without introspecting FastMCP
+    internals.
+    """
+    return {
+        **STATIC_CAPABILITY,
+        "toolset_count": len(manager.status()),
+        "prompts": list(prompts),
+        "resources": list(resources),
+    }
+
+
+def apply_capability(
+    mcp: FastMCP, manager: ToolsetManager, prompts: list[str], resources: list[str]
+) -> None:
+    """Write the live snapshot into ``experimental_capabilities["godot_mcp"]``.
+
+    The static fields (version / min_godot / docs) are seeded by the
+    ``FastMCP`` constructor; this overwrites the dynamic fields
+    (toolset_count / prompts / resources) from the live registry so they can
+    never drift from the real catalog.
+    """
+    caps = mcp.experimental_capabilities[CAPABILITY_KEY]
+    snapshot = build_capability(manager, prompts, resources)
+    caps["toolset_count"] = snapshot["toolset_count"]
+    caps["prompts"] = snapshot["prompts"]
+    caps["resources"] = snapshot["resources"]

--- a/mcp_server/diagnostics.py
+++ b/mcp_server/diagnostics.py
@@ -65,42 +65,37 @@ class ServerDiagnostics(BaseModel):
     next_steps: list[str]
 
 
-def _count_tools_by_tag(mcp: FastMCP, tag: str) -> int:
-    """Count registered tools carrying a given category tag."""
+async def _count_tools_by_tag(mcp: FastMCP, tag: str) -> int:
+    """Count registered tools carrying a given category tag.
+
+    Uses the public ``mcp.local_provider.list_tools()`` (FastMCP 4.0), which
+    returns the full set including toolset-gated (disabled) tools — matching the
+    diagnostics contract that reports a toolset's total tool count regardless of
+    whether it is currently enabled.
+    """
     count = 0
-    # Tools are stored in the local provider's _components dict under 'tool:{name}@' keys.
-    components = getattr(getattr(mcp, "_local_provider", None), "_components", {})
-    for key, component in components.items():
-        if not key.startswith("tool:"):
-            continue
-        if tag in (getattr(component, "tags", set())):
+    for tool in await mcp.local_provider.list_tools():
+        if tag in (getattr(tool, "tags", set())):
             count += 1
     return count
 
 
-def _list_prompts(mcp: FastMCP) -> list[str]:
-    """Return names of all registered prompts."""
-    names: list[str] = []
-    components = getattr(getattr(mcp, "_local_provider", None), "_components", {})
-    for key, component in components.items():
-        if not key.startswith("prompt:"):
-            continue
-        name = getattr(component, "name", "")
-        if name:
-            names.append(name)
-    return names
+async def _list_prompts(mcp: FastMCP) -> list[str]:
+    """Return names of all registered prompts via the public ``mcp.list_prompts()``."""
+    return [p.name for p in await mcp.list_prompts() if p.name]
 
 
-def _list_resources(mcp: FastMCP) -> list[str]:
-    """Return URIs of all registered resources."""
-    uris: list[str] = []
-    components = getattr(getattr(mcp, "_local_provider", None), "_components", {})
-    for key, component in components.items():
-        if not key.startswith("resource:"):
-            continue
-        uri = getattr(component, "uri", "")
-        if uri:
-            uris.append(str(uri))
+async def _list_resources(mcp: FastMCP) -> list[str]:
+    """Return URIs of all registered resources via the public ``mcp.list_resources()``.
+
+    Includes both static resources and resource templates: static resources
+    expose a concrete ``uri``; templates expose a ``uri_template``. The
+    capabilities snapshot merges both, so callers see the complete resource
+    surface advertised over the wire.
+    """
+    uris: list[str] = [str(r.uri) for r in await mcp.list_resources() if r.uri]
+    templates = await mcp.list_resource_templates()
+    uris.extend(t.uri_template for t in templates if t.uri_template)
     return uris
 
 
@@ -151,8 +146,7 @@ COMMON_ERRORS: list[dict[str, str]] = [
     {
         "symptom": "ToolError: unknown tool",
         "cause": "The toolset containing that tool is not enabled.",
-        "fix": "Call enable_toolset(\"scene_edit\") "
-        "or the relevant category before using the tool.",
+        "fix": 'Call enable_toolset("scene_edit") or the relevant category before using the tool.',
     },
     {
         "symptom": "BRIDGE_DISCONNECTED",
@@ -192,7 +186,7 @@ COMMON_ERRORS: list[dict[str, str]] = [
 ]
 
 
-def _build_toolset_summaries(mcp: FastMCP, manager: ToolsetManager) -> list[ToolsetSummary]:
+async def _build_toolset_summaries(mcp: FastMCP, manager: ToolsetManager) -> list[ToolsetSummary]:
     """Build summaries with live tool counts for every known toolset."""
     summaries: list[ToolsetSummary] = []
     for info in manager.status():
@@ -201,7 +195,7 @@ def _build_toolset_summaries(mcp: FastMCP, manager: ToolsetManager) -> list[Tool
                 name=info.name,
                 enabled=info.enabled,
                 description=info.description,
-                tool_count=_count_tools_by_tag(mcp, info.name),
+                tool_count=await _count_tools_by_tag(mcp, info.name),
                 min_godot=info.min_godot,
             )
         )
@@ -225,14 +219,12 @@ def _next_steps(bridge_connected: bool, active_scene: str | None) -> list[str]:
         steps.append("No scene is open. Open or create a scene before editing nodes.")
     else:
         steps.append(f"Active scene: {active_scene}. Ready for scene editing.")
-    steps.append(
-        "For live testing, register MCPRuntimeProbe as an autoload, "
-        "then play_scene()."
-    )
+    steps.append("For live testing, register MCPRuntimeProbe as an autoload, then play_scene().")
     return steps
 
 
 # -- registration -----------------------------------------------------------
+
 
 def register_diagnostics(
     mcp: FastMCP,
@@ -259,9 +251,9 @@ def register_diagnostics(
             contract_version=CONTRACT_VERSION,
             min_compatible_contract=MIN_COMPATIBLE_CONTRACT,
             transport=config.transport,
-            toolsets=_build_toolset_summaries(mcp, manager),
-            prompts=_list_prompts(mcp),
-            resources=_list_resources(mcp),
+            toolsets=await _build_toolset_summaries(mcp, manager),
+            prompts=await _list_prompts(mcp),
+            resources=await _list_resources(mcp),
             bridge=bridge_diag,
             active_scene=active_scene,
             common_errors=COMMON_ERRORS,

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import wraps
@@ -86,34 +86,23 @@ def annotations_for_safety_class(safety_class: str) -> ToolAnnotations | None:
     return ToolAnnotations(read_only_hint=False, destructive_hint=False)
 
 
-def _iter_registered_tools(mcp: FastMCP) -> Iterator[Any]:
+async def _iter_registered_tools(mcp: FastMCP) -> AsyncIterator[Any]:
     """Yield every registered tool object, including toolset-gated (disabled) ones.
 
-    FastMCP's public ``list_tools()`` filters out disabled tools, but annotations
-    must be applied to *all* tools so they are already correct the moment a gated
-    toolset is enabled. We read the providers' component registry directly; the
-    access is guarded so a future FastMCP internals change degrades to a no-op
-    rather than breaking server startup.
+    FastMCP's server-level ``list_tools()`` filters out disabled tools, but
+    annotations must be applied to *all* tools so they are already correct the
+    moment a gated toolset is enabled. FastMCP 4.0 exposes the local provider
+    as the public ``mcp.local_provider`` attribute, and its ``list_tools()``
+    returns the unfiltered set (filtering happens at the server level, not the
+    provider level — see ``LocalProvider.list_tools``).
     """
-    try:
-        from fastmcp.tools import Tool
-    except ImportError:
-        logger.warning("fastmcp.tools.Tool not importable; skipping safety annotations")
-        return
-
-    for provider in getattr(mcp, "providers", []):
-        for component in getattr(provider, "_components", {}).values():
-            if isinstance(component, Tool):
-                yield component
+    for tool in await mcp.local_provider.list_tools():
+        yield tool
 
 
-def apply_safety_annotations(mcp: FastMCP) -> None:
-    """Set standard MCP ``annotations`` on every tool from its ``safety_class``.
-
-    Call once after all tools are registered. An annotation set explicitly at
-    registration is preserved (treated as an intentional override).
-    """
-    for tool in _iter_registered_tools(mcp):
+async def _apply_safety_annotations_async(mcp: FastMCP) -> None:
+    """Async implementation; ``apply_safety_annotations`` runs this on a loop."""
+    async for tool in _iter_registered_tools(mcp):
         if tool.annotations is not None:
             continue
         safety_class = (tool.meta or {}).get("safety_class")
@@ -122,6 +111,40 @@ def apply_safety_annotations(mcp: FastMCP) -> None:
         annotations = annotations_for_safety_class(safety_class)
         if annotations is not None:
             tool.annotations = annotations
+
+
+def apply_safety_annotations(mcp: FastMCP) -> None:
+    """Set standard MCP ``annotations`` on every tool from its ``safety_class``.
+
+    Call once after all tools are registered. An annotation set explicitly at
+    registration is preserved (treated as an intentional override).
+
+    Enumerates tools via the public async ``mcp.local_provider.list_tools()``
+    (FastMCP 4.0). Run on a worker thread with its own event loop so this works
+    whether ``create_server`` is called from sync code or from inside an async
+    test's running loop.
+    """
+    import asyncio
+    import threading
+
+    done = threading.Event()
+    result: list[BaseException | None] = [None]
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(_apply_safety_annotations_async(mcp))
+        except BaseException as exc:  # noqa: BLE001 - re-raised on caller thread
+            result[0] = exc
+        finally:
+            loop.close()
+            done.set()
+
+    threading.Thread(target=_runner, daemon=True).start()
+    done.wait()
+    if result[0] is not None:
+        raise result[0]
 
 
 class PreconditionError(Exception):
@@ -216,9 +239,7 @@ def parse_approval_response(payload: Any) -> ApprovalResponse:
         return ApprovalResponse(approved=False, reason="malformed approval response")
 
 
-async def post_approval(
-    url: str, request: ApprovalRequest, timeout: float
-) -> ApprovalResponse:
+async def post_approval(url: str, request: ApprovalRequest, timeout: float) -> ApprovalResponse:
     """Default poster: POST the request as JSON and parse the verdict.
 
     Only transport-level failures (timeout, connection) propagate — those are the
@@ -301,9 +322,7 @@ class ApprovalGate:
         if response.approved:
             logger.info("approval granted", extra={"action": action})
             return
-        logger.info(
-            "approval denied", extra={"action": action, "reason": response.reason}
-        )
+        logger.info("approval denied", extra={"action": action, "reason": response.reason})
         raise PreconditionError(
             response.reason or f"'{action}' was denied by the human approver.",
             required="human_approval",

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -18,6 +18,7 @@ from contextlib import asynccontextmanager
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
+from mcp_server.capabilities import STATIC_CAPABILITY, apply_capability
 from mcp_server.config import ServerConfig
 from mcp_server.diagnostics import register_diagnostics
 from mcp_server.prompts import register_prompts
@@ -107,18 +108,8 @@ def create_server(
         instructions=SERVER_INSTRUCTIONS,
         website_url="https://github.com/hybridindie/godot-mcp",
         # The dynamic fields (toolset_count / prompts / resources) are filled in
-        # from the live registry after registration; see _apply_capabilities below.
-        experimental_capabilities={
-            "godot_mcp": {
-                "version": "2026.06.01",
-                "min_godot": "4.4",
-                "docs": {
-                    "tutorial": "https://github.com/hybridindie/godot-mcp/blob/main/TUTORIAL.md",
-                    "tool_contracts": "https://github.com/hybridindie/godot-mcp/blob/main/docs/tool-contracts.md",
-                    "architecture": "https://github.com/hybridindie/godot-mcp/blob/main/docs/architecture.md",
-                },
-            }
-        },
+        # from the live registry after registration; see capabilities.apply_capability.
+        experimental_capabilities={"godot_mcp": dict(STATIC_CAPABILITY)},
     )
     # Expose every tool as godot_<toolset>_<action> (issue #224). Installed before any
     # registration so tools register under their final name; tag-based gating is unaffected.
@@ -179,23 +170,7 @@ def create_server(
     apply_safety_annotations(mcp)
 
     # Fill the capabilities snapshot from the live registry so it can never drift
-    # from the real toolset / prompt / resource catalog (issue #231).
-    _apply_capabilities(mcp, manager, prompt_names, resource_uris)
+    # from the real toolset / prompt / resource catalog (issue #231/#233).
+    apply_capability(mcp, manager, prompt_names, resource_uris)
 
     return mcp
-
-
-def _apply_capabilities(
-    mcp: FastMCP, manager: ToolsetManager, prompts: list[str], resources: list[str]
-) -> None:
-    """Derive the dynamic ``experimental_capabilities`` fields from the live registry.
-
-    ``toolset_count`` comes from ``manager.status()`` (the gated toolsets plus the
-    always-on ``core`` toolset — everything ``list_toolsets`` reports); ``prompts``
-    and ``resources`` are the names the registration functions report, so the
-    snapshot tracks the catalog without introspecting FastMCP internals (#231/#233).
-    """
-    caps = mcp.experimental_capabilities["godot_mcp"]
-    caps["toolset_count"] = len(manager.status())
-    caps["prompts"] = prompts
-    caps["resources"] = resources

--- a/tests/contract/test_input_constraints.py
+++ b/tests/contract/test_input_constraints.py
@@ -15,6 +15,7 @@ from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
 
 from mcp_server.server import create_server
+from tests.helpers import list_all_tools
 
 # Params that must be bounded wherever they appear (a lower bound at minimum).
 BOUNDED_PARAMS = {
@@ -52,7 +53,7 @@ def test_targeted_numeric_params_declare_bounds() -> None:
     server = create_server()
     import asyncio
 
-    tools = asyncio.run(server._list_tools())
+    tools = asyncio.run(list_all_tools(server))
     missing_min: list[str] = []
     missing_max: list[str] = []
     checked = 0

--- a/tests/contract/test_provider_surface.py
+++ b/tests/contract/test_provider_surface.py
@@ -1,0 +1,90 @@
+"""Contract test: no FastMCP private-internals reaches (issue #313).
+
+The server must use FastMCP 4.0's public provider surface
+(``mcp.local_provider.list_tools()`` / ``mcp.list_prompts()`` /
+``mcp.list_resources()``) and ``ServerExtension`` rather than reading
+``provider._components`` or calling the private ``mcp._list_tools()``. These
+tests fail as soon as a private reach is reintroduced, since the source no
+longer contains the offending tokens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server
+from tests.helpers import list_all_tools
+
+_SOURCE_FILES = [
+    Path("mcp_server/safety.py"),
+    Path("mcp_server/diagnostics.py"),
+    Path("mcp_server/server.py"),
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: Path) -> str:
+    return (_REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_no_components_reach_in_source() -> None:
+    """``provider._components`` / ``_local_provider._components`` must not appear."""
+    offenders: list[str] = []
+    for rel in _SOURCE_FILES:
+        text = _read(rel)
+        if "_components" in text:
+            offenders.append(str(rel))
+    assert not offenders, f"private _components reach still in: {offenders}"
+
+
+def test_no_private_list_tools_in_source() -> None:
+    """``mcp._list_tools()`` must not appear in server source."""
+    offenders: list[str] = []
+    for rel in _SOURCE_FILES:
+        if "._list_tools(" in _read(rel):
+            offenders.append(str(rel))
+    assert not offenders, f"private _list_tools call still in: {offenders}"
+
+
+def test_no_getattr_components_shim_in_source() -> None:
+    """The defensive ``getattr(..., "_components", ...)`` shims must be gone."""
+    for rel in _SOURCE_FILES:
+        assert "_components" not in _read(rel), rel
+
+
+@pytest.mark.asyncio
+async def test_list_all_tools_includes_disabled() -> None:
+    """The public helper returns the full set, not just the enabled subset."""
+    mcp = create_server(ServerConfig())
+    all_tools = await list_all_tools(mcp)
+    enabled = await mcp.list_tools()
+    enabled_names = {t.name for t in enabled}
+    all_names = {t.name for t in all_tools}
+    assert enabled_names <= all_names
+    assert len(all_tools) > len(enabled), (len(all_tools), len(enabled))
+
+
+@pytest.mark.asyncio
+async def test_local_provider_is_public_attribute() -> None:
+    """``mcp.local_provider`` is a public attribute in FastMCP 4.0."""
+    mcp = create_server(ServerConfig())
+    assert mcp.local_provider is not None
+    assert hasattr(mcp.local_provider, "list_tools")
+    assert hasattr(mcp.local_provider, "list_prompts")
+    assert hasattr(mcp.local_provider, "list_resources")
+
+
+@pytest.mark.asyncio
+async def test_public_list_prompts_and_resources_match_registry() -> None:
+    """``mcp.list_prompts()`` / ``mcp.list_resources()`` are the public surface."""
+    mcp = create_server(ServerConfig())
+    prompts = await mcp.list_prompts()
+    resources = await mcp.list_resources()
+    assert prompts, "expected prompts registered"
+    assert resources, "expected resources registered"
+    assert all(hasattr(p, "name") for p in prompts)
+    assert all(hasattr(r, "uri") for r in resources)

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -16,6 +16,7 @@ from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
 from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for, make_addon_responder
+from tests.helpers import list_all_tools
 
 pytestmark = pytest.mark.asyncio
 
@@ -29,8 +30,8 @@ def _server() -> FastMCP:
 
 async def test_every_classified_tool_carries_annotations() -> None:
     server = _server()
-    # _list_tools returns ALL registered tools, including toolset-gated ones.
-    tools = await server._list_tools()
+    # list_all_tools returns ALL registered tools, including toolset-gated ones.
+    tools = await list_all_tools(server)
     assert tools, "expected a non-empty tool surface"
 
     seen = {"read_only": 0, "mutating": 0, "destructive": 0, "runtime": 0}

--- a/tests/contract/test_tool_naming.py
+++ b/tests/contract/test_tool_naming.py
@@ -12,13 +12,14 @@ from mcp_server.categories import CORE_TAG
 from mcp_server.config import ServerConfig
 from mcp_server.server import create_server
 from mcp_server.tool_naming import _category, godot_tool_name
+from tests.helpers import list_all_tools
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_every_tool_is_godot_named_and_consistent() -> None:
     mcp = create_server(ServerConfig())
-    tools = await mcp._list_tools()
+    tools = await list_all_tools(mcp)
     assert tools, "no tools registered"
 
     names: list[str] = []

--- a/tests/contract/test_value_shapes.py
+++ b/tests/contract/test_value_shapes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 
 from mcp_server.server import create_server
+from tests.helpers import list_all_tools
 
 # Every tool that takes a polymorphic ``value: Any``.
 VALUE_SETTERS = {
@@ -29,7 +30,7 @@ REQUIRED_MARKERS = ("Vector2", "Color", "NodePath")
 
 def test_value_setters_document_accepted_shapes() -> None:
     server = create_server()
-    tools = {t.name: t for t in asyncio.run(server._list_tools())}
+    tools = {t.name: t for t in asyncio.run(list_all_tools(server))}
 
     missing_tools = VALUE_SETTERS - set(tools)
     assert not missing_tools, f"setter tools not found: {sorted(missing_tools)}"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,28 @@
+"""Shared test helpers.
+
+Centralizes the few FastMCP internals the suite still needs so a future
+internals shift is a one-line fix here rather than a sweep across N files.
+
+Specifically: enumerating *all* registered tools (including toolset-gated /
+disabled ones) is required by several contract tests. FastMCP's public
+``mcp.list_tools()`` filters out disabled tools; the public
+``mcp.local_provider.list_tools()`` returns the full set (filtering happens at
+the server level, not the provider level — see FastMCP 4.0 ``LocalProvider``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+async def list_all_tools(mcp: FastMCP) -> list[Any]:
+    """Return every registered tool, including toolset-gated (disabled) ones.
+
+    Uses the public ``FastMCP.local_provider`` surface (FastMCP 4.0): the local
+    provider's ``list_tools()`` returns the unfiltered set; the server-level
+    ``FastMCP.list_tools()`` is what applies the enabled/disabled filter.
+    """
+    return list(await mcp.local_provider.list_tools())

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastmcp.exceptions import ToolError
 
@@ -25,6 +27,13 @@ from tests.fakes import FakeAddonConnection, Responder, connector_for
 
 # asyncio_mode=auto handles the async tests; no module-wide mark (it would warn on
 # the synchronous tests below).
+
+
+async def _collect(agen: Any) -> list[Any]:
+    out: list[Any] = []
+    async for item in agen:
+        out.append(item)
+    return out
 
 
 def test_safety_meta_constants() -> None:
@@ -55,6 +64,8 @@ def test_annotations_for_safety_class_mapping() -> None:
 
 
 def test_apply_safety_annotations_respects_explicit_override() -> None:
+    import asyncio
+
     from fastmcp import FastMCP
     from mcp.types import ToolAnnotations
 
@@ -74,10 +85,10 @@ def test_apply_safety_annotations_respects_explicit_override() -> None:
 
     apply_safety_annotations(mcp)
 
-    # Read back via the component registry the production code uses.
+    # Read back via the public provider surface the production code uses.
     from mcp_server.safety import _iter_registered_tools
 
-    by_name = {t.name: t for t in _iter_registered_tools(mcp)}
+    by_name = {t.name: t for t in asyncio.run(_collect(_iter_registered_tools(mcp)))}
     assert by_name["derived"].annotations is not None
     assert by_name["derived"].annotations.read_only_hint is True
     # An explicit annotation set at registration is preserved, not overwritten.

--- a/tests/unit/test_skills_metadata.py
+++ b/tests/unit/test_skills_metadata.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from mcp_server.server import create_server
+from tests.helpers import list_all_tools
 
 # Tool-call-shaped references in skill bodies, e.g. ``godot_runtime_play_scene(``.
 # The trailing ``(`` avoids matching plugin/path tokens like ``addons/godot_mcp/``.
@@ -85,7 +86,7 @@ def test_skill_tool_references_exist() -> None:
     or imagined tool), which would silently fail at call time.
     """
     server: Any = create_server()
-    tool_names = {t.name for t in asyncio.run(server._list_tools())}
+    tool_names = {t.name for t in asyncio.run(list_all_tools(server))}
     unknown: dict[str, set[str]] = {}
     for skill in _skill_dirs():
         text = (skill / "SKILL.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Replaces #324 (closed due to deleted base branch). Same branch, rebased onto current main.

## Summary
Replaces 3 `_components` private-API reaches with FastMCP 4.0's public provider surface (`mcp.local_provider.list_tools()`, `mcp.list_prompts()`, `mcp.list_resources()`). Migrates all 5 test `_list_tools()` call sites to a shared `tests/helpers.py::list_all_tools` helper. `ServerExtension` migration deferred (would relocate capabilities to a different wire field — breaking change). `enable/disable(tags=)` confirmed working.

## Test plan
- [x] 6 contract tests in `tests/contract/test_provider_surface.py`
- [x] mypy + ruff clean