### PR TITLE
docs(server): document ServerExtension investigation for capabilities (#332)

### DIFF
--- a/mcp_server/capabilities.py
+++ b/mcp_server/capabilities.py
@@ -1,28 +1,63 @@
-"""The ``godot_mcp`` experimental capability snapshot (issue #231/#313).
+"""The ``godot_mcp`` experimental capability snapshot (issue #231/#313/#332).
 
-FastMCP 4.0 introduced the ``ServerExtension`` API (SEP-2133) for structured
+FastMCP 4.0b1 introduced the ``ServerExtension`` API (SEP-2133) for structured
 opt-in server capabilities. A ``ServerExtension`` advertises its settings under
-``ServerCapabilities.extensions[identifier]`` — a *distinct* field from
+``ServerCapabilities.extensions[identifier]`` — a *distinct* wire field from
 ``ServerCapabilities.experimental``. The existing ``godot_mcp`` capability is
 advertised under ``experimental`` (consumed by clients reading
 ``experimental.godot_mcp``), and the contract test
 (``tests/contract/test_capabilities.py``) pins that location.
 
-Migrating ``godot_mcp`` to ``ServerExtension.settings()`` would relocate it to
-``capabilities.extensions["dev.godot/godot_mcp"]`` — a wire-level
-capability-location change that breaks existing clients and the contract test.
-That relocation is a backwards-incompatible contract change, out of scope for
-this stabilization issue (which only replaces private-API reaches with the
-public provider surface). When the contract is intentionally revised to move
-``godot_mcp`` from ``experimental`` to the extensions slot, the natural
-expression is a ``GodotMcpExtension(ServerExtension)`` whose ``settings()``
-returns the snapshot below; the structure of this module is shaped so that
-migration is a one-step move.
+Issue #332 investigated migrating this snapshot onto a
+``GodotMcpExtension(ServerExtension)``. Findings against FastMCP 4.0.0b1
+(``fastmcp.server.extensions.ServerExtension``, located at
+``fastmcp/server/extensions.py``):
+
+* The full ``ServerExtension`` public surface is ``identifier``, ``settings()``,
+  ``methods()``, ``lifespan()``, ``intercept_tool_call()``, ``client_settings()``
+  plus the ``server`` property and ``_bind()``. There is **no hook to write into
+  ``experimental_capabilities``** — extensions can only contribute to
+  ``ServerCapabilities.extensions[identifier]``.
+* ``settings()`` is hard-wired to ``capabilities.extensions[identifier]`` in
+  ``FastMCPServerMiddleware.get_capabilities``
+  (``fastmcp/server/low_level.py`` around the
+  ``registered_extensions = {extension.identifier: extension.settings() ...}``
+  block): the returned ``ServerCapabilities`` is rebuilt with
+  ``extensions={**existing, UI_EXTENSION_ID: {}, **registered}``, and
+  ``experimental`` is passed through unchanged from the constructor. So an
+  extension cannot relocate its advertisement into ``experimental``.
+* ``ServerExtension.identifier`` must match SEP-2133's reverse-DNS
+  ``vendor-prefix/name`` grammar (``validate_extension_identifier`` rejects
+  anything else). The bare ``godot_mcp`` key this module advertises today is
+  *not* a valid extension identifier — the closest legal identifier is
+  e.g. ``dev.godot/godot_mcp``. Any ``ServerExtension`` migration therefore
+  forces a key rename in addition to the wire-field relocation, so it is
+  doubly backwards-incompatible: clients reading
+  ``experimental.godot_mcp`` would see nothing, and the new
+  ``extensions["dev.godot/godot_mcp"]`` slot is a name they have never seen.
+
+Conclusion: option (a) — keep the capability in ``experimental`` while using the
+extension API — is **not expressible** in 4.0b1. The only available migration
+(option b) relocates the snapshot to ``extensions[<reverse-dns>]`` with a
+renamed key, breaking the contract test and any client consuming
+``experimental.godot_mcp``. That is a wire-breaking contract change that needs
+explicit sign-off, not a silent swap during stabilization. This issue is
+therefore resolved as "documented why it can't be done without a
+wire-breaking change"; the dict-mutation in ``apply_capability`` stays as the
+intentional shape until the contract is revised.
+
+When the contract is intentionally revised, the migration is a one-step move:
+subclass ``ServerExtension`` with ``identifier = "dev.godot/godot_mcp"`` (or
+whatever reverse-DNS prefix the contract lands on), override ``settings()`` to
+return ``build_capability(...)`` below, register with ``mcp.add_extension(...)``,
+and drop both the ``experimental_capabilities`` constructor seed and the
+``apply_capability`` call. The snapshot construction (``build_capability``) is
+already provider-surface-derived and unchanged by the relocation.
 
 For now the snapshot is built from the public provider surface
 (``manager.status()`` for toolset_count, and the registrant-reported prompt /
 resource names) and written into ``experimental_capabilities["godot_mcp"]`` via
-the FastMCP constructor / ``_apply_capabilities``. No ``_components`` reach is
+the FastMCP constructor / ``apply_capability``. No ``_components`` reach is
 required: the counts already come from the registry, not from introspecting
 FastMCP internals.
 """
@@ -36,6 +71,12 @@ from fastmcp import FastMCP
 from mcp_server.toolsets import ToolsetManager
 
 CAPABILITY_KEY = "godot_mcp"
+
+# Note (issue #332): ``CAPABILITY_KEY`` is the *experimental-capabilities* key,
+# not a valid ``ServerExtension.identifier`` — SEP-2133 requires a reverse-DNS
+# ``vendor-prefix/name`` form (e.g. ``dev.godot/godot_mcp``). A future
+# ServerExtension migration must rename the key, which is part of why it is a
+# wire-breaking change. See the module docstring for the full 4.0b1 findings.
 
 STATIC_CAPABILITY: dict[str, Any] = {
     "version": "2026.06.01",


### PR DESCRIPTION
Closes #332.

## Summary

Issue #332 asked whether the `experimental_capabilities["godot_mcp"]` dict mutation in `apply_capability` (mcp_server/capabilities.py:80) could migrate onto a `ServerExtension` (SEP-2133) without a wire-breaking change. This PR records the investigation findings; no code behaviour changes.

## FastMCP 4.0.0b1 ServerExtension API shape

From `fastmcp/server/extensions.py` (`fastmcp.server.extensions.ServerExtension`):

- **Public surface:** `identifier`, `settings()`, `methods()`, `lifespan()`, `intercept_tool_call()`, `client_settings()`, plus the `server` property and `_bind()`.
- **`settings()` return value** is advertised exclusively at `ServerCapabilities.extensions[identifier]`.
- **`identifier`** must match SEP-2133's reverse-DNS `vendor-prefix/name` grammar (`validate_extension_identifier` rejects anything else); the bare `godot_mcp` key is *not* a valid extension identifier.

The capability-merge path in `FastMCPServerMiddleware.get_capabilities` (`fastmcp/server/low_level.py`) rebuilds the returned `ServerCapabilities` with `extensions={**existing, UI_EXTENSION_ID: {}, **registered}` (where `registered = {ext.identifier: ext.settings() for ext in self._extensions.values()}`), and passes `experimental` through unchanged from the constructor. Empirically confirmed:

```
experimental: {'godot_mcp': {'existing': True}}
extensions:   {'io.modelcontextprotocol/ui': {}, 'dev.godot/godot_mcp': {...}}
```

## Was the migration possible?

**No — not without a wire-breaking change.**

- **Option (a)** (keep the capability in `experimental` while using the extension API): **not expressible in 4.0b1.** `ServerExtension` has no hook to write into `experimental_capabilities`; `settings()` is hard-wired to `extensions[identifier]`.
- **Option (b)** (move to `extensions[<reverse-dns>]`): technically possible but **doubly backwards-incompatible**:
  1. the snapshot relocates from `experimental` to `extensions` (a distinct wire field); and
  2. `identifier` must be reverse-DNS, so the key renames from `godot_mcp` to e.g. `dev.godot/godot_mcp`.

Both effects break `tests/contract/test_capabilities.py` (which pins `experimental_capabilities["godot_mcp"]`) and any client consuming `experimental.godot_mcp`.

## Wire-field implications

- The capability snapshot relocates from `ServerCapabilities.experimental["godot_mcp"]` → `ServerCapabilities.extensions["dev.godot/godot_mcp"]` (or whichever reverse-DNS prefix the contract lands on).
- Existing clients reading `experimental.godot_mcp` would see nothing; the new slot is a key they have never seen.
- This is a contract-level decision needing explicit sign-off, not a silent swap during stabilization.

## Outcome

Per the issue's exploratory framing ("a 'documented why it can't be done' outcome is a valid result"), the dict mutation in `apply_capability` stays as the intentional shape. Findings are recorded in:
- the `mcp_server/capabilities.py` module docstring (full 4.0b1 API surface, the merge path, the identifier-grammar blocker, and the one-step migration recipe for when the contract is revised), and
- a note on `CAPABILITY_KEY` clarifying it is the experimental key, not a valid extension identifier.

When the contract is intentionally revised, the migration is a one-step move: subclass `ServerExtension` with `identifier = "dev.godot/godot_mcp"`, override `settings()` to return `build_capability(...)`, register via `mcp.add_extension(...)`, and drop both the `experimental_capabilities` constructor seed in server.py:117 and the `apply_capability` call in server.py:193. The snapshot construction (`build_capability`) is already provider-surface-derived and unchanged by the relocation.

## Verification

- `uv run ruff check .` — clean
- `uv run mypy` — Success: no issues found in 239 source files
- `uv run pytest -q` — 614 passed

## Files changed

- `mcp_server/capabilities.py` — module docstring + `CAPABILITY_KEY` note (docstring only; no behaviour change)