### PR TITLE
feat(navigation): godot_navigation_get_region read-back (closes #302)

### DIFF
--- a/godot/addons/godot_mcp/handlers/navigation.gd
+++ b/godot/addons/godot_mcp/handlers/navigation.gd
@@ -15,6 +15,7 @@ func _init(router: MCPCommandRouter) -> void:
 
 func register(handlers: Dictionary) -> void:
 	handlers["cmd_bake_navigation_mesh"] = _cmd_bake_navigation_mesh
+	handlers["cmd_get_navigation_region"] = _cmd_get_navigation_region
 	handlers["cmd_set_navigation_layers"] = _cmd_set_navigation_layers
 	handlers["cmd_setup_navigation_agent"] = _cmd_setup_navigation_agent
 	handlers["cmd_setup_navigation_region"] = _cmd_setup_navigation_region
@@ -99,6 +100,54 @@ func _cmd_bake_navigation_mesh(params: Dictionary) -> Dictionary:
 	else:
 		return _router._fail("VALIDATION_ERROR", "Node is not a NavigationRegion2D/NavigationRegion3D.")
 	return _router._ok({"node_path": str(params.get("node_path")), "baked": true})
+
+
+
+func _cmd_get_navigation_region(params: Dictionary) -> Dictionary:
+	var found := _router._resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var region: Node = found["node"]
+	var path := str(params.get("node_path"))
+	if region is NavigationRegion2D:
+		var navpoly: NavigationPolygon = region.navigation_polygon
+		if navpoly == null:
+			return _router._ok({
+				"node_path": path,
+				"has_polygon": false,
+				"outline_count": 0,
+				"vertex_count": 0,
+				"polygon_count": 0,
+			})
+		return _router._ok({
+			"node_path": path,
+			"has_polygon": true,
+			"outline_count": navpoly.get_outline_count(),
+			"vertex_count": navpoly.get_vertex_count(),
+			"polygon_count": navpoly.get_polygon_count(),
+		})
+	elif region is NavigationRegion3D:
+		var navmesh: NavigationMesh = region.navigation_mesh
+		if navmesh == null:
+			return _router._ok({
+				"node_path": path,
+				"has_polygon": false,
+				"outline_count": 0,
+				"vertex_count": 0,
+				"polygon_count": 0,
+			})
+		var vertex_count := 0
+		if navmesh.has_method("get_vertices"):
+			var verts: PackedVector3Array = navmesh.get_vertices()
+			vertex_count = verts.size()
+		return _router._ok({
+			"node_path": path,
+			"has_polygon": true,
+			"outline_count": 0,
+			"vertex_count": vertex_count,
+			"polygon_count": navmesh.get_polygon_count(),
+		})
+	return _router._fail("VALIDATION_ERROR", "Node is not a NavigationRegion2D/NavigationRegion3D.")
 
 
 

--- a/mcp_server/harness.py
+++ b/mcp_server/harness.py
@@ -35,6 +35,7 @@ READ_ONLY_COMMANDS: frozenset[str] = frozenset(
         "cmd_get_node_property_list",
         "cmd_find_nodes_by_type",
         "cmd_get_dependencies",
+        "cmd_get_navigation_region",
     }
 )
 

--- a/mcp_server/models/navigation.py
+++ b/mcp_server/models/navigation.py
@@ -29,3 +29,11 @@ class NavigationLayersResult(BaseModel):
     node_path: str
     navigation_layers: int = 0
     dry_run: bool = False
+
+
+class NavigationRegionInfo(BaseModel):
+    node_path: str
+    has_polygon: bool = False
+    outline_count: int = 0
+    vertex_count: int = 0
+    polygon_count: int = 0

--- a/mcp_server/tools/navigation.py
+++ b/mcp_server/tools/navigation.py
@@ -23,11 +23,12 @@ from mcp_server.models.navigation import (
     BakeNavigationResult,
     NavigationAgentResult,
     NavigationLayersResult,
+    NavigationRegionInfo,
     NavigationRegionResult,
 )
-from mcp_server.safety import MUTATING, enforce_preconditions, require_node_exists
+from mcp_server.safety import MUTATING, READ_ONLY, enforce_preconditions, require_node_exists
 from mcp_server.tools._progress import safe_info, safe_progress
-from mcp_server.tools._route import run_or_preview
+from mcp_server.tools._route import route, run_or_preview
 
 NAVIGATION = {NAVIGATION_TAG}
 
@@ -122,4 +123,18 @@ def register_navigation(mcp: FastMCP, bridge: Bridge) -> None:
         preview = {"node_path": node_path}
         return await run_or_preview(
             dry_run, NavigationLayersResult, preview, bridge, "cmd_set_navigation_layers", params
+        )
+
+    @mcp.tool(meta=READ_ONLY, tags=NAVIGATION)
+    async def get_navigation_region(node_path: str) -> NavigationRegionInfo:
+        """Read back the baked navigation polygon/mesh for the NavigationRegion2D/3D at
+        ``node_path``. Returns ``has_polygon`` plus ``outline_count``, ``vertex_count``,
+        and ``polygon_count`` — a verifier uses these to confirm a bake produced
+        non-empty geometry. For NavigationRegion3D, ``vertex_count`` may be 0 when the
+        engine version does not expose the vertex array.
+        """
+        await require_node_exists(bridge, node_path)
+        params = {"node_path": node_path}
+        return NavigationRegionInfo(
+            **await route(bridge, "cmd_get_navigation_region", params)
         )

