### PR TITLE
refactor(tools): guard ctx progress to unblock task=True (closes #331)

### DIFF
--- a/mcp_server/tools/_progress.py
+++ b/mcp_server/tools/_progress.py
@@ -1,0 +1,26 @@
+"""Guarded Context progress helpers (issue #331).
+
+``ctx.info`` / ``ctx.report_progress`` raise ``RuntimeError: session is not
+available`` in the detached task input loop (``task=True``), because the
+session back-channel is gone. These helpers no-op on that failure so
+long-running tools can be task-enabled without losing progress for the
+non-task path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def safe_info(ctx: Any, msg: str) -> None:
+    try:
+        await ctx.info(msg)
+    except Exception:
+        pass
+
+
+async def safe_progress(ctx: Any, current: float, total: float) -> None:
+    try:
+        await ctx.report_progress(current, total)
+    except Exception:
+        pass

--- a/mcp_server/tools/export.py
+++ b/mcp_server/tools/export.py
@@ -22,6 +22,7 @@ from mcp_server.defaults import (
 from mcp_server.models.export import ExportInfoResult, ExportPresetsResult, ExportResult
 from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
 from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError, enforce_preconditions
+from mcp_server.tools._progress import safe_info, safe_progress
 from mcp_server.tools._route import route
 
 EXPORT = {EXPORT_TAG}
@@ -44,7 +45,7 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         """
         return ExportInfoResult(**await route(bridge, "cmd_get_export_info", {}))
 
-    @mcp.tool(meta=RUNTIME, tags=EXPORT)
+    @mcp.tool(meta=RUNTIME, tags=EXPORT, task=True)
     @enforce_preconditions
     async def export_project(
         preset: str,
@@ -69,16 +70,18 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         if preset not in names:
             raise ToolError(f"No export preset named '{preset}'. Available: {names}.")
         project_dir = await resolve_project_dir(bridge, config)
-        await ctx.info(
-            f"Exporting preset '{preset}' → {output_path} (timeout {timeout_seconds:g}s)…"
+        await safe_info(
+            ctx,
+            f"Exporting preset '{preset}' → {output_path} (timeout {timeout_seconds:g}s)…",
         )
-        await ctx.report_progress(0, 1)
+        await safe_progress(ctx, 0, 1)
         run = await runner.export(project_dir, preset, output_path, debug, float(timeout_seconds))
-        await ctx.report_progress(1, 1)
+        await safe_progress(ctx, 1, 1)
         summary = summarize_run(run)
-        await ctx.info(
+        await safe_info(
+            ctx,
             f"Export finished: exit={summary.exit_code}, "
-            f"{len(summary.errors)} error(s), {len(summary.warnings)} warning(s)"
+            f"{len(summary.errors)} error(s), {len(summary.warnings)} warning(s)",
         )
         return ExportResult(
             exported=summary.exit_code == 0 and not summary.timed_out,

--- a/mcp_server/tools/navigation.py
+++ b/mcp_server/tools/navigation.py
@@ -26,6 +26,7 @@ from mcp_server.models.navigation import (
     NavigationRegionResult,
 )
 from mcp_server.safety import MUTATING, enforce_preconditions, require_node_exists
+from mcp_server.tools._progress import safe_info, safe_progress
 from mcp_server.tools._route import run_or_preview
 
 NAVIGATION = {NAVIGATION_TAG}
@@ -84,7 +85,7 @@ def register_navigation(mcp: FastMCP, bridge: Bridge) -> None:
             dry_run, NavigationAgentResult, preview, bridge, "cmd_setup_navigation_agent", params
         )
 
-    @mcp.tool(meta=MUTATING, tags=NAVIGATION)
+    @mcp.tool(meta=MUTATING, tags=NAVIGATION, task=True)
     @enforce_preconditions
     async def bake_navigation_mesh(
         node_path: str, dry_run: bool = False, *, ctx: Context
@@ -97,14 +98,14 @@ def register_navigation(mcp: FastMCP, bridge: Bridge) -> None:
         params = {"node_path": node_path}
         preview = {"node_path": node_path, "baked": False}
         if not dry_run:
-            await ctx.info(f"Baking navigation mesh for {node_path}…")
-            await ctx.report_progress(0, 1)
+            await safe_info(ctx, f"Baking navigation mesh for {node_path}…")
+            await safe_progress(ctx, 0, 1)
         result = await run_or_preview(
             dry_run, BakeNavigationResult, preview, bridge, "cmd_bake_navigation_mesh", params
         )
         if not dry_run:
-            await ctx.report_progress(1, 1)
-            await ctx.info(f"Navigation bake finished for {node_path}")
+            await safe_progress(ctx, 1, 1)
+            await safe_info(ctx, f"Navigation bake finished for {node_path}")
         return result
 
     @mcp.tool(meta=MUTATING, tags=NAVIGATION)

--- a/mcp_server/tools/runtime.py
+++ b/mcp_server/tools/runtime.py
@@ -19,14 +19,13 @@ from mcp_server.defaults import (
 from mcp_server.models.runtime import RunCaptureResult
 from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
 from mcp_server.safety import RUNTIME, PreconditionError, enforce_preconditions
+from mcp_server.tools._progress import safe_info, safe_progress
 
 
-def register_runtime(
-    mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: Runner
-) -> None:
+def register_runtime(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: Runner) -> None:
     """Register the runtime-loop tool."""
 
-    @mcp.tool(meta=RUNTIME, tags={RUNTIME_TAG})
+    @mcp.tool(meta=RUNTIME, tags={RUNTIME_TAG}, task=True)
     @enforce_preconditions
     async def run_and_capture(
         scene: str | None = None,
@@ -50,13 +49,16 @@ def register_runtime(
                 required="godot_bin",
             )
         project_dir = await resolve_project_dir(bridge, config)
-        await ctx.info(f"Running {scene or 'main scene'} headless (timeout {timeout_seconds:g}s)…")
-        await ctx.report_progress(0, 1)
+        await safe_info(
+            ctx, f"Running {scene or 'main scene'} headless (timeout {timeout_seconds:g}s)…"
+        )
+        await safe_progress(ctx, 0, 1)
         output = await runner.run(project_dir, scene, float(timeout_seconds))
-        await ctx.report_progress(1, 1)
+        await safe_progress(ctx, 1, 1)
         result = summarize_run(output)
-        await ctx.info(
+        await safe_info(
+            ctx,
             f"Run finished: exit={result.exit_code}, "
-            f"{len(result.errors)} error(s), {len(result.warnings)} warning(s)"
+            f"{len(result.errors)} error(s), {len(result.warnings)} warning(s)",
         )
         return result

--- a/mcp_server/tools/testing.py
+++ b/mcp_server/tools/testing.py
@@ -41,9 +41,12 @@ from mcp_server.models.testing import (
 from mcp_server.qa import ImageCompareError, compare_images, evaluate_assertion, random_input_events
 from mcp_server.runtime import Runner, resolve_project_dir
 from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError
+from mcp_server.tools._progress import safe_info, safe_progress
 from mcp_server.tools._route import poll_ready, route
 
 TESTING = {TESTING_TAG}
+
+
 async def _read_live_value(
     bridge: Bridge, node_path: str, prop: str, timeout_ms: int
 ) -> tuple[Any, str]:
@@ -128,18 +131,18 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         project_dir = await resolve_project_dir(bridge, config)
         if not _gut_present(project_dir):
             return RunTestsResult(ran=False, framework="gut", framework_absent=True)
-        await ctx.info(f"Running GUT suite in {test_dir} (timeout {timeout_seconds:g}s)…")
-        await ctx.report_progress(0, 1)
+        await safe_info(ctx, f"Running GUT suite in {test_dir} (timeout {timeout_seconds:g}s)…")
+        await safe_progress(ctx, 0, 1)
         output = await runner.run_tests(project_dir, test_dir, timeout=float(timeout_seconds))
-        await ctx.report_progress(1, 1)
+        await safe_progress(ctx, 1, 1)
         if output.timed_out:
-            await ctx.info("Test run timed out")
+            await safe_info(ctx, "Test run timed out")
             return RunTestsResult(
                 ran=True, framework="gut", timed_out=True, raw_summary=output.stdout.strip()[-2000:]
             )
         result = parse_gut_results(output.stdout)
         result.exit_code = output.exit_code
-        await ctx.info(f"Tests finished: {result.passed} passed, {result.failed} failed")
+        await safe_info(ctx, f"Tests finished: {result.passed} passed, {result.failed} failed")
         return result
 
     @mcp.tool(meta=READ_ONLY, tags=TESTING)

--- a/tests/contract/test_context_progress.py
+++ b/tests/contract/test_context_progress.py
@@ -78,3 +78,28 @@ async def test_run_tests_streams_progress_and_logs(tmp_path: Path) -> None:
 
     assert progress, "expected at least one progress update from run_tests"
     assert logs, "expected at least one structured log message from run_tests"
+
+
+async def test_safe_progress_noops_on_session_unavailable() -> None:
+    """The guarded progress helpers swallow RuntimeError (detached task session).
+
+    Simulates the ``task=True`` detached-session failure by passing a Context
+    whose ``info``/``report_progress`` raise ``RuntimeError: session is not
+    available``. The tools must complete successfully — the progress calls
+    no-op instead of propagating the error.
+    """
+    from mcp_server.tools._progress import safe_info, safe_progress
+
+    class _BrokenCtx:
+        async def info(self, msg: str, *args: object, **kwargs: object) -> None:
+            raise RuntimeError("session is not available")
+
+        async def report_progress(
+            self, current: float, total: float, *args: object, **kwargs: object
+        ) -> None:
+            raise RuntimeError("session is not available")
+
+    ctx = _BrokenCtx()
+    await safe_info(ctx, "should not raise")
+    await safe_progress(ctx, 0, 1)
+    await safe_progress(ctx, 1, 1)


### PR DESCRIPTION
## Summary

The four long-running tools (`run_and_capture`, `export_project`, `run_tests`, `bake_navigation_mesh`) now use `safe_info`/`safe_progress` helpers that no-op when `ctx` raises `RuntimeError` (the detached task session where `ctx.session` is `None`). This unblocks `task=True` — all four are now marked `task=True` so the MCP client can poll while the bridge op runs, decoupling MCP request lifetime from bridge operation lifetime (the #315 goal).

## Changes

- **New** `mcp_server/tools/_progress.py` — `safe_info(ctx, msg)` and `safe_progress(ctx, current, total)` that try/except and no-op on failure
- `mcp_server/tools/runtime.py` — `run_and_capture` uses guarded helpers, marked `task=True`
- `mcp_server/tools/export.py` — `export_project` same
- `mcp_server/tools/testing.py` — `run_tests` same
- `mcp_server/tools/navigation.py` — `bake_navigation_mesh` same
- `tests/contract/test_context_progress.py` — new test: `safe_progress_noops_on_session_unavailable` simulates the detached-session failure

## Test plan

- [x] `uv run pytest -q` — 615 passed (existing progress tests + new guard test)
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean

Resolves the #315 spike finding: `ctx.info`/`ctx.report_progress` no longer block `task=True`.