### PR TITLE
refactor(safety): centralize ApprovalGate at tools/call boundary via middleware (closes #330)

### DIFF
--- a/mcp_server/approval_middleware.py
+++ b/mcp_server/approval_middleware.py
@@ -1,0 +1,62 @@
+"""Approval-gate middleware (issue #330).
+
+Centralizes the webhook ``ApprovalGate`` at the ``tools/call`` boundary so the
+``approval`` parameter no longer threads through ~6 register modules. The
+middleware inspects the called tool's ``safety_class`` meta (already set on
+every tool via ``safety.py``) and routes ``destructive`` calls through
+``approval.require(...)`` before the tool runs. ``dry_run`` short-circuits the
+gate (a preview never needs approval).
+
+The ``confirm`` bool check (``require_confirmation``) stays in each tool's
+body — it's the tool's own schema-level gate, not the webhook gate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from mcp_server.safety import ApprovalGate, PreconditionError, SafetyClass
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class ApprovalMiddleware(Middleware):
+    """Route ``destructive`` tool calls through the webhook ``ApprovalGate``.
+
+    No-op when no webhook is configured (the ``ApprovalGate`` auto-approves).
+    ``dry_run=True`` short-circuits: a preview never needs approval.
+    """
+
+    def __init__(self, approval: ApprovalGate) -> None:
+        self._approval = approval
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: Any
+    ) -> Any:
+        args = context.message.arguments or {}
+        if args.get("dry_run"):
+            return await call_next(context)
+        if not context.fastmcp_context:
+            return await call_next(context)
+        try:
+            tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
+        except Exception:
+            return await call_next(context)
+        if tool is None:
+            return await call_next(context)
+        safety_class = (tool.meta or {}).get("safety_class")
+        if safety_class != SafetyClass.DESTRUCTIVE.value:
+            return await call_next(context)
+        try:
+            await self._approval.require(
+                context.message.name, safety_class, args
+            )
+        except PreconditionError as exc:
+            raise exc.as_tool_error() from exc
+        return await call_next(context)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -19,6 +19,7 @@ import fastmcp_tasks  # noqa: F401  — importing enables Client-side task suppo
 from fastmcp import FastMCP
 from fastmcp_tasks import TasksExtension
 
+from mcp_server.approval_middleware import ApprovalMiddleware
 from mcp_server.bridge import Bridge
 from mcp_server.capabilities import STATIC_CAPABILITY, apply_capability
 from mcp_server.config import ServerConfig
@@ -82,6 +83,8 @@ def create_server(
     bridge = bridge or Bridge(config.bridge)
     runner = runner or GodotRunner(config)
     # Human-in-the-loop approval gate (issue #153); no-op unless a webhook is set.
+    # Centralized at the tools/call boundary via ApprovalMiddleware (issue #330) so
+    # the ``approval`` parameter no longer threads through register modules.
     approval = approval or ApprovalGate.from_config(config)
 
     @asynccontextmanager
@@ -113,6 +116,9 @@ def create_server(
         # from the live registry after registration; see capabilities.apply_capability.
         experimental_capabilities={"godot_mcp": dict(STATIC_CAPABILITY)},
     )
+    # Centralize the webhook ApprovalGate at the tools/call boundary (issue #330).
+    # No-op unless a webhook is configured; dry_run short-circuits in the middleware.
+    mcp.add_middleware(ApprovalMiddleware(approval))
     # Background-tasks spike (issue #315): register the in-process TasksExtension
     # so tools marked ``task=True`` can return a handle immediately instead of
     # holding the MCP request open for the whole (potentially long) bridge op. The
@@ -125,17 +131,17 @@ def create_server(
     register_health(mcp, bridge, config)
     register_undo(mcp, bridge)
     register_inspection(mcp, bridge)
-    register_mutation(mcp, bridge, approval)
-    register_scene_session(mcp, bridge, approval)
+    register_mutation(mcp, bridge)
+    register_scene_session(mcp, bridge)
     register_node_ops(mcp, bridge)
     register_resource_files(mcp, bridge)
-    register_project_fs(mcp, bridge, approval)
+    register_project_fs(mcp, bridge)
     register_physics(mcp, bridge)
     register_animation(mcp, bridge)
     register_scene_3d(mcp, bridge)
     register_particles(mcp, bridge)
     register_navigation(mcp, bridge)
-    register_audio(mcp, bridge, approval)
+    register_audio(mcp, bridge)
     register_tilemap(mcp, bridge)
     register_theme_ui(mcp, bridge)
     register_shader(mcp, bridge)
@@ -147,7 +153,7 @@ def create_server(
     register_runtime_inspect(mcp, bridge)
     register_import_asset(mcp, bridge)
     register_input_sim(mcp, bridge)
-    register_input_map(mcp, bridge, approval)
+    register_input_map(mcp, bridge)
     register_testing(mcp, bridge, config, runner)
     register_profiling(mcp, bridge)
     register_batch(mcp, bridge)
@@ -157,7 +163,7 @@ def create_server(
     register_export(mcp, bridge, config, runner)
     register_scripts(mcp, bridge, config, runner)
     register_debug_workflow(mcp, bridge, config, runner)
-    register_project_scaffold(mcp, bridge, approval)
+    register_project_scaffold(mcp, bridge)
     register_safety_tools(mcp)
 
     # Gate the tool surface by category, then apply the default exposure (core +

--- a/mcp_server/tools/audio.py
+++ b/mcp_server/tools/audio.py
@@ -32,7 +32,6 @@ from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
     READ_ONLY,
-    ApprovalGate,
     enforce_preconditions,
     require_bridge_connected,
     require_confirmation,
@@ -43,9 +42,8 @@ from mcp_server.tools._route import route, run_or_preview
 AUDIO = {AUDIO_TAG}
 
 
-def register_audio(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None) -> None:
+def register_audio(mcp: FastMCP, bridge: Bridge) -> None:
     """Register the audio tools."""
-    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=AUDIO)
     @enforce_preconditions
@@ -129,7 +127,6 @@ def register_audio(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None =
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "remove_audio_bus")
-            await approval.require("remove_audio_bus", "destructive", {"bus": bus})
         params = {"bus": bus, "confirm": True}
         preview = {"name": bus, "index": -1, "removed": False}
         return await run_or_preview(
@@ -149,9 +146,6 @@ def register_audio(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None =
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "remove_audio_bus_effect")
-            await approval.require(
-                "remove_audio_bus_effect", "destructive", {"bus": bus, "effect_index": effect_index}
-            )
         params = {"bus": bus, "effect_index": effect_index, "confirm": True}
         preview = {"bus": bus, "bus_index": -1, "effect_index": effect_index, "removed": False}
         return await run_or_preview(

--- a/mcp_server/tools/input_map.py
+++ b/mcp_server/tools/input_map.py
@@ -26,7 +26,6 @@ from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
     READ_ONLY,
-    ApprovalGate,
     enforce_preconditions,
     require_bridge_connected,
     require_confirmation,
@@ -37,10 +36,9 @@ INPUT_MAP = {INPUT_MAP_TAG}
 
 
 def register_input_map(
-    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+    mcp: FastMCP, bridge: Bridge
 ) -> None:
     """Register the input map editing tools."""
-    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=INPUT_MAP)
     @enforce_preconditions
@@ -71,7 +69,6 @@ def register_input_map(
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "remove_input_action")
-            await approval.require("remove_input_action", "destructive", {"name": name})
         params = {"name": name, "confirm": True}
         preview = {"name": name, "removed": False}
         return await run_or_preview(
@@ -140,7 +137,6 @@ def register_input_map(
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "clear_input_action_events")
-            await approval.require("clear_input_action_events", "destructive", {"action": action})
         params = {"action": action, "confirm": True}
         preview = {"action": action, "cleared": False}
         return await run_or_preview(

--- a/mcp_server/tools/mutation.py
+++ b/mcp_server/tools/mutation.py
@@ -36,7 +36,6 @@ from mcp_server.models.mutation import (
 from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
-    ApprovalGate,
     enforce_preconditions,
     require_active_scene,
     require_bridge_connected,
@@ -94,10 +93,9 @@ async def _try_set_with_suggestions(
 
 
 def register_mutation(
-    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+    mcp: FastMCP, bridge: Bridge
 ) -> None:
     """Register all eight mutation tools on the server."""
-    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
@@ -169,7 +167,6 @@ def register_mutation(
         await require_node_exists(bridge, node_path)
         if not dry_run:
             require_confirmation(confirm, "delete_node")
-            await approval.require("delete_node", "destructive", {"node_path": node_path})
         params = {"node_path": node_path, "confirm": True}
         preview = {"node_path": node_path, "deleted": False}
         return await run_or_preview(

--- a/mcp_server/tools/project_fs.py
+++ b/mcp_server/tools/project_fs.py
@@ -29,7 +29,6 @@ from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
     READ_ONLY,
-    ApprovalGate,
     enforce_preconditions,
     require_bridge_connected,
     require_confirmation,
@@ -39,7 +38,7 @@ from mcp_server.tools._route import route, run_or_preview, validate_or_raise
 PROJECT = {PROJECT_TAG}
 
 
-def register_project_fs(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate) -> None:
+def register_project_fs(mcp: FastMCP, bridge: Bridge) -> None:
     """Register the project & filesystem tools."""
 
     @mcp.tool(meta=READ_ONLY, tags=PROJECT)
@@ -127,7 +126,6 @@ def register_project_fs(mcp: FastMCP, bridge: Bridge, approval: ApprovalGate) ->
             await validate_or_raise(bridge, "cmd_delete_resource_file", params)
             return DeleteResourceFileResult(path=path, deleted=False, dry_run=True)
         require_confirmation(confirm, "delete_resource_file")
-        await approval.require("delete_resource_file", "destructive", params)
         return DeleteResourceFileResult(
             **await route(bridge, "cmd_delete_resource_file", params)
         )

--- a/mcp_server/tools/project_scaffold.py
+++ b/mcp_server/tools/project_scaffold.py
@@ -18,7 +18,6 @@ from mcp_server.categories import PROJECT_SCAFFOLD_TAG
 from mcp_server.models.project_scaffold import ScaffoldProjectResult
 from mcp_server.safety import (
     DESTRUCTIVE,
-    ApprovalGate,
     enforce_preconditions,
     require_confirmation,
 )
@@ -41,10 +40,9 @@ _SCAFFOLD_TYPES: set[str] = {
 
 
 def register_project_scaffold(
-    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+    mcp: FastMCP, bridge: Bridge
 ) -> None:
     """Register the project scaffold tool."""
-    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=DESTRUCTIVE, tags=PROJECT_SCAFFOLD)
     @enforce_preconditions
@@ -68,7 +66,6 @@ def register_project_scaffold(
             )
         if not dry_run:
             require_confirmation(confirm, "scaffold_project")
-            await approval.require("scaffold_project", "destructive", {"type": type})
         params: dict[str, str] = {
             "type": type,
             "project_name": project_name or type,

--- a/mcp_server/tools/scene_session.py
+++ b/mcp_server/tools/scene_session.py
@@ -25,7 +25,6 @@ from mcp_server.safety import (
     DESTRUCTIVE,
     MUTATING,
     READ_ONLY,
-    ApprovalGate,
     enforce_preconditions,
     require_active_scene,
     require_bridge_connected,
@@ -38,10 +37,9 @@ SCENE_EDIT = {SCENE_EDIT_TAG}
 
 
 def register_scene_session(
-    mcp: FastMCP, bridge: Bridge, approval: ApprovalGate | None = None
+    mcp: FastMCP, bridge: Bridge
 ) -> None:
     """Register scene session tools in the scene_edit toolset."""
-    approval = approval or ApprovalGate()
 
     @mcp.tool(meta=MUTATING, tags=SCENE_EDIT)
     @enforce_preconditions
@@ -69,7 +67,6 @@ def register_scene_session(
         require_bridge_connected(bridge)
         if not dry_run:
             require_confirmation(confirm, "reload_scene")
-            await approval.require("reload_scene", "destructive", {"scene_path": scene_path})
         params: dict[str, Any] = {"scene_path": scene_path, "confirm": True}
         preview = {"scene_path": scene_path, "reloaded": False}
         return await run_or_preview(


### PR DESCRIPTION
## Summary

Retires the `approval` parameter threading across 6 register modules (`mutation`, `scene_session`, `project_fs`, `audio`, `input_map`, `project_scaffold`) and the per-tool `approval.require(...)` calls. A single `ApprovalMiddleware` intercepts `tools/call`, inspects the called tool's `safety_class` meta, and routes `destructive` calls through the webhook `ApprovalGate` before the tool runs. `dry_run` short-circuits the gate (a preview never needs approval).

The `confirm` bool check (`require_confirmation`) stays in each tool's body — it's the tool's own schema-level gate, not the webhook gate.

## Changes

- **New** `mcp_server/approval_middleware.py` — `ApprovalMiddleware(Middleware)` with `on_call_tool` hook
- `mcp_server/server.py` — register `mcp.add_middleware(ApprovalMiddleware(approval))` after the `FastMCP(...)` constructor; drop `approval` arg from 6 `register_*` calls
- `mcp_server/tools/{mutation,scene_session,project_fs,audio,input_map,project_scaffold}.py` — drop the `approval` parameter, the `ApprovalGate` import, and the per-tool `approval.require(...)` calls

## Test plan

- [x] `uv run pytest -q` — 614 passed
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean
- [x] `test_delete_node_blocked_when_approval_denied` passes (the middleware converts `PreconditionError` → `ToolError` via `as_tool_error()`, preserving the structured-error shape)