### PR TITLE
fix(docker): publish bridge port and bind 0.0.0.0 for the inverted bridge (closes #285)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -21,18 +21,14 @@ The server listens on `http://localhost:9090`.
 ## Bridge networking
 
 Since the bridge inversion (#276) the **server is the listener** and the Godot editor
-connects *in*, so the container must publish the bridge port and bind all interfaces:
+connects *in*, so the container publishes the bridge port and binds all interfaces:
 
 - In the container (compose `environment`): `GODOT_MCP_BRIDGE_URL: ws://0.0.0.0:9080`, and
-  publish it: `ports: ["9080:9080"]`.
+  published: `ports: ["9080:9080"]`.
 - On the host, point the editor's addon at the published port:
   `GODOT_MCP_BRIDGE_URL=ws://127.0.0.1:9080`.
 - Binding `0.0.0.0` relaxes the localhost-only default — only do this on a trusted host.
-
-> The bundled `docker-compose.yml` still carries the pre-inversion
-> `ws://host.docker.internal:9080` and doesn't publish `9080` yet (the server dialed *out*
-> to the host editor under the old direction). Apply the two changes above until the compose
-> fix lands — tracked in [#285](https://github.com/hybridindie/godot-mcp/issues/285).
+  Auth for the HTTP transport is tracked in [#226](https://github.com/hybridindie/godot-mcp/issues/226).
 
 ## Mounting a project
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,12 +5,15 @@ services:
       dockerfile: docker/Dockerfile
     ports:
       - "9090:9090"
+      - "9080:9080"
     environment:
       GODOT_MCP_TRANSPORT: http
       GODOT_MCP_HTTP_HOST: "0.0.0.0"
       GODOT_MCP_HTTP_PORT: "9090"
-      # Default for a Godot editor running on the Docker host.
-      GODOT_MCP_BRIDGE_URL: ws://host.docker.internal:9080
+      # The server binds the bridge port inside the container so the host editor
+      # can connect in (bridge inversion, #276). Binding 0.0.0.0 relaxes the
+      # localhost-only default — only do this on a trusted host (#226).
+      GODOT_MCP_BRIDGE_URL: ws://0.0.0.0:9080
       # Optional: point at a project directory mounted from the host.
       # GODOT_MCP_PROJECT_DIR: /project
     # volumes:


### PR DESCRIPTION
## Summary

The bundled `docker-compose.yml` predates the bridge inversion (#276): the server is now the WebSocket **listener** (the Godot addon connects *in*), but the compose still had the pre-inversion config (server dialing *out* to `host.docker.internal`). Fix:

- Publish `9080` alongside `9090` (`ports: ["9080:9080"]`)
- Bind `0.0.0.0` inside the container (`GODOT_MCP_BRIDGE_URL: ws://0.0.0.0:9080`) so the host editor can connect to the published port
- Remove the pre-inversion `ws://host.docker.internal:9080` (the server no longer dials out)
- Update `docker/README.md`: drop the "apply these changes until the fix lands" note; point at #226 for the auth follow-up

## Test plan

- [x] `docker-compose.yml` syntax valid (YAML)
- [x] No Python/test changes (infra-only)