### PR TITLE
docs: update for FastMCP 4.0 + recent features (#301-303, #226, #227, #330)

### DIFF
--- a/.claude/rules/mcp-tools.md
+++ b/.claude/rules/mcp-tools.md
@@ -44,7 +44,7 @@ Check before mutating, and fail with a structured precondition error (see [[erro
 A large flat tool surface degrades agent tool-selection and burns context. Keep the *exposed* surface small even as the catalog grows toward full Godot coverage:
 
 - Tag every tool with **exactly one category** (`tags={...}` from `mcp_server/categories.py`) in addition to its `safety_class` meta. `core` is always exposed; other categories are gated.
-- **New categories register gated off** — added to `TOOLSETS` but not `DEFAULT_ENABLED`. The agent turns them on with `enable_toolset` (which uses FastMCP `enable(tags=…)` and fires `tools/list_changed`). Default exposure stays `core` + `inspection`.
+- **New categories register gated off** — added to `TOOLSETS` but not `DEFAULT_ENABLED`. The agent turns them on with `enable_toolset` (which writes into the per-session enabled set via `ToolsetMiddleware`, issue #227). Default exposure stays `core` + `inspection`. In sessionless mode (default `Client`), the middleware passes through (no filtering) since the client can't maintain per-session state; legacy-mode clients get per-session isolation.
 - **Prefer fewer, richer tools over many micro-tools.** Design create-with-config (`create_node(..., properties?, script?)`) and batch setters over one-tool-per-field. One tool per noun with a few clear verbs — never a single `do(action, params)` dispatcher (it discards the per-tool schemas/descriptions that guide the agent).
 - **Never merge across safety classes** (e.g. don't fold `delete` into a fat `node` tool — it buries the `confirm` gate).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ These span many files and are the things easiest to get wrong:
 - **JSON-safe serialization** — the scene tree and node properties must serialize to JSON-safe types only (no Godot objects). Large trees support a `max_depth` parameter.
 - **Type coercion** (issue #6) — Godot types (`Vector2/3`, `Color`, `Rect2`, `NodePath`) are coerced to/from JSON in a dedicated `type_coerce.gd` helper, not inline.
 - **Read-only vs. mutating split** — read-only context is exposed both as tools (issue #5) and as `godot://` resources (issue #11); mutations only ever go through tools.
-- **Naming** — `snake_case` for all domain/data fields and Pydantic models; addon command handlers are `cmd_<verb>_<noun>`. Every MCP tool is exposed as `godot_<toolset>_<action>` (issue #224) — the prefix *is* the gating toolset (always-on `core`/meta tools are `godot_<action>`); the mapping is applied centrally in `mcp_server/transforms.py` (via FastMCP 4.0's `ToolTransform`, issue #312) and enforced by `tests/contract/test_tool_naming.py`.
+- **Naming** — `snake_case` for all domain/data fields and Pydantic models; addon command handlers are `cmd_<verb>_<noun>`. Every MCP tool is exposed as `godot_<toolset>_<action>` (issue #224) — the prefix *is* the gating toolset (always-on `core`/meta tools are `godot_<action>`); the mapping is applied centrally in `mcp_server/transforms.py` (via FastMCP 4.0's `ToolTransform`, issue #312) and enforced by `tests/contract/test_tool_transform.py`.
 
 ## Game-agnostic scope
 
@@ -82,7 +82,7 @@ godot-mcp deliberately ships **no** game vocabulary — no Tower/Enemy/Wave mode
 
 The scaffold (issue #1) is in place: `uv`-managed Python package, the addon under `godot/`, docs, and CI.
 
-- Godot **4.4+** (floor), **validated on 4.7-stable** (the `godot/` project declares `config/features=PackedStringArray("4.7")`); Python **3.11+**; **FastMCP** (PrefectHQ/fastmcp) as the MCP framework, managed with **uv**. Always verify Godot APIs against the current docs for the pinned version (via `context7` or `docs.godotengine.org`) rather than from memory — see [[addon]].
+- Godot **4.4+** (floor), **validated on 4.7-stable** (the `godot/` project declares `config/features=PackedStringArray("4.7")`); Python **3.11+**; **FastMCP 4.0** (PrefectHQ/fastmcp, pinned to the 4.0 beta), managed with **uv**. Always verify Godot APIs against the current docs for the pinned version (via `context7` or `docs.godotengine.org`) rather than from memory — see [[addon]].
 - **Dev commands** (run from repo root, mirrored by `.github/workflows/ci.yml`):
   - `uv sync` — create the venv and install runtime + dev deps.
   - `uv run pytest -q` — full suite; single file `uv run pytest tests/unit/test_smoke.py`; single test `uv run pytest tests/unit/test_smoke.py::test_version_is_calver`.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ mount). Claude Code, via `.mcp.json`:
 { "mcpServers": { "godot": { "type": "http", "url": "http://127.0.0.1:9090/mcp" } } }
 ```
 
+For non-loopback binds (e.g. Docker's `0.0.0.0`), set `GODOT_MCP_AUTH_TOKEN` to a
+bearer token — the server refuses to start without one, and clients pass it as
+`auth`:
+
+```json
+{ "mcpServers": { "godot": { "type": "http", "url": "http://0.0.0.0:9090/mcp", "auth": "<token>" } } }
+```
+
 ---
 
 ## Using godot-mcp
@@ -605,7 +613,8 @@ All configuration is optional and passed via environment variables:
 | `GODOT_MCP_GODOT_BIN` | auto-discovered | Godot executable for `godot_runtime_run_and_capture` / `godot_export_project` |
 | `GODOT_MCP_PROJECT_DIR` | connected editor's project | Project directory for runner, export, and analysis |
 | `GODOT_MCP_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) — JSON to stderr |
-| `GODOT_MCP_APPROVAL_WEBHOOK` | unset | Optional human-in-the-loop approval webhook for destructive tools (`ApprovalGate`) |
+| `GODOT_MCP_APPROVAL_WEBHOOK` | unset | Optional human-in-the-loop approval webhook for destructive tools (`ApprovalMiddleware`) |
+| `GODOT_MCP_AUTH_TOKEN` | unset | Bearer token for HTTP transport auth; **required** for non-loopback binds |
 
 ---
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -82,15 +82,17 @@ Every tool is tagged with exactly one:
   for agent introspection.
 - Each `safety_class` also drives the tool's **standard MCP `annotations`** (issue #220), set
   for every tool (incl. gated-off ones) at server build so clients render them natively:
-  `read_only` → `readOnlyHint=true, idempotentHint=true`; `destructive` → `destructiveHint=true`;
-  `mutating`/`runtime` → `readOnlyHint=false, destructiveHint=false`. An annotation set
+  `read_only` → `read_only_hint=true, idempotent_hint=true`; `destructive` → `destructive_hint=true`;
+  `mutating`/`runtime` → `read_only_hint=false, destructive_hint=false`. An annotation set
   explicitly at registration is preserved.
 
-### Human-in-the-loop approval (issue #153)
+### Human-in-the-loop approval (issue #153, centralized via middleware #330)
 
 An optional webhook gates `destructive` tools behind a human decision. It is **opt-in**:
 with no webhook configured the gate auto-approves, so evals and headless runs are never
-blocked. Configure via environment:
+blocked. The gate runs at the `tools/call` boundary via `ApprovalMiddleware` (issue #330)
+— no per-tool wiring; any tool tagged `destructive` is automatically routed through the
+webhook. Configure via environment:
 
 | Env var | Default | Meaning |
 |---------|---------|---------|
@@ -334,7 +336,7 @@ Import external files (local paths or HTTP URLs) into a Godot project and assemb
 | `godot_asset_import_create_material_from_textures` | `albedo?, normal?, roughness?, metallic?, ao?, emission?, path?` | `CreateMaterialResult { material_path, created, channels_set }` | `mutating` |
 | `godot_asset_import_get_status` | `target_path: str` | `ImportStatusResult { imported, last_modified?, type? }` | `read_only` |
 
-`godot_asset_import_asset` auto-detects the Godot type from the file extension (`.png`→`Texture2D`, `.glb`→`PackedScene`, `.wav`→`AudioStreamWAV`, etc.). When `source` is an HTTP(S) URL it is downloaded via `httpx` with a 60-second timeout, then copied to `target_path` (must start with `res://`). The response is streamed to disk in 64 KiB chunks to avoid buffering the entire payload in memory. The `options` dict may contain `overwrite` (bool, default `false`) and `import_settings` (dict, e.g. `{"type": "Texture2D", "compress": "lossy"}`). The editor filesystem scan is triggered after copy so Godot imports the file.
+`godot_asset_import_asset` auto-detects the Godot type from the file extension (`.png`→`Texture2D`, `.glb`→`PackedScene`, `.wav`→`AudioStreamWAV`, etc.). When `source` is an HTTP(S) URL it is downloaded via `httpx2` with a 60-second timeout, then copied to `target_path` (must start with `res://`). The response is streamed to disk in 64 KiB chunks to avoid buffering the entire payload in memory. The `options` dict may contain `overwrite` (bool, default `false`) and `import_settings` (dict, e.g. `{"type": "Texture2D", "compress": "lossy"}`). The editor filesystem scan is triggered after copy so Godot imports the file.
 
 `godot_asset_import_create_material_from_textures` creates a `StandardMaterial3D`, assigns every non-empty texture channel that exists in the project, and saves the material as a `.tres`. The default `path` is `res://materials/generated_{rand}.tres`. Only channels with a valid `res://` texture path are included in `channels_set`. Both mutating tools accept `dry_run: bool = False` and echo it in the result (sending no change when true).
 
@@ -399,7 +401,7 @@ Author AnimationPlayer animations and AnimationTree graphs. All `mutating`
 | `godot_animation_add_state_machine_state` | `tree_path, state_name, animation?` | `StateMachineStateResult { tree_path, state }` |
 | `godot_animation_set_blend_tree_node` | `tree_path, node_name, node_type` | `BlendTreeNodeResult { tree_path, node, node_type }` |
 | `godot_animation_list_animations` | `node_path` | `AnimationList { player_path, animations[] }` (`read_only`) |
-| `godot_animation_get` | `node_path, animation_name` | `AnimationDetail { name, length, tracks[]{type, path, keys[]{time, value}} }` (`read_only`) |
+| `godot_animation_get` | `node_path, animation_name` | `AnimationDetail { name, length, loop_mode, tracks[]{type, path, keys[]{time, value}} }` (`read_only`) |
 
 `godot_animation_create` adds a default `AnimationLibrary` ("") if absent and rejects a
 duplicate name. `godot_animation_add_track` returns the new track index; `track_type` is one
@@ -485,6 +487,7 @@ Author navigation — generic over 2D/3D, pass the node type names. All `mutatin
 | `godot_navigation_setup_region` | `parent_path, region_type="NavigationRegion2D", name?, properties?` | `NavigationRegionResult { node_path, region_type, created }` |
 | `godot_navigation_setup_agent` | `parent_path, agent_type="NavigationAgent2D", name?, properties?` | `NavigationAgentResult { node_path, agent_type, created }` |
 | `godot_navigation_bake_mesh` | `node_path` | `BakeNavigationResult { node_path, baked }` |
+| `godot_navigation_get_region` | `node_path` | `NavigationRegionInfo { node_path, has_polygon, outline_count, vertex_count, polygon_count }` (`read_only`) |
 | `godot_navigation_set_layers` | `node_path, layers[]` (1-based bit indices) | `NavigationLayersResult { node_path, navigation_layers }` |
 
 `godot_navigation_setup_region` adds a NavigationRegion2D/3D with an empty navmesh resource
@@ -599,6 +602,7 @@ Author shaders — create/read `.gdshader` files, assign a ShaderMaterial, set u
 | `godot_shader_read` | `shader_path` | `ShaderReadResult { shader_path, code }` (read_only) |
 | `godot_shader_assign_material` | `node_path, shader_path` | `ShaderMaterialResult { node_path, shader_path, material_property }` |
 | `godot_shader_set_param` | `node_path, name, value, param_type?` | `ShaderParamResult { node_path, name }` |
+| `godot_shader_get_param` | `node_path, name` | `ShaderParamReadResult { node_path, name, value, exists }` (`read_only`) |
 
 `godot_shader_create` writes a `res://*.gdshader` file (undo restores the prior content or
 removes it). `godot_shader_assign_material` wraps the shader in a ShaderMaterial and assigns it


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the FastMCP 4.0 migration and recent feature work.

## Changes

**`docs/tool-contracts.md`:**
- camelCase MCP annotations → snake_case (`readOnlyHint` → `read_only_hint`, etc.) — SDK v2 field rename
- `httpx` → `httpx2` in the asset-import description
- Approval section: notes the `ApprovalMiddleware` centralization (#330) — no per-tool wiring
- New tools added to the contract tables:
  - `godot_shader_get_param` (#301) — read live ShaderMaterial uniform values
  - `godot_navigation_get_region` (#302) — read-back for baked navigation regions
  - `loop_mode` field in `AnimationDetail` (#303)

**`.claude/rules/mcp-tools.md`:**
- Toolset gating rule: updated from process-global `enable(tags=)` to per-session `ToolsetMiddleware` (#227); notes sessionless vs legacy-mode behavior

**`README.md`:**
- Added `GODOT_MCP_AUTH_TOKEN` env var (#226) — required for non-loopback HTTP binds
- Documented bearer token auth with client config example
- Updated `ApprovalGate` → `ApprovalMiddleware` reference

**`CLAUDE.md`:**
- `FastMCP` → `FastMCP 4.0` (pinned to the 4.0 beta)
- `test_tool_naming.py` → `test_tool_transform.py` (the #312 ToolTransform migration renamed the test)