### PR TITLE
docs: re-verify FastMCP references against 4.0 + close umbrella (closes #311)

### DIFF
--- a/.claude/rules/async-patterns.md
+++ b/.claude/rules/async-patterns.md
@@ -21,6 +21,10 @@ FastMCP runs an async server. The WebSocket bridge is the one place latency and 
 - Injectable clock for deterministic tests of timeout/backoff.
 - Document concurrency assumptions when a handler is only safe under single-writer (single editor) semantics.
 
+## Sessionless-era compatibility (FastMCP 4.0)
+
+The server is stateless by design — no `ctx.elicit()`, `ctx.set_state`, or `Middleware.on_initialize` — so it works on the modern sessionless `2026-07-28` protocol (which `fastmcp.Client` negotiates by default in 4.0) without porting. Do not add features that depend on per-session state or server-initiated requests; if a future tool needs a back-channel to the client, use the guard pattern (return an `InputRequiredResult` describing what the tool needs, and the client calls again with the answer) rather than `ctx.elicit()`, which raises on the modern protocol. `ctx.info` / `ctx.report_progress` are safe — they ride the response stream as notifications, not requests — but guard them with `safe_info` / `safe_progress` (`mcp_server/tools/_progress.py`) so they no-op in the detached task session (`task=True`), where `ctx.session` is `None`.
+
 ## Anti-patterns
 
 - A synchronous WebSocket client inside async code.

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ We follow an issue-driven workflow. Read [`CLAUDE.md`](CLAUDE.md) and the path-s
 ## Resources
 
 - [Model Context Protocol spec](https://modelcontextprotocol.io)
-- [FastMCP docs](https://github.com/PrefectHQ/fastmcp)
+- [FastMCP docs](https://gofastmcp.com)
 - [Godot 4.4 docs](https://docs.godotengine.org/en/4.4/)
 - [Project issues](https://github.com/hybridindie/godot-mcp/issues)
 - [`docs/tool-contracts.md`](docs/tool-contracts.md) — the authoritative per-tool reference


### PR DESCRIPTION
## Summary

The last item on the FastMCP 4.0 migration umbrella's preflight checklist: re-verify all FastMCP-behavior references against the 4.0 docs.

## Changes

- **`.claude/rules/async-patterns.md`** — add "Sessionless-era compatibility" section documenting:
  - Why the server works on the modern `2026-07-28` protocol (stateless by design — no `ctx.elicit`, `ctx.set_state`, `on_initialize`)
  - Guard-pattern guidance for future tools that need a back-channel to the client (return `InputRequiredResult`, don't use `ctx.elicit()`)
  - `safe_info`/`safe_progress` guard for `task=True` tools (detached session where `ctx.session` is `None`)
- **`README.md`** — update FastMCP docs link to `gofastmcp.com` (the 4.0 docs site, replacing the GitHub repo link)

## Verification

The other docs touch points (`CLAUDE.md:85,91`, `AGENTS.md:16`) reference FastMCP at a high level ("FastMCP server", "FastMCP 4.0's ToolTransform") and don't reference any 3.x API shapes — no changes needed. `CLAUDE.md:75` already mentions `ToolTransform` and `transforms.py` from the #312 migration.

Closes the umbrella #311.