### PR TITLE
refactor: address medium-severity findings from code audit

### DIFF
--- a/mcp_server/approval_middleware.py
+++ b/mcp_server/approval_middleware.py
@@ -14,14 +14,12 @@ body — it's the tool's own schema-level gate, not the webhook gate.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from mcp_server.safety import ApprovalGate, PreconditionError, SafetyClass
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +44,14 @@ class ApprovalMiddleware(Middleware):
             return await call_next(context)
         try:
             tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
+        except ToolError:
+            return await call_next(context)
         except Exception:
+            logger.warning(
+                "unexpected error looking up tool %r; skipping approval gate",
+                context.message.name,
+                exc_info=True,
+            )
             return await call_next(context)
         if tool is None:
             return await call_next(context)

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -113,38 +113,17 @@ async def _apply_safety_annotations_async(mcp: FastMCP) -> None:
             tool.annotations = annotations
 
 
-def apply_safety_annotations(mcp: FastMCP) -> None:
+async def apply_safety_annotations(mcp: FastMCP) -> None:
     """Set standard MCP ``annotations`` on every tool from its ``safety_class``.
 
     Call once after all tools are registered. An annotation set explicitly at
     registration is preserved (treated as an intentional override).
 
     Enumerates tools via the public async ``mcp.local_provider.list_tools()``
-    (FastMCP 4.0). Run on a worker thread with its own event loop so this works
-    whether ``create_server`` is called from sync code or from inside an async
-    test's running loop.
+    (FastMCP 4.0). Must be called from an async context (e.g. inside the server
+    lifespan or an async test).
     """
-    import asyncio
-    import threading
-
-    done = threading.Event()
-    result: list[BaseException | None] = [None]
-
-    def _runner() -> None:
-        loop = asyncio.new_event_loop()
-        try:
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(_apply_safety_annotations_async(mcp))
-        except BaseException as exc:  # noqa: BLE001 - re-raised on caller thread
-            result[0] = exc
-        finally:
-            loop.close()
-            done.set()
-
-    threading.Thread(target=_runner, daemon=True).start()
-    done.wait()
-    if result[0] is not None:
-        raise result[0]
+    await _apply_safety_annotations_async(mcp)
 
 
 class PreconditionError(Exception):
@@ -210,6 +189,15 @@ async def require_node_exists(bridge: Bridge, node_path: str) -> None:
             error=ErrorCode.RESOURCE_NOT_FOUND,
         )
     _raise_if_failed(response)
+
+
+def require_godot_binary(binary: str | None) -> None:
+    """Fail fast if no Godot binary is available for headless runner tools."""
+    if binary is None:
+        raise PreconditionError(
+            "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
+            required="godot_bin",
+        )
 
 
 def require_confirmation(confirm: bool, action: str) -> None:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -104,6 +104,10 @@ def create_server(
                 exc_info=True,
             )
         try:
+            await apply_safety_annotations(mcp)
+        except Exception:
+            logger.warning("failed to apply safety annotations", exc_info=True)
+        try:
             yield
         finally:
             await bridge.close()
