### PR TITLE
feat(security): add auth for HTTP transport — refuse non-loopback without token (closes #226)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,6 +28,8 @@ connects *in*, so the container publishes the bridge port and binds all interfac
 - On the host, point the editor's addon at the published port:
   `GODOT_MCP_BRIDGE_URL=ws://127.0.0.1:9080`.
 - Binding `0.0.0.0` relaxes the localhost-only default — only do this on a trusted host.
+  The server refuses a non-loopback bind without `GODOT_MCP_AUTH_TOKEN`; clients pass
+  the token as `auth=<token>` (see [#226](https://github.com/hybridindie/godot-mcp/issues/226)).
   Auth for the HTTP transport is tracked in [#226](https://github.com/hybridindie/godot-mcp/issues/226).
 
 ## Mounting a project

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       # can connect in (bridge inversion, #276). Binding 0.0.0.0 relaxes the
       # localhost-only default — only do this on a trusted host (#226).
       GODOT_MCP_BRIDGE_URL: ws://0.0.0.0:9080
+      # Required when binding off-loopback (0.0.0.0): set a bearer token or the
+      # server refuses to start. Clients pass it as `auth=<token>` (#226).
+      # GODOT_MCP_AUTH_TOKEN: set-me
       # Optional: point at a project directory mounted from the host.
       # GODOT_MCP_PROJECT_DIR: /project
     # volumes:

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -74,6 +74,9 @@ class ServerConfig(BaseModel):
     approval_webhook: str | None = None
     approval_timeout: float = 30.0
     approval_fail_open: bool = True
+    # HTTP transport auth (issue #226). Opt-in: loopback HTTP is allowed without a
+    # token; a non-loopback bind requires a token or the server refuses to start.
+    auth_token: str | None = None
 
     @classmethod
     def from_env(cls) -> ServerConfig:
@@ -90,4 +93,25 @@ class ServerConfig(BaseModel):
             approval_timeout=float(os.environ.get("GODOT_MCP_APPROVAL_TIMEOUT", 30.0)),
             approval_fail_open=os.environ.get("GODOT_MCP_APPROVAL_FAIL_OPEN", "true").lower()
             != "false",
+            auth_token=os.environ.get("GODOT_MCP_AUTH_TOKEN"),
         )
+
+    def validate_http_auth(self) -> None:
+        """Refuse a non-loopback HTTP bind unless an auth token is configured.
+
+        Loopback (127.0.0.1 / localhost) is the default and safe without auth.
+        Binding off-loopback exposes unauthenticated code execution (write_script,
+        run_and_capture, export) — require a token or fail fast with a clear error.
+        stdio is never gated (local subprocess).
+        """
+        if self.transport != "http":
+            return
+        if self.auth_token:
+            return
+        host = self.host
+        if host not in ("127.0.0.1", "localhost", "::1", "[::1]"):
+            raise ValueError(
+                f"HTTP transport bound to {host} (non-loopback) without GODOT_MCP_AUTH_TOKEN. "
+                "Binding off-loopback exposes unauthenticated code execution. "
+                "Set GODOT_MCP_AUTH_TOKEN to a bearer token, or bind 127.0.0.1."
+            )

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -22,6 +22,7 @@ def main() -> None:
     """Build the server from the environment and run it on the configured transport."""
     config = ServerConfig.from_env()
     configure_logging(config.log_level)
+    config.validate_http_auth()
     logger.info("starting godot-mcp", extra={"transport": config.transport})
 
     server = create_server(config)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -107,11 +107,23 @@ def create_server(
         finally:
             await bridge.close()
 
+    # HTTP transport auth (issue #226): a StaticTokenVerifier gates the server
+    # when a token is configured. Loopback without a token is allowed (validated
+    # in main.py); non-loopback requires a token or main.py refuses to start.
+    auth = None
+    if config.auth_token:
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        auth = StaticTokenVerifier(
+            tokens={config.auth_token: {"client_id": "godot-mcp-client"}},
+        )
+
     mcp = FastMCP(
         SERVER_NAME,
         lifespan=lifespan,
         instructions=SERVER_INSTRUCTIONS,
         website_url="https://github.com/hybridindie/godot-mcp",
+        auth=auth,
         # The dynamic fields (toolset_count / prompts / resources) are filled in
         # from the live registry after registration; see capabilities.apply_capability.
         experimental_capabilities={"godot_mcp": dict(STATIC_CAPABILITY)},

--- a/tests/unit/test_http_auth.py
+++ b/tests/unit/test_http_auth.py
@@ -1,0 +1,47 @@
+"""Contract tests for HTTP transport auth (issue #226)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mcp_server.config import ServerConfig
+
+
+def test_loopback_http_allowed_without_token() -> None:
+    """Loopback HTTP (127.0.0.1) is allowed without a token — localhost-only is the default."""
+    config = ServerConfig(transport="http", host="127.0.0.1")
+    assert config.auth_token is None
+    config.validate_http_auth()  # should not raise
+
+
+def test_non_loopback_http_without_token_raises() -> None:
+    """Non-loopback HTTP without a token is refused — unauthenticated RCE surface."""
+    config = ServerConfig(transport="http", host="0.0.0.0")
+    assert config.auth_token is None
+    with pytest.raises(ValueError, match="GODOT_MCP_AUTH_TOKEN"):
+        config.validate_http_auth()
+
+
+def test_non_loopback_http_with_token_allowed() -> None:
+    """Non-loopback HTTP with a token is allowed."""
+    config = ServerConfig(transport="http", host="0.0.0.0", auth_token="secret-token")
+    config.validate_http_auth()  # should not raise
+
+
+def test_stdio_transport_never_requires_token() -> None:
+    """stdio never needs auth — it's a local subprocess."""
+    config = ServerConfig(transport="stdio", host="0.0.0.0")
+    config.validate_http_auth()  # should not raise
+
+
+def test_auth_token_from_env() -> None:
+    """GODOT_MCP_AUTH_TOKEN sets the token."""
+
+    os.environ["GODOT_MCP_AUTH_TOKEN"] = "env-token-123"
+    try:
+        config = ServerConfig.from_env()
+    finally:
+        del os.environ["GODOT_MCP_AUTH_TOKEN"]
+    assert config.auth_token == "env-token-123"


### PR DESCRIPTION
## Summary

Two-layer auth gate for the HTTP transport, closing the unauthenticated-RCE surface for off-loopback binds:

1. **Refuse non-loopback without a token** — `ServerConfig.validate_http_auth()` raises a clear `ValueError` if the HTTP transport is bound to a non-loopback host (`0.0.0.0`, etc.) without `GODOT_MCP_AUTH_TOKEN` set. Called in `main.py` before the server starts. Loopback (`127.0.0.1`/`localhost`/`::1`) and stdio are never gated.

2. **StaticTokenVerifier** — when a token is configured, a FastMCP `StaticTokenVerifier` gates the server via the `auth=` constructor kwarg. Clients pass the token as `Client(url, auth="<token>")`. No JWT/OAuth infrastructure needed — right-sized for a local dev tool.

## Changes

- `mcp_server/config.py` — add `auth_token: str | None` field + `GODOT_MCP_AUTH_TOKEN` env var + `validate_http_auth()` method
- `mcp_server/server.py` — wire `StaticTokenVerifier` into the `FastMCP(..., auth=auth)` constructor when a token is set
- `mcp_server/main.py` — call `config.validate_http_auth()` before starting
- `docker/docker-compose.yml` — document `GODOT_MCP_AUTH_TOKEN` (commented out, required for `0.0.0.0` bind)
- `docker/README.md` — document the auth requirement for non-loopback binds
- `tests/unit/test_http_auth.py` — 5 tests: loopback allowed without token, non-loopback refused without token, non-loopback allowed with token, stdio never gated, env var sets the token

## Test plan

- [x] `uv run pytest -q` — 628 passed
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean