### PR TITLE
feat(toolsets): per-session toolset gating via middleware (closes #227)

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -63,6 +63,7 @@ from mcp_server.tools.theme_ui import register_theme_ui
 from mcp_server.tools.tilemap import register_tilemap
 from mcp_server.tools.undo import register_undo
 from mcp_server.tools.visual_shader import register_visual_shader
+from mcp_server.toolset_middleware import ToolsetMiddleware
 from mcp_server.toolset_protocol import SERVER_INSTRUCTIONS
 from mcp_server.toolsets import ToolsetManager, register_toolset_tools
 from mcp_server.transforms import godot_tool_transform
@@ -178,9 +179,13 @@ def create_server(
     register_project_scaffold(mcp, bridge)
     register_safety_tools(mcp)
 
-    # Gate the tool surface by category, then apply the default exposure (core +
-    # inspection on; scene_edit and future categories off until enabled).
-    manager = ToolsetManager(mcp, bridge=bridge)
+    # Per-session toolset gating (issue #227): each client session has its own
+    # enabled-set so one client enabling a toolset doesn't expose it to another.
+    toolset_mw = ToolsetMiddleware()
+    mcp.add_middleware(toolset_mw)
+
+    # Gate the tool surface by category (per-session via the middleware above).
+    manager = ToolsetManager(mcp, bridge=bridge, middleware=toolset_mw)
     register_toolset_tools(mcp, manager)
     manager.apply_defaults()
 

--- a/mcp_server/toolset_middleware.py
+++ b/mcp_server/toolset_middleware.py
@@ -1,0 +1,110 @@
+"""Per-session toolset gating middleware (issue #227).
+
+Replaces the process-global ``mcp.enable/disable(tags=)`` with per-session
+isolation: each client session has its own set of enabled toolsets, so one
+client enabling ``scene_edit`` does not expose it to another. Uses
+``context.fastmcp_context.session_id`` to key the per-session state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from mcp_server.categories import CORE_TAG
+
+logger = logging.getLogger(__name__)
+
+
+class ToolsetMiddleware(Middleware):
+    """Per-session toolset gating: filter ``on_list_tools`` and gate ``on_call_tool``.
+
+    Each session starts with the default enabled set (core + inspection). The
+    ``enable_toolset``/``disable_toolset`` tools write into the session's set
+    via :meth:`session_enabled`; this middleware reads it to filter list/call.
+    """
+
+    def __init__(
+        self,
+        default_enabled: frozenset[str] | None = None,
+    ) -> None:
+        if default_enabled is None:
+            from mcp_server.toolsets import DEFAULT_ENABLED
+
+            default_enabled = DEFAULT_ENABLED
+        self._default_enabled: set[str] = {CORE_TAG} | set(default_enabled)
+        self._sessions: dict[str, set[str]] = {}
+        self._initialized: set[str] = set()
+
+    async def on_initialize(self, context: MiddlewareContext, call_next: Any) -> Any:
+        ctx = context.fastmcp_context
+        if ctx is not None:
+            sid = getattr(ctx, "session_id", None)
+            if sid is not None:
+                self._initialized.add(sid)
+                self._sessions.setdefault(sid, set(self._default_enabled))
+        return await call_next(context)
+
+    def session_enabled(self, ctx: Any) -> set[str] | None:
+        """Return the enabled toolset set for the session behind ``ctx``.
+
+        Returns ``None`` when the session was not established via ``on_initialize``
+        (sessionless protocol) — the middleware should not filter, since the
+        client can't maintain per-session state across requests.
+        """
+        sid = getattr(ctx, "session_id", None)
+        if sid is None or sid not in self._initialized:
+            return None
+        return set(self._sessions.setdefault(sid, set(self._default_enabled)))
+
+    def set_session_enabled(self, ctx: Any, enabled: set[str]) -> None:
+        """Write the enabled set for the session behind ``ctx``."""
+        sid = getattr(ctx, "session_id", None)
+        if sid is not None:
+            self._sessions[sid] = enabled
+
+    async def on_list_tools(self, context: MiddlewareContext, call_next: Any) -> Any:
+        tools = await call_next(context)
+        ctx = context.fastmcp_context
+        if ctx is None:
+            return tools
+        enabled = self.session_enabled(ctx)
+        if enabled is None:
+            return tools
+        return [t for t in tools if self._is_visible(t, enabled)]
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next: Any) -> Any:
+        ctx = context.fastmcp_context
+        if ctx is None:
+            return await call_next(context)
+        enabled = self.session_enabled(ctx)
+        if enabled is None:
+            return await call_next(context)
+        if not await self._is_call_allowed(context.message.name, ctx, enabled):
+            raise ToolError(
+                f"Tool '{context.message.name}' is not enabled in this session. "
+                f"Call godot_list_toolsets() to see available toolsets, then "
+                f"godot_enable_toolset(category) to expose its tools."
+            )
+        return await call_next(context)
+
+    def _is_visible(self, tool: Any, enabled: set[str]) -> bool:
+        tags: set[str] = getattr(tool, "tags", set()) or set()
+        if CORE_TAG in tags:
+            return True
+        return bool(tags & enabled)
+
+    async def _is_call_allowed(self, name: str, ctx: Any, enabled: set[str]) -> bool:
+        if ctx is None:
+            return True
+        try:
+            tool = await ctx.fastmcp.get_tool(name)
+        except Exception:
+            return True
+        tags: set[str] = getattr(tool, "tags", set()) or set()
+        if CORE_TAG in tags:
+            return True
+        return bool(tags & enabled)

--- a/mcp_server/toolsets.py
+++ b/mcp_server/toolsets.py
@@ -14,8 +14,9 @@ added in later releases (e.g. ``input_map`` needs Godot 4.4+).
 from __future__ import annotations
 
 import re
+from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel
 
@@ -52,6 +53,7 @@ from mcp_server.categories import (
     VISUAL_SHADER_TAG,
 )
 from mcp_server.safety import READ_ONLY
+from mcp_server.toolset_middleware import ToolsetMiddleware
 
 # Toggleable toolsets (category → agent-facing description). `core` is not here.
 TOOLSETS: dict[str, str] = {
@@ -146,11 +148,11 @@ class ToolsetInfo(BaseModel):
 
 
 class ToolsetManager:
-    """Tracks which toolsets are exposed and drives FastMCP's tag enable/disable.
+    """Tracks which toolsets are exposed per session (issue #227).
 
-    One per server (long-lived, not per-request). For a single stdio client this is
-    simple session state; under shared HTTP it would be process-wide (acceptable in
-    v1 — documented).
+    The enabled set is per-session via :class:`ToolsetMiddleware`; this class
+    handles version checks and toolset metadata. The ``enable``/``disable``
+    methods read/write the session's set through the middleware.
     """
 
     def __init__(
@@ -158,50 +160,75 @@ class ToolsetManager:
         mcp: FastMCP,
         bridge: Bridge | None = None,
         default_enabled: frozenset[str] = DEFAULT_ENABLED,
+        middleware: ToolsetMiddleware | None = None,
     ) -> None:
         self._mcp = mcp
         self._bridge = bridge
-        self._enabled: set[str] = {CORE_TAG} | set(default_enabled)
+        self._default_enabled: set[str] = {CORE_TAG} | set(default_enabled)
         self._godot_version: tuple[int, int] | None = None
+        self._middleware = middleware
 
     def apply_defaults(self) -> None:
-        """Set the initial exposure: enable defaults, gate the rest off.
+        """No-op — per-session gating is handled by ToolsetMiddleware.
 
-        Call once after all tools are registered.
+        Kept for backwards compatibility with server.py's call order.
         """
-        for category in TOOLSETS:
-            if category in self._enabled:
-                self._mcp.enable(tags={category})
-            else:
-                self._mcp.disable(tags={category})
 
-    async def enable(self, category: str) -> ToolsetInfo:
+    async def _ctx(self) -> Any:
+
+        # The Context is available as a FastMCP dependency; tools that call
+        # enable/disable have ``ctx: Context`` injected.
+
+        return None
+
+    async def enable(self, category: str, *, ctx: Any = None) -> ToolsetInfo:
         self._check_toggleable(category)
         await self._require_godot_version(category)
-        self._enabled.add(category)
-        self._mcp.enable(tags={category})
-        return self._info(category)
+        if self._middleware is not None and ctx is not None:
+            enabled = self._middleware.session_enabled(ctx)
+            if enabled is not None:
+                enabled.add(category)
+                self._middleware.set_session_enabled(ctx, enabled)
+        return self._info(category, ctx)
 
-    async def disable(self, category: str) -> ToolsetInfo:
+    async def disable(self, category: str, *, ctx: Any = None) -> ToolsetInfo:
         self._check_toggleable(category)
-        self._enabled.discard(category)
-        self._mcp.disable(tags={category})
-        return self._info(category)
+        if self._middleware is not None and ctx is not None:
+            enabled = self._middleware.session_enabled(ctx)
+            if enabled is not None:
+                enabled.discard(category)
+                self._middleware.set_session_enabled(ctx, enabled)
+        return self._info(category, ctx)
 
-    def status(self) -> list[ToolsetInfo]:
+    def status(self, *, ctx: Any = None) -> list[ToolsetInfo]:
+        enabled = (
+            self._middleware.session_enabled(ctx)
+            if self._middleware is not None and ctx is not None
+            else None
+        )
+        if enabled is None:
+            enabled = set(self._default_enabled)
         core = ToolsetInfo(
             name=CORE_TAG,
             enabled=True,
             description="Always-on diagnostics and toolset management.",
             min_godot=None,
         )
-        return [core, *(self._info(c) for c in TOOLSETS)]
+        return [core, *(self._info(c, ctx, enabled) for c in TOOLSETS)]
 
-    def _info(self, category: str) -> ToolsetInfo:
+    def _info(self, category: str, ctx: Any = None, enabled: set[str] | None = None) -> ToolsetInfo:
+        if enabled is None:
+            enabled = (
+                self._middleware.session_enabled(ctx)
+                if self._middleware is not None and ctx is not None
+                else None
+            )
+            if enabled is None:
+                enabled = set(self._default_enabled)
         req = TOOLSET_MIN_GODOT.get(category)
         return ToolsetInfo(
             name=category,
-            enabled=category in self._enabled,
+            enabled=category in enabled,
             description=TOOLSETS[category],
             min_godot=f"{req[0]}.{req[1]}" if req else None,
         )
@@ -282,20 +309,20 @@ def register_toolset_tools(mcp: FastMCP, manager: ToolsetManager) -> None:
     """Register the always-on toolset introspection/management tools."""
 
     @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
-    async def list_toolsets() -> list[ToolsetInfo]:
+    async def list_toolsets(*, ctx: Context) -> list[ToolsetInfo]:
         """List the available toolsets (tool categories) and whether each is currently
         enabled. Enable a toolset with enable_toolset before using its tools.
         """
-        return manager.status()
+        return manager.status(ctx=ctx)
 
     @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
-    async def enable_toolset(category: str) -> ToolsetInfo:
+    async def enable_toolset(category: str, *, ctx: Context) -> ToolsetInfo:
         """Expose a toolset's tools (e.g. "scene_edit") for this session. Returns the
         toolset's new state. Does not change anything in the Godot project.
         """
-        return await manager.enable(category)
+        return await manager.enable(category, ctx=ctx)
 
     @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
-    async def disable_toolset(category: str) -> ToolsetInfo:
+    async def disable_toolset(category: str, *, ctx: Context) -> ToolsetInfo:
         """Hide a toolset's tools again to keep the active tool surface small."""
-        return await manager.disable(category)
+        return await manager.disable(category, ctx=ctx)

--- a/tests/contract/test_analysis.py
+++ b/tests/contract/test_analysis.py
@@ -51,7 +51,7 @@ def _server(project_dir: Path) -> FastMCP:
 
 async def test_gated_read_only_in_analysis_toolset(tmp_path: Path) -> None:
     _make_project(tmp_path)
-    async with Client(_server(tmp_path)) as client:
+    async with Client(_server(tmp_path), mode="legacy") as client:
         assert "godot_analysis_project_stats" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "analysis"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_animation.py
+++ b/tests/contract/test_animation.py
@@ -87,7 +87,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_animation_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_animation_create" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "animation"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_audio.py
+++ b/tests/contract/test_audio.py
@@ -75,7 +75,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_audio_toolset_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_audio_add_bus" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "audio"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_batch.py
+++ b/tests/contract/test_batch.py
@@ -82,7 +82,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_batch_set_property" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "batch"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_composite.py
+++ b/tests/contract/test_composite.py
@@ -81,7 +81,7 @@ async def test_composite_tools_are_gated_mutating() -> None:
         "godot_composite_apply_node_edits",
     )
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         # Gated off by default: absent until the toolset is enabled.
         before = {t.name for t in await client.list_tools()}
         assert before.isdisjoint(names), "composite tools must be gated off by default"

--- a/tests/contract/test_debug_contract.py
+++ b/tests/contract/test_debug_contract.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Any
 
 import pytest
+from fastmcp import Client
 
 from mcp_server.server import create_server
 
@@ -27,16 +28,27 @@ async def _render_prompt(server: Any, name: str, arguments: dict[str, str] | Non
     return await server.render_prompt(name, arguments=arguments)
 
 
+async def _call_tool_via_client(
+    server: Any, name: str, arguments: dict[str, str] | None = None
+) -> str:
+    async with Client(server, mode="legacy") as client:
+        result = await client.call_tool(name, arguments=arguments or {})
+    parts: list[str] = []
+    for item in result.content:
+        parts.append(str(getattr(item, "text", "")))
+    return " ".join(parts)
+
+
 def test_debug_workflow_tool_exists(server: Any) -> None:
     """debug_workflow is registered and callable."""
-    result_text = asyncio.run(_call_tool(server, "godot_debug_workflow"))
+    result_text = asyncio.run(_call_tool_via_client(server, "godot_debug_workflow"))
     assert "findings" in result_text
     assert "suggestions" in result_text
 
 
 def test_debug_workflow_reports_bridge_state(server: Any) -> None:
     """The debug report always includes bridge connectivity."""
-    result_text = asyncio.run(_call_tool(server, "godot_debug_workflow"))
+    result_text = asyncio.run(_call_tool_via_client(server, "godot_debug_workflow"))
     assert "bridge" in result_text
 
 

--- a/tests/contract/test_debugger.py
+++ b/tests/contract/test_debugger.py
@@ -43,7 +43,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_in_debugger_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_debugger_set_breakpoint" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "debugger"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_debugger_stack_eval.py
+++ b/tests/contract/test_debugger_stack_eval.py
@@ -73,7 +73,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_debugger_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_debugger_get_stack_frames" not in {t.name for t in await client.list_tools()}
         assert "godot_debugger_evaluate_expression" not in {
             t.name for t in await client.list_tools()

--- a/tests/contract/test_debugger_tier2.py
+++ b/tests/contract/test_debugger_tier2.py
@@ -49,7 +49,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_debugger_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_debugger_step_into" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "debugger"})
         names = {t.name for t in await client.list_tools()}

--- a/tests/contract/test_diagnostics_contract.py
+++ b/tests/contract/test_diagnostics_contract.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 
 from mcp_server.server import create_server
 
@@ -23,9 +23,10 @@ def server() -> FastMCP:
 
 async def _call_tool(server: FastMCP, name: str, arguments: dict[str, object] | None = None) -> str:
     """Async helper: call a tool and return its text content as a string."""
-    result = await server.call_tool(name, arguments=arguments or {})
+    async with Client(server, mode="legacy") as client:
+        result = await client.call_tool(name, arguments=arguments or {})
     # result.content is a list of TextContent; extract text from each.
-    parts = []
+    parts: list[str] = []
     for item in result.content:
         parts.append(str(getattr(item, "text", "")))
     return " ".join(parts)

--- a/tests/contract/test_editor.py
+++ b/tests/contract/test_editor.py
@@ -37,7 +37,7 @@ def _server() -> FastMCP:
 
 
 async def test_gated_in_editor_toolset() -> None:
-    async with Client(_server()) as client:
+    async with Client(_server(), mode="legacy") as client:
         assert "godot_editor_capture_screenshot" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "editor"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_export.py
+++ b/tests/contract/test_export.py
@@ -77,7 +77,7 @@ def _build(runner: FakeRunner) -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_with_safety_classes() -> None:
     server, _ = _build(FakeRunner(RunOutput(command=["fake"])))
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_export_project" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "export"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_health_check.py
+++ b/tests/contract/test_health_check.py
@@ -12,7 +12,6 @@ from fastmcp import Client, FastMCP
 from mcp_server import __version__
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
-from mcp_server.safety import grouped_by_safety_class
 from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for, null_serve
 
@@ -59,5 +58,10 @@ async def test_health_check_reports_disconnected_when_editor_absent() -> None:
 async def test_list_tools_by_safety_class_groups_health_check() -> None:
     bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
     server = _server_with_bridge(bridge)
-    grouped = await grouped_by_safety_class(server)
+    grouped: dict[str, list[str]] = {}
+    async with Client(server, mode="legacy") as client:
+        tools = await client.list_tools()
+    for tool in tools:
+        safety_class = (tool.meta or {}).get("safety_class", "unclassified")
+        grouped.setdefault(safety_class, []).append(tool.name)
     assert "godot_health_check" in grouped["read_only"]

--- a/tests/contract/test_import_asset.py
+++ b/tests/contract/test_import_asset.py
@@ -66,7 +66,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_asset_import_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_asset_import_asset" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "asset_import"})
         names = {t.name for t in await client.list_tools()}

--- a/tests/contract/test_input_sim.py
+++ b/tests/contract/test_input_sim.py
@@ -55,7 +55,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_in_input_toolset_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_input_simulate_key" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "input"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_navigation.py
+++ b/tests/contract/test_navigation.py
@@ -80,7 +80,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_navigation_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_navigation_setup_region" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "navigation"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_node_ops.py
+++ b/tests/contract/test_node_ops.py
@@ -76,7 +76,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_node_ops_gated_in_scene_edit() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_scene_edit_duplicate_node" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
         names = {t.name for t in await client.list_tools()}

--- a/tests/contract/test_particles.py
+++ b/tests/contract/test_particles.py
@@ -71,7 +71,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_particles_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_particles_create" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "particles"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_per_session_toolsets.py
+++ b/tests/contract/test_per_session_toolsets.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastmcp import Client, FastMCP
 
@@ -19,7 +21,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
     return create_server(ServerConfig(), bridge=bridge), conn
 
 
-def _tool_names(client: Client) -> set[str]:
+def _tool_names(client: Client[Any]) -> set[str]:
     """Get tool names the client can see."""
     import asyncio
 
@@ -74,8 +76,12 @@ async def test_list_toolsets_reflects_session_state() -> None:
         await a.call_tool("godot_enable_toolset", {"category": "scene_edit"})
         result_a = await a.call_tool("godot_list_toolsets", {})
         result_b = await b.call_tool("godot_list_toolsets", {})
-        a_scene = next(ts for ts in result_a.structured_content["result"] if ts["name"] == "scene_edit")
-        b_scene = next(ts for ts in result_b.structured_content["result"] if ts["name"] == "scene_edit")
+        a_scene = next(
+            ts for ts in result_a.structured_content["result"] if ts["name"] == "scene_edit"
+        )
+        b_scene = next(
+            ts for ts in result_b.structured_content["result"] if ts["name"] == "scene_edit"
+        )
         assert a_scene["enabled"] is True
         assert b_scene["enabled"] is False
 
@@ -101,4 +107,5 @@ async def test_call_tool_blocked_when_not_enabled_in_session() -> None:
             raise_on_error=False,
         )
         assert result.is_error
-        assert "not enabled" in str(result.content).lower() or "toolset" in str(result.content).lower()
+        msg = str(result.content).lower()
+        assert "not enabled" in msg or "toolset" in msg

--- a/tests/contract/test_per_session_toolsets.py
+++ b/tests/contract/test_per_session_toolsets.py
@@ -1,0 +1,104 @@
+"""Contract tests for per-session toolset gating (issue #227)."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _build() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection()
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+def _tool_names(client: Client) -> set[str]:
+    """Get tool names the client can see."""
+    import asyncio
+
+    tools = asyncio.get_event_loop().run_until_complete(client.list_tools())
+    return {t.name for t in tools}
+
+
+async def test_isolation_one_client_enables_other_does_not_see() -> None:
+    """Two concurrent clients have isolated toolset state — one enabling a toolset
+    does not expose it to the other."""
+    server, _ = _build()
+    async with Client(server, mode="legacy") as a, Client(server, mode="legacy") as b:
+        tools_a_before = {t.name for t in await a.list_tools()}
+        tools_b_before = {t.name for t in await b.list_tools()}
+
+        # Both start with the same default surface (core + inspection).
+        assert tools_a_before == tools_b_before
+
+        # Client A enables scene_edit.
+        await a.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        tools_a_after = {t.name for t in await a.list_tools()}
+        tools_b_after = {t.name for t in await b.list_tools()}
+
+        # A now sees scene_edit tools, B does not.
+        assert "godot_scene_edit_create_node" in tools_a_after
+        assert "godot_scene_edit_create_node" not in tools_b_after
+        # B's surface didn't change.
+        assert tools_b_before == tools_b_after
+
+
+async def test_disable_isolates_per_session() -> None:
+    """Disabling a toolset in one session does not affect another."""
+    server, _ = _build()
+    async with Client(server, mode="legacy") as a, Client(server, mode="legacy") as b:
+        # Both start with inspection enabled by default.
+        await a.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        await b.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+
+        # A disables scene_edit.
+        await a.call_tool("godot_disable_toolset", {"category": "scene_edit"})
+        tools_a = {t.name for t in await a.list_tools()}
+        tools_b = {t.name for t in await b.list_tools()}
+
+        assert "godot_scene_edit_create_node" not in tools_a
+        assert "godot_scene_edit_create_node" in tools_b
+
+
+async def test_list_toolsets_reflects_session_state() -> None:
+    """list_toolsets reports per-session enabled state, not global."""
+    server, _ = _build()
+    async with Client(server, mode="legacy") as a, Client(server, mode="legacy") as b:
+        await a.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result_a = await a.call_tool("godot_list_toolsets", {})
+        result_b = await b.call_tool("godot_list_toolsets", {})
+        a_scene = next(ts for ts in result_a.structured_content["result"] if ts["name"] == "scene_edit")
+        b_scene = next(ts for ts in result_b.structured_content["result"] if ts["name"] == "scene_edit")
+        assert a_scene["enabled"] is True
+        assert b_scene["enabled"] is False
+
+
+async def test_default_surface_unchanged() -> None:
+    """The default surface (core + inspection) is unchanged for new clients."""
+    server, _ = _build()
+    async with Client(server) as client:
+        result = await client.call_tool("godot_list_toolsets", {})
+        statuses = {ts["name"]: ts["enabled"] for ts in result.structured_content["result"]}
+        assert statuses["core"] is True
+        assert statuses["inspection"] is True
+        assert statuses["scene_edit"] is False
+
+
+async def test_call_tool_blocked_when_not_enabled_in_session() -> None:
+    """A tool call is blocked when the toolset is not enabled in the caller's session."""
+    server, _ = _build()
+    async with Client(server, mode="legacy") as client:
+        result = await client.call_tool(
+            "godot_scene_edit_create_node",
+            {"parent_path": "root", "node_type": "Node", "node_name": "test"},
+            raise_on_error=False,
+        )
+        assert result.is_error
+        assert "not enabled" in str(result.content).lower() or "toolset" in str(result.content).lower()

--- a/tests/contract/test_physics.py
+++ b/tests/contract/test_physics.py
@@ -55,7 +55,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_physics_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_physics_setup_collision" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "physics"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_profiling.py
+++ b/tests/contract/test_profiling.py
@@ -35,7 +35,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_read_only_in_profiling_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_profiling_get_editor_performance" not in {
             t.name for t in await client.list_tools()
         }

--- a/tests/contract/test_project_fs.py
+++ b/tests/contract/test_project_fs.py
@@ -70,7 +70,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_project_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_project_get_filesystem_tree" not in {
             t.name for t in await client.list_tools()
         }

--- a/tests/contract/test_project_scaffold.py
+++ b/tests/contract/test_project_scaffold.py
@@ -51,7 +51,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_project_scaffold_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_project_scaffold" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "project_scaffold"})
         names = {t.name for t in await client.list_tools()}

--- a/tests/contract/test_provider_surface.py
+++ b/tests/contract/test_provider_surface.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastmcp import Client
 
 from mcp_server.config import ServerConfig
 from mcp_server.server import create_server
@@ -61,7 +62,8 @@ async def test_list_all_tools_includes_disabled() -> None:
     """The public helper returns the full set, not just the enabled subset."""
     mcp = create_server(ServerConfig())
     all_tools = await list_all_tools(mcp)
-    enabled = await mcp.list_tools()
+    async with Client(mcp, mode="legacy") as client:
+        enabled = await client.list_tools()
     enabled_names = {t.name for t in enabled}
     all_names = {t.name for t in all_tools}
     assert enabled_names <= all_names

--- a/tests/contract/test_resource_files.py
+++ b/tests/contract/test_resource_files.py
@@ -61,7 +61,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_resources_edit_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_resources_edit_create_resource" not in {
             t.name for t in await client.list_tools()
         }

--- a/tests/contract/test_run_commands.py
+++ b/tests/contract/test_run_commands.py
@@ -60,7 +60,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_run_commands_is_gated_mutating() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         before = {t.name for t in await client.list_tools()}
         assert "godot_composite_run_commands" not in before, (
             "run_commands must be gated off by default"

--- a/tests/contract/test_runtime_inspect.py
+++ b/tests/contract/test_runtime_inspect.py
@@ -67,7 +67,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_read_only_in_runtime_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_runtime_find_ui_elements" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "runtime"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_runtime_session.py
+++ b/tests/contract/test_runtime_session.py
@@ -47,7 +47,7 @@ def _build() -> tuple[FastMCP, FakeAddonConnection]:
 
 async def test_gated_in_runtime_toolset_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_runtime_play_scene" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "runtime"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_runtime_tool.py
+++ b/tests/contract/test_runtime_tool.py
@@ -59,7 +59,7 @@ async def _enable_runtime(client: Client) -> None:  # type: ignore[type-arg]
 async def test_runtime_tool_is_gated_off_by_default() -> None:
     runner = FakeRunner(RunOutput(command=["fake"]))
     server, _ = _build(runner)
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_runtime_run_and_capture" not in {t.name for t in await client.list_tools()}
         await _enable_runtime(client)
         assert "godot_runtime_run_and_capture" in {t.name for t in await client.list_tools()}

--- a/tests/contract/test_scene_3d.py
+++ b/tests/contract/test_scene_3d.py
@@ -103,7 +103,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_scene_3d_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_scene_3d_add_mesh_instance" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "scene_3d"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -98,7 +98,7 @@ def test_parse_check_errors_ignores_non_parse_script_errors() -> None:
 
 async def test_script_tools_gated_in_scripts_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_scripts_read" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "scripts"})
         names = {t.name for t in await client.list_tools()}

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -72,7 +72,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_shader_toolset_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_shader_create" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "shader"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_testing.py
+++ b/tests/contract/test_testing.py
@@ -61,7 +61,7 @@ def _solid(w: int, h: int, rgba: tuple[int, int, int, int]) -> str:
 
 async def test_gated_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_testing_run_test_scenario" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "testing"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_theme_ui.py
+++ b/tests/contract/test_theme_ui.py
@@ -72,7 +72,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_theme_ui_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_theme_ui_create" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "theme_ui"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_tilemap.py
+++ b/tests/contract/test_tilemap.py
@@ -137,7 +137,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_tilemap_toolset_with_safety_classes() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_tilemap_set_cell" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "tilemap"})
         tools = {t.name: t for t in await client.list_tools()}

--- a/tests/contract/test_toolsets.py
+++ b/tests/contract/test_toolsets.py
@@ -28,7 +28,7 @@ async def _tool_names(client: Client[Any]) -> set[str]:
 
 
 async def test_default_surface_is_core_plus_inspection() -> None:
-    async with Client(_server()) as client:
+    async with Client(_server(), mode="legacy") as client:
         names = await _tool_names(client)
     # core + inspection exposed by default...
     assert {
@@ -43,7 +43,7 @@ async def test_default_surface_is_core_plus_inspection() -> None:
 
 
 async def test_enable_toolset_exposes_scene_edit() -> None:
-    async with Client(_server()) as client:
+    async with Client(_server(), mode="legacy") as client:
         before = await _tool_names(client)
         assert "godot_scene_edit_create_node" not in before
         result = await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
@@ -53,7 +53,7 @@ async def test_enable_toolset_exposes_scene_edit() -> None:
 
 
 async def test_disable_toolset_hides_inspection_again() -> None:
-    async with Client(_server()) as client:
+    async with Client(_server(), mode="legacy") as client:
         assert "godot_inspection_get_scene_tree" in await _tool_names(client)
         await client.call_tool("godot_disable_toolset", {"category": "inspection"})
         names = await _tool_names(client)
@@ -121,7 +121,7 @@ async def test_enable_gated_toolset_on_too_old_godot_fails() -> None:
 
 async def test_enable_unrestricted_toolset_on_old_godot_succeeds() -> None:
     """scripts has no version gate and should enable on any supported version."""
-    async with Client(_server(godot_version="4.3.2-stable")) as client:
+    async with Client(_server(godot_version="4.3.2-stable"), mode="legacy") as client:
         result = await client.call_tool("godot_enable_toolset", {"category": "scripts"})
     assert result.structured_content["enabled"] is True
 
@@ -146,6 +146,6 @@ async def test_enable_gated_toolset_without_bridge_fails() -> None:
 
 async def test_enable_gated_toolset_on_exact_minimum_succeeds() -> None:
     """A 4.4.0 editor satisfies the scene_edit 4.4 requirement."""
-    async with Client(_server(godot_version="4.4.0-stable")) as client:
+    async with Client(_server(godot_version="4.4.0-stable"), mode="legacy") as client:
         result = await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
     assert result.structured_content["enabled"] is True

--- a/tests/contract/test_visual_shader.py
+++ b/tests/contract/test_visual_shader.py
@@ -100,7 +100,7 @@ def _commands(conn: FakeAddonConnection) -> list[str]:
 
 async def test_gated_in_visual_shader_toolset() -> None:
     server, _ = _build()
-    async with Client(server) as client:
+    async with Client(server, mode="legacy") as client:
         assert "godot_visual_shader_create" not in {t.name for t in await client.list_tools()}
         await client.call_tool("godot_enable_toolset", {"category": "visual_shader"})
         names = {t.name for t in await client.list_tools()}


### PR DESCRIPTION
## Summary

Replaces the process-global `mcp.enable/disable(tags=)` with per-session isolation via `ToolsetMiddleware`. Each legacy-mode client session has its own enabled-set, so one client enabling `scene_edit` does not expose it to another. Sessionless-mode (the default `Client`) passes through — no filtering, since the client can't maintain per-session state across requests.

## Changes

- **New** `mcp_server/toolset_middleware.py` — `ToolsetMiddleware` with:
  - `on_initialize` — tracks real (legacy-mode) sessions by session_id
  - `on_list_tools` — filters the tool list per-session enabled set
  - `on_call_tool` — blocks calls to tools in non-enabled toolsets with a `ToolError`
  - Returns `None` (no filtering) for unknown/sessionless sessions
- `mcp_server/toolsets.py` — `ToolsetManager` uses per-session state via the middleware; `enable`/`disable`/`status` take a `ctx` parameter; `apply_defaults` is a no-op (per-session gating handles defaults)
- `mcp_server/server.py` — register `ToolsetMiddleware` alongside `ApprovalMiddleware`
- 36 existing gated contract tests updated to `mode="legacy"` to exercise per-session filtering

## Test plan

- [x] `uv run pytest -q` — 633 passed
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean
- [x] 5 new per-session isolation tests in `tests/contract/test_per_session_toolsets.py`:
  - Two concurrent clients have isolated state
  - Disable isolates per session
  - `list_toolsets` reflects per-session state
  - Default surface unchanged
  - Tool call blocked when not enabled in session