@@ -132,13 +136,12 @@ def create_server(
     # Centralize the webhook ApprovalGate at the tools/call boundary (issue #330).
     # No-op unless a webhook is configured; dry_run short-circuits in the middleware.
     mcp.add_middleware(ApprovalMiddleware(approval))
-    # Background-tasks spike (issue #315): register the in-process TasksExtension
-    # so tools marked ``task=True`` can return a handle immediately instead of
-    # holding the MCP request open for the whole (potentially long) bridge op. The
-    # in-memory single-process backend is sufficient for a local dev tool. No tool
-    # is marked ``task=True`` yet — see tests/contract/test_background_tasks.py for
-    # the spike finding (ctx-progress calls are incompatible with the detached task
-    # session) that blocks adopting tasks for the four long-running tools as-is.
+    # Background tasks (issue #315): register the in-process TasksExtension so
+    # tools marked ``task=True`` can return a handle immediately instead of
+    # holding the MCP request open for the whole bridge op. Three long-running
+    # tools are task-enabled (run_and_capture, export_project, bake_navigation_mesh);
+    # their ctx.info/ctx.report_progress calls use safe_info/safe_progress
+    # (tools/_progress.py) to no-op in the detached task session.
     mcp.add_extension(TasksExtension())
 
     register_health(mcp, bridge, config)
@@ -187,7 +190,6 @@ def create_server(
     # Gate the tool surface by category (per-session via the middleware above).
     manager = ToolsetManager(mcp, bridge=bridge, middleware=toolset_mw)
     register_toolset_tools(mcp, manager)
-    manager.apply_defaults()
 
     # Comprehensive diagnostics: toolset counts, bridge state, troubleshooting.
     register_diagnostics(mcp, bridge, config, manager)
@@ -197,7 +199,8 @@ def create_server(
 
     # Derive standard MCP annotations (readOnlyHint/destructiveHint/...) from each
     # tool's safety_class, for every tool incl. gated-off ones (issue #220).
-    apply_safety_annotations(mcp)
+    # Applied inside the async lifespan (see above) since FastMCP 4.0's
+    # local_provider.list_tools() is async.
 
     # Expose every tool as godot_<toolset>_<action> (issue #312). FastMCP 4.0's
     # ToolTransform renames tools as they flow to clients and reverse-maps public

--- a/mcp_server/tools/_route.py
+++ b/mcp_server/tools/_route.py
@@ -4,8 +4,13 @@ Keeps tool handlers thin (delegation only, per .claude/rules/architecture.md): s
 a command, return the result dict on success, or raise a structured ``ToolError`` on
 failure so the agent gets an actionable message instead of a stack trace. When the
 addon returns a precondition-style envelope (carrying ``required``), that field is
-included in the error text so the agent knows what to satisfy — regardless of whether
-the calling tool is decorated with ``@enforce_preconditions`` (read-only tools are not).
+included in the error text so the agent knows what to satisfy.
+
+Convention for ``@enforce_preconditions``: apply it to any tool that can raise
+``PreconditionError`` before calling ``route()`` (e.g. via ``require_godot_binary``,
+``require_bridge_connected``, ``require_active_scene``, ``require_node_exists``).
+Read-only tools that never raise ``PreconditionError`` don't need it; ``route()``
+already shapes addon-side precondition envelopes into ``ToolError``.
 """
 
 from __future__ import annotations

--- a/mcp_server/tools/export.py
+++ b/mcp_server/tools/export.py
@@ -21,7 +21,12 @@ from mcp_server.defaults import (
 )
 from mcp_server.models.export import ExportInfoResult, ExportPresetsResult, ExportResult
 from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
-from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError, enforce_preconditions
+from mcp_server.safety import (
+    READ_ONLY,
+    RUNTIME,
+    enforce_preconditions,
+    require_godot_binary,
+)
 from mcp_server.tools._progress import safe_info, safe_progress
 from mcp_server.tools._route import route
 
@@ -60,11 +65,7 @@ def register_export(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner: 
         — requires export templates installed; returns the exit code and parsed
         errors/warnings. Use a generous ``timeout_seconds`` (exports can be slow).
         """
-        if runner.binary is None:
-            raise PreconditionError(
-                "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
-                required="godot_bin",
-            )
+        require_godot_binary(runner.binary)
         presets = ExportPresetsResult(**await route(bridge, "cmd_list_export_presets", {}))
         names = [p.name for p in presets.presets]
         if preset not in names:

--- a/mcp_server/tools/runtime.py
+++ b/mcp_server/tools/runtime.py
@@ -18,7 +18,11 @@ from mcp_server.defaults import (
 )
 from mcp_server.models.runtime import RunCaptureResult
 from mcp_server.runtime import Runner, resolve_project_dir, summarize_run
-from mcp_server.safety import RUNTIME, PreconditionError, enforce_preconditions
+from mcp_server.safety import (
+    RUNTIME,
+    enforce_preconditions,
+    require_godot_binary,
+)
 from mcp_server.tools._progress import safe_info, safe_progress
 
 
@@ -43,11 +47,7 @@ def register_runtime(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         WHEN NOT TO USE: You need to simulate input or inspect live state —
         use play_scene() + get_game_scene_tree() / simulate_key() instead.
         """
-        if runner.binary is None:
-            raise PreconditionError(
-                "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
-                required="godot_bin",
-            )
+        require_godot_binary(runner.binary)
         project_dir = await resolve_project_dir(bridge, config)
         await safe_info(
             ctx, f"Running {scene or 'main scene'} headless (timeout {timeout_seconds:g}s)…"

--- a/mcp_server/tools/scripts.py
+++ b/mcp_server/tools/scripts.py
@@ -28,7 +28,12 @@ from mcp_server.models.scripts import (
 )
 from mcp_server.output import paginate
 from mcp_server.runtime import Runner, resolve_project_dir
-from mcp_server.safety import MUTATING, READ_ONLY, PreconditionError, enforce_preconditions
+from mcp_server.safety import (
+    MUTATING,
+    READ_ONLY,
+    enforce_preconditions,
+    require_godot_binary,
+)
 from mcp_server.scripts_parse import parse_check_errors
 from mcp_server.tools._route import route, run_or_preview, validate_or_raise
 
@@ -118,11 +123,7 @@ def register_scripts(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         """Parse-check ``script_path`` and return structured errors (message + line),
         or an empty list when it parses cleanly. Use after writing/patching a script.
         """
-        if runner.binary is None:
-            raise PreconditionError(
-                "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
-                required="godot_bin",
-            )
+        require_godot_binary(runner.binary)
         project_dir = await resolve_project_dir(bridge, config)
         output = await runner.check_script(project_dir, script_path, timeout=30.0)
         errors = parse_check_errors(output.stdout + "\n" + output.stderr)

--- a/mcp_server/tools/testing.py
+++ b/mcp_server/tools/testing.py
@@ -40,7 +40,7 @@ from mcp_server.models.testing import (
 )
 from mcp_server.qa import ImageCompareError, compare_images, evaluate_assertion, random_input_events
 from mcp_server.runtime import Runner, resolve_project_dir
-from mcp_server.safety import READ_ONLY, RUNTIME, PreconditionError
+from mcp_server.safety import READ_ONLY, RUNTIME, require_godot_binary
 from mcp_server.tools._progress import safe_info, safe_progress
 from mcp_server.tools._route import poll_ready, route
 
@@ -123,11 +123,7 @@ def register_testing(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         WHEN NOT TO USE: there is no test suite — write one first, or use
         run_and_capture / get_parse_errors for a smoke/parse check.
         """
-        if runner.binary is None:
-            raise PreconditionError(
-                "Godot binary not found. Set GODOT_MCP_GODOT_BIN to your Godot executable.",
-                required="godot_bin",
-            )
+        require_godot_binary(runner.binary)
         project_dir = await resolve_project_dir(bridge, config)
         if not _gut_present(project_dir):
             return RunTestsResult(ran=False, framework="gut", framework_absent=True)

--- a/mcp_server/toolset_middleware.py
+++ b/mcp_server/toolset_middleware.py
@@ -9,12 +9,16 @@ client enabling ``scene_edit`` does not expose it to another. Uses
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from mcp_server.categories import CORE_TAG
+
+if TYPE_CHECKING:
+    from fastmcp import Context
+    from fastmcp.tools.base import Tool
 
 logger = logging.getLogger(__name__)
 
@@ -37,18 +41,16 @@ class ToolsetMiddleware(Middleware):
             default_enabled = DEFAULT_ENABLED
         self._default_enabled: set[str] = {CORE_TAG} | set(default_enabled)
         self._sessions: dict[str, set[str]] = {}
-        self._initialized: set[str] = set()
 
     async def on_initialize(self, context: MiddlewareContext, call_next: Any) -> Any:
         ctx = context.fastmcp_context
         if ctx is not None:
             sid = getattr(ctx, "session_id", None)
             if sid is not None:
-                self._initialized.add(sid)
                 self._sessions.setdefault(sid, set(self._default_enabled))
         return await call_next(context)
 
-    def session_enabled(self, ctx: Any) -> set[str] | None:
+    def session_enabled(self, ctx: Context | None) -> set[str] | None:
         """Return the enabled toolset set for the session behind ``ctx``.
 
         Returns ``None`` when the session was not established via ``on_initialize``
@@ -56,11 +58,11 @@ class ToolsetMiddleware(Middleware):
         client can't maintain per-session state across requests.
         """
         sid = getattr(ctx, "session_id", None)
-        if sid is None or sid not in self._initialized:
+        if sid is None or sid not in self._sessions:
             return None
         return set(self._sessions.setdefault(sid, set(self._default_enabled)))
 
-    def set_session_enabled(self, ctx: Any, enabled: set[str]) -> None:
+    def set_session_enabled(self, ctx: Context | None, enabled: set[str]) -> None:
         """Write the enabled set for the session behind ``ctx``."""
         sid = getattr(ctx, "session_id", None)
         if sid is not None:
@@ -91,20 +93,26 @@ class ToolsetMiddleware(Middleware):
             )
         return await call_next(context)
 
-    def _is_visible(self, tool: Any, enabled: set[str]) -> bool:
-        tags: set[str] = getattr(tool, "tags", set()) or set()
-        if CORE_TAG in tags:
-            return True
-        return bool(tags & enabled)
+    def _is_visible(self, tool: Tool, enabled: set[str]) -> bool:
+        return _tag_visible(getattr(tool, "tags", set()) or set(), enabled)
 
-    async def _is_call_allowed(self, name: str, ctx: Any, enabled: set[str]) -> bool:
-        if ctx is None:
-            return True
+    async def _is_call_allowed(self, name: str, ctx: Context, enabled: set[str]) -> bool:
         try:
             tool = await ctx.fastmcp.get_tool(name)
+        except ToolError:
+            return True
         except Exception:
+            logger.warning(
+                "unexpected error looking up tool %r; allowing call",
+                name,
+                exc_info=True,
+            )
             return True
-        tags: set[str] = getattr(tool, "tags", set()) or set()
-        if CORE_TAG in tags:
-            return True
-        return bool(tags & enabled)
+        return _tag_visible(getattr(tool, "tags", set()) or set(), enabled)
+
+
+def _tag_visible(tags: set[str], enabled: set[str]) -> bool:
+    """Whether a tool with ``tags`` is visible to a session with ``enabled``."""
+    if CORE_TAG in tags:
+        return True
+    return bool(tags & enabled)

--- a/mcp_server/toolsets.py
+++ b/mcp_server/toolsets.py
@@ -168,19 +168,6 @@ class ToolsetManager:
         self._godot_version: tuple[int, int] | None = None
         self._middleware = middleware
 
-    def apply_defaults(self) -> None:
-        """No-op — per-session gating is handled by ToolsetMiddleware.
-
-        Kept for backwards compatibility with server.py's call order.
-        """
-
-    async def _ctx(self) -> Any:
-
-        # The Context is available as a FastMCP dependency; tools that call
-        # enable/disable have ``ctx: Context`` injected.
-
-        return None
-
     async def enable(self, category: str, *, ctx: Any = None) -> ToolsetInfo:
         self._check_toggleable(category)
         await self._require_godot_version(category)

--- a/mcp_server/transforms.py
+++ b/mcp_server/transforms.py
@@ -123,10 +123,19 @@ def godot_tool_transform(mcp: Any) -> ToolTransform:
 def _registered_tools(mcp: Any) -> Sequence[Tool]:
     """Synchronously read the tools registered on the server's local provider.
 
-    ``FastMCP._list_tools`` is async, but the local provider's component dict is
-    populated synchronously by the ``register_*`` calls, so this reads it
-    without an event loop. The server built by ``create_server`` has exactly one
-    ``LocalProvider``; this helper is only called there, at build time.
+    ``FastMCP.local_provider.list_tools()`` is async, but ``create_server`` is
+    sync and the transform must be registered before any client connects. The
+    local provider's ``_components`` dict is populated synchronously by the
+    ``register_*`` calls, so this reads it without an event loop.
+
+    **Known fragility:** ``_components`` is a private attribute of
+    ``LocalProvider`` and may change in future FastMCP releases. If it breaks,
+    the fallback is to move ``godot_tool_transform(mcp)`` into the async lifespan
+    (where ``await mcp.local_provider.list_tools()`` is available) and register
+    the transform there. The current approach is chosen because the transform
+    must be in place before the first ``list_tools`` call, which happens during
+    client initialization — the lifespan runs *after* the server object is built
+    but *before* any client connects, so the sync read is safe today.
     """
     from fastmcp.tools.base import Tool
 

--- a/tests/contract/test_tool_annotations.py
+++ b/tests/contract/test_tool_annotations.py
@@ -14,6 +14,7 @@ from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
+from mcp_server.safety import apply_safety_annotations
 from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for, make_addon_responder
 from tests.helpers import list_all_tools
@@ -30,6 +31,7 @@ def _server() -> FastMCP:
 
 async def test_every_classified_tool_carries_annotations() -> None:
     server = _server()
+    await apply_safety_annotations(server)
     # list_all_tools returns ALL registered tools (with server transforms applied),
     # including toolset-gated ones the public list_tools() filters out.
     tools = await list_all_tools(server)

--- a/tests/unit/test_safety.py
+++ b/tests/unit/test_safety.py
@@ -83,7 +83,7 @@ def test_apply_safety_annotations_respects_explicit_override() -> None:
         """doc"""
         return "x"
 
-    apply_safety_annotations(mcp)
+    asyncio.run(apply_safety_annotations(mcp))
 
     # Read back via the public provider surface the production code uses.
     from mcp_server.safety import _iter_registered_tools


### PR DESCRIPTION
## Summary

Addresses 7 medium-severity and 5 low-severity findings from a codebase audit following the FastMCP 4.0 migration.

## Medium-severity fixes

| # | Finding | Fix |
|---|---|---|
| **#1** | Stale comment says "No tool is marked `task=True`" — 3 tools are | Updated comment |
| **#5** | Duplicated "Godot binary not found" PreconditionError ×4 | Extracted `require_godot_binary()` helper in `safety.py` |
| **#12** | `@enforce_preconditions` inconsistently applied to read-only tools | Documented convention in `_route.py` docstring |
| **#14** | `apply_safety_annotations` spawns thread + event loop (brittle) | Made async; called from the async lifespan |
| **#15** | `Any` for `ctx`/`tool` in gating code | Typed as `Context`/`Tool` under `TYPE_CHECKING` |
| **#17** | Private `_components` reach in `transforms.py` | Documented fragility + fallback path |
| **#18** | Broad `except` in `ApprovalMiddleware` silently bypasses gate | Narrowed to `ToolError`; log+pass-through for others |

## Low-severity cleanup

- **#2** — Removed `apply_defaults()` no-op + call in `server.py`
- **#3** — Removed dead `_ctx()` stub in `toolsets.py`
- **#8** — Extracted shared `_tag_visible()` helper in `toolset_middleware.py`
- **#20** — Dropped redundant `_initialized` set (use `_sessions` keys)
- **#25** — Removed empty `if TYPE_CHECKING: pass` block

## Test plan

- [x] `uv run pytest -q` — 633 passed
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean