### PR TITLE
feat(shader): godot_shader_get_param reads live uniform value (closes #301)

### DIFF
--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -29,6 +29,7 @@ func _init(router: MCPCommandRouter) -> void:
 func register(handlers: Dictionary) -> void:
 	handlers["cmd_assign_shader_material"] = _cmd_assign_shader_material
 	handlers["cmd_create_shader"] = _cmd_create_shader
+	handlers["cmd_get_shader_param"] = _cmd_get_shader_param
 	handlers["cmd_read_shader"] = _cmd_read_shader
 	handlers["cmd_set_shader_param"] = _cmd_set_shader_param
 
@@ -123,6 +124,34 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	ur.add_undo_method(material, "set_shader_parameter", name, prev)
 	ur.commit_action()
 	return _router._ok({"node_path": str(params.get("node_path")), "name": name})
+
+
+func _cmd_get_shader_param(params: Dictionary) -> Dictionary:
+	var found := _router._resolve(params.get("node_path", ""))
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var prop := _material_property_for(node)
+	if prop.is_empty():
+		return _router._fail("VALIDATION_ERROR", "Node has no material slot (not a CanvasItem/GeometryInstance3D).")
+	var material: Variant = node.get(prop)
+	if not (material is ShaderMaterial):
+		return _router._fail("VALIDATION_ERROR", "Node has no ShaderMaterial assigned; assign one first.", "shader_material")
+	var name := str(params.get("name", ""))
+	if name.is_empty():
+		return _router._fail("VALIDATION_ERROR", "'name' must be a non-empty string.")
+	var exists := false
+	for param in material.get_shader_parameter_list():
+		if param.name == name:
+			exists = true
+			break
+	var value: Variant = material.get_shader_parameter(name)
+	return _router._ok({
+		"node_path": str(params.get("node_path")),
+		"name": name,
+		"value": Coerce.to_json(value),
+		"exists": exists,
+	})
 
 
 func _material_property_for(node: Node) -> String:

--- a/mcp_server/models/shader.py
+++ b/mcp_server/models/shader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel
 
 
@@ -27,3 +29,10 @@ class ShaderParamResult(BaseModel):
     node_path: str
     name: str
     dry_run: bool = False
+
+
+class ShaderParamReadResult(BaseModel):
+    node_path: str
+    name: str
+    value: Any = None
+    exists: bool = False

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -19,6 +19,7 @@ from mcp_server.defaults import (
 )
 from mcp_server.models.shader import (
     ShaderMaterialResult,
+    ShaderParamReadResult,
     ShaderParamResult,
     ShaderReadResult,
     ShaderResult,
@@ -91,6 +92,16 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         return await run_or_preview(
             dry_run, ShaderParamResult, preview, bridge, "cmd_set_shader_param", params
         )
+
+    @mcp.tool(meta=READ_ONLY, tags=SHADER)
+    async def get_shader_param(node_path: str, name: str) -> ShaderParamReadResult:
+        """Read the live value of shader uniform ``name`` on the node's
+        ShaderMaterial — the read-only inverse of ``set_shader_param``. Returns
+        ``exists=False`` when the parameter is not declared on the material.
+        """
+        await require_node_exists(bridge, node_path)
+        params = {"node_path": node_path, "name": name}
+        return ShaderParamReadResult(**await route(bridge, "cmd_get_shader_param", params))
 
     @mcp.tool(meta=READ_ONLY, tags=SHADER)
     async def read_shader(shader_path: str) -> ShaderReadResult:

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -42,6 +42,21 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "name": p["name"]}
             )
+        case "cmd_get_shader_param":
+            if p.get("name") == "missing":
+                return ResponseEnvelope.success(
+                    cmd.id,
+                    {
+                        "node_path": p["node_path"],
+                        "name": p["name"],
+                        "value": None,
+                        "exists": False,
+                    },
+                )
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"node_path": p["node_path"], "name": p["name"], "value": 2.0, "exists": True},
+            )
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -111,3 +126,34 @@ async def test_dry_run_sends_no_mutation() -> None:
         )
     assert result.structured_content["dry_run"] is True
     assert "cmd_create_shader" not in _commands(conn)
+
+
+async def test_get_shader_param_returns_value() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_get_param", {"node_path": "Sprite2D", "name": "strength"}
+        )
+    assert result.structured_content["value"] == 2.0
+    assert result.structured_content["exists"] is True
+
+
+async def test_get_shader_param_nonexistent_returns_exists_false() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_get_param", {"node_path": "Sprite2D", "name": "missing"}
+        )
+    assert result.structured_content["exists"] is False
+
+
+async def test_get_shader_param_is_read_only() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        grouped = await client.call_tool(
+            "godot_list_tools_by_safety_class", {}
+        )
+    assert "godot_shader_get_param" in grouped.structured_content["read_only"]


### PR DESCRIPTION
Add a read-only `godot_shader_get_param` tool — the inverse of `godot_shader_set_param` — that reads a live ShaderMaterial uniform value back from the editor.

## Changes

**Addon** (`godot/addons/godot_mcp/handlers/shaders.gd`)
- Register `cmd_get_shader_param` → `_cmd_get_shader_param`
- Resolve node, reuse `_material_property_for`, require ShaderMaterial, read `material.get_shader_parameter(name)`
- Coerce the value to JSON via `MCPTypeCoerce.to_json()` (same pattern as `animation_read.gd` / `scene_inspect.gd`)
- `exists` derived from `material.get_shader_parameter_list()` (declared on the shader), not just non-null — distinguishes a declared uniform set to null from an unknown name

**Server**
- `ShaderParamReadResult` model (`mcp_server/models/shader.py`): `node_path`, `name`, `value: Any = None`, `exists: bool = False`
- `get_shader_param` tool (`mcp_server/tools/shader.py`): `@mcp.tool(meta=READ_ONLY, tags=SHADER)`, `require_node_exists` precondition, routes `cmd_get_shader_param`. Tool name auto-derived by ToolTransform as `godot_shader_get_param` (`_TRIM['shader']` trims 'shader').

**Tests** (`tests/contract/test_shader.py`)
- `cmd_get_shader_param` responder case
- `test_get_shader_param_returns_value` — asserts `value == 2.0`, `exists is True`
- `test_get_shader_param_nonexistent_returns_exists_false` — asserts `exists is False`
- `test_get_shader_param_is_read_only` — appears in `godot_list_tools_by_safety_class` `read_only` group

## Verification
- `uv run pytest tests/contract/test_shader.py -q` → 7 passed
- `uv run pytest tests/contract -q` → 351 passed
- `uv run mypy` → no issues
- `uv run ruff check .` → clean

TDD: failing test first, then implementation.