### PR TITLE
feat(animation): add loop_mode to AnimationDetail (closes #303)

### DIFF
--- a/godot/addons/godot_mcp/animation_read.gd
+++ b/godot/addons/godot_mcp/animation_read.gd
@@ -22,6 +22,12 @@ const _TYPE_NAMES := {
 	Animation.TYPE_ANIMATION: "animation",
 }
 
+const _LOOP_MODE_NAMES := {
+	Animation.LOOP_NONE: "none",
+	Animation.LOOP_LINEAR: "linear",
+	Animation.LOOP_PINGPONG: "pingpong",
+}
+
 
 ## All animation names on a player (across its libraries), as plain strings.
 static func names(player: AnimationPlayer) -> Array:
@@ -46,4 +52,9 @@ static func serialize(anim_name: String, animation: Animation) -> Dictionary:
 			"path": String(animation.track_get_path(i)),
 			"keys": keys,
 		})
-	return {"name": anim_name, "length": animation.length, "tracks": tracks}
+	return {
+		"name": anim_name,
+		"length": animation.length,
+		"loop_mode": _LOOP_MODE_NAMES.get(animation.loop_mode, "none"),
+		"tracks": tracks,
+	}

--- a/godot/tests/animation_read_smoke.gd
+++ b/godot/tests/animation_read_smoke.gd
@@ -15,8 +15,9 @@ func _initialize() -> void:
 	var lib := AnimationLibrary.new()
 	player.add_animation_library("", lib)
 
-	var anim := Animation.new()
+	var 	anim := Animation.new()
 	anim.length = 2.0
+	anim.loop_mode = Animation.LOOP_LINEAR
 	var ti := anim.add_track(Animation.TYPE_VALUE)
 	anim.track_set_path(ti, NodePath("Sprite2D:position"))
 	anim.track_insert_key(ti, 0.5, Vector2(10, 20))
@@ -32,6 +33,7 @@ func _initialize() -> void:
 	var detail: Dictionary = AnimRead.serialize("walk", anim)
 	_eq(failures, "name", detail.get("name"), "walk")
 	_eq(failures, "length", detail.get("length"), 2.0)
+	_eq(failures, "loop_mode", detail.get("loop_mode"), "linear")
 	var tracks: Array = detail.get("tracks")
 	if tracks.size() != 1:
 		failures.append("track count: %s" % str(tracks))

--- a/mcp_server/models/animation.py
+++ b/mcp_server/models/animation.py
@@ -39,6 +39,7 @@ class AnimationDetail(BaseModel):
 
     name: str
     length: float = 0.0
+    loop_mode: str = "none"
     tracks: list[AnimationTrack] = Field(default_factory=list)
 
 

--- a/tests/contract/test_animation.py
+++ b/tests/contract/test_animation.py
@@ -53,6 +53,11 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_get_animation":
             if p["animation_name"] == "missing":
                 return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No animation.")
+            if p["animation_name"] == "run":
+                return ResponseEnvelope.success(
+                    cmd.id,
+                    {"name": "run", "length": 1.0, "loop_mode": "linear", "tracks": []},
+                )
             return ResponseEnvelope.success(
                 cmd.id,
                 {
@@ -218,3 +223,23 @@ async def test_animation_reads_are_read_only() -> None:
         tools = {t.name: t for t in await client.list_tools()}
     assert tools["godot_animation_list_animations"].meta["safety_class"] == "read_only"
     assert tools["godot_animation_get"].meta["safety_class"] == "read_only"
+
+
+async def test_get_animation_includes_loop_mode() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "animation"})
+        result = await client.call_tool(
+            "godot_animation_get", {"node_path": "AnimationPlayer", "animation_name": "run"}
+        )
+    assert result.structured_content["loop_mode"] == "linear"
+
+
+async def test_get_animation_loop_mode_defaults_to_none() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "animation"})
+        result = await client.call_tool(
+            "godot_animation_get", {"node_path": "AnimationPlayer", "animation_name": "walk"}
+        )
+    assert result.structured_content["loop_mode"] == "none"


### PR DESCRIPTION
## What

Adds `loop_mode` to `AnimationDetail` so `godot_animation_get` reports whether an animation loops.

## Why

Godot's `Animation` resource exposes a `loop_mode` property (`LOOP_NONE` / `LOOP_LINEAR` / `LOOP_PINGPONG`). The read path (`cmd_get_animation` → `MCPAnimationRead.serialize` → `AnimationDetail`) was dropping it, so consumers couldn't tell whether an animation loops — a property that matters for round-tripping animations and for agents choosing playback semantics.

## Changes

**Addon** — `godot/addons/godot_mcp/animation_read.gd`:
- New `_LOOP_MODE_NAMES` const mapping `Animation.LOOP_*` → `"none"` / `"linear"` / `"pingpong"`.
- `serialize()` now includes `"loop_mode"` in the returned dict (defaults to `"none"` if the value is unexpected).

**Python model** — `mcp_server/models/animation.py`:
- `AnimationDetail.loop_mode: str = "none"` (defaults to `none` so older addons that omit the field still parse).

**Tests** — `tests/contract/test_animation.py`:
- `test_get_animation_includes_loop_mode` — responder returns `loop_mode: "linear"`, asserts it surfaces.
- `test_get_animation_loop_mode_defaults_to_none` — responder omits the field, asserts the model default `"none"`.

**Addon smoke** — `godot/tests/animation_read_smoke.gd`:
- Sets `anim.loop_mode = Animation.LOOP_LINEAR` and asserts `detail["loop_mode"] == "linear"`.

## Verification

- `uv run pytest tests/contract/test_animation.py -q` → 10 passed
- `uv run pytest -q --ignore=tests/integration` → 549 passed (e2e failures are environment-only — no `godot` binary locally)
- `uv run mypy` → clean
- `uv run ruff check .` → clean

Closes #303