--- a/tests/contract/test_navigation.py
+++ b/tests/contract/test_navigation.py
@@ -39,6 +39,28 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             )
         case "cmd_bake_navigation_mesh":
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "baked": True})
+        case "cmd_get_navigation_region":
+            if p["node_path"] == "EmptyRegion":
+                return ResponseEnvelope.success(
+                    cmd.id,
+                    {
+                        "node_path": p["node_path"],
+                        "has_polygon": False,
+                        "outline_count": 0,
+                        "vertex_count": 0,
+                        "polygon_count": 0,
+                    },
+                )
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "has_polygon": True,
+                    "outline_count": 1,
+                    "vertex_count": 4,
+                    "polygon_count": 1,
+                },
+            )
         case "cmd_set_navigation_layers":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "navigation_layers": 5}
@@ -67,9 +89,16 @@ async def test_gated_in_navigation_toolset() -> None:
         "godot_navigation_setup_agent",
         "godot_navigation_bake_mesh",
         "godot_navigation_set_layers",
+        "godot_navigation_get_region",
     }
     assert expected <= set(tools)
-    assert all(tools[n].meta["safety_class"] == "mutating" for n in expected)
+    assert all(tools[n].meta["safety_class"] == "mutating" for n in {
+        "godot_navigation_setup_region",
+        "godot_navigation_setup_agent",
+        "godot_navigation_bake_mesh",
+        "godot_navigation_set_layers",
+    })
+    assert tools["godot_navigation_get_region"].meta["safety_class"] == "read_only"
 
 
 async def test_region_agent_and_bake() -> None:
@@ -112,3 +141,45 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_bake_navigation_mesh" not in _commands(conn)
+
+
+async def test_get_navigation_region_returns_baked_data() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "navigation"})
+        result = await client.call_tool(
+            "godot_navigation_get_region", {"node_path": "NavigationRegion2D"}
+        )
+    info = result.structured_content
+    assert info["node_path"] == "NavigationRegion2D"
+    assert info["has_polygon"] is True
+    assert info["outline_count"] == 1
+    assert info["vertex_count"] == 4
+    assert info["polygon_count"] == 1
+
+
+async def test_get_navigation_region_reports_empty_when_no_polygon() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "navigation"})
+        result = await client.call_tool(
+            "godot_navigation_get_region", {"node_path": "EmptyRegion"}
+        )
+    info = result.structured_content
+    assert info["has_polygon"] is False
+    assert info["outline_count"] == 0
+    assert info["vertex_count"] == 0
+    assert info["polygon_count"] == 0
+
+
+async def test_get_navigation_region_is_read_only() -> None:
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "navigation"})
+        await client.call_tool(
+            "godot_navigation_get_region", {"node_path": "NavigationRegion2D"}
+        )
+    sent = _commands(conn)
+    assert "cmd_get_navigation_region" in sent
+    # read-only tool must not issue any mutation command
+    assert not any(c.startswith("cmd_set_") or c == "cmd_bake_navigation_mesh" for c in sent)


### PR DESCRIPTION
Add a read-only `godot_navigation_get_region` tool so the verifier can confirm a baked NavigationRegion2D/3D is non-empty without rebaking.

Implements option 1 from issue #302 (a new read-only tool) — keeps `BakeNavigationResult` unchanged and works on already-baked regions.

**Addon** (`godot/addons/godot_mcp/handlers/navigation.gd`):
- `cmd_get_navigation_region` resolves the node, validates it is a NavigationRegion2D/3D, and reads the assigned navmesh/navpoly resource.
- NavigationRegion2D: returns `has_polygon`, `outline_count`, `vertex_count`, `polygon_count` from `NavigationPolygon`.
- NavigationRegion3D: returns `polygon_count` from `NavigationMesh` plus `vertex_count` via `get_vertices()` when available (0 otherwise).
- Empty (null resource) returns all-zero counts with `has_polygon: false`.

**Python**:
- `NavigationRegionInfo` model (`mcp_server/models/navigation.py`).
- `get_navigation_region` tool (`mcp_server/tools/navigation.py`) tagged `READ_ONLY`/`NAVIGATION`, precondition `require_node_exists`.
- Registered in `READ_ONLY_COMMANDS` so `gather_reads` can pipeline it.

**Tool name**: auto-derived by ToolTransform as `godot_navigation_get_region` (`navigation` token trimmed from action).

TDD: failing contract tests first, then implementation. Contract suite green; `mypy` and `ruff` clean on touched files.