### PR TITLE
feat(approval): return InputRequiredResult for mutating tools (guard pattern for durable approval) (closes #346)

### DIFF
--- a/mcp_server/approval_middleware.py
+++ b/mcp_server/approval_middleware.py
@@ -1,4 +1,4 @@
-"""Approval-gate middleware (issue #330).
+"""Approval-gate middleware (issue #330, extended by #346).
 
 Centralizes the webhook ``ApprovalGate`` at the ``tools/call`` boundary so the
 ``approval`` parameter no longer threads through ~6 register modules. The
@@ -9,34 +9,99 @@ gate (a preview never needs approval).
 
 The ``confirm`` bool check (``require_confirmation``) stays in each tool's
 body — it's the tool's own schema-level gate, not the webhook gate.
+
+Issue #346 adds the **guard pattern**: when ``require_approval`` is set and
+no webhook is configured, a ``mutating``/``destructive`` tool returns an
+``InputRequiredResult`` (an elicitation the client fulfils and re-calls) on
+its first round, and the second round inspects the answer in
+``ctx.input_responses`` to either run the tool or deny. This is durable (no
+server-side state — the tool name + params + safety_class round-trip through
+``request_state``) and works on the sessionless protocol godot-mcp uses by
+design (see ``.opencode/rules/async-patterns.md``).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.base import InputRequiredToolResult
+from mcp.types import ElicitRequest, ElicitRequestFormParams, InputRequiredResult
 
 from mcp_server.safety import ApprovalGate, PreconditionError, SafetyClass
 
 logger = logging.getLogger(__name__)
 
+# The elicitation key the guard uses for the approve/deny ask. The client's
+# answer arrives in ``ctx.input_responses[APPROVE_KEY]`` on the next round.
+APPROVE_KEY = "approve"
+
+# JSON Schema for the elicitation: a single boolean "approve" field. The
+# client renders this as a yes/no form (or, for a programmatic handler, a
+# typed ElicitResult(approve=bool)).
+_APPROVE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"approve": {"type": "boolean", "title": "Approve"}},
+    "required": ["approve"],
+}
+
+
+def _is_gated_safety_class(value: str) -> bool:
+    """mutating and destructive tools are gated; read_only and runtime are not."""
+    return value in (SafetyClass.MUTATING.value, SafetyClass.DESTRUCTIVE.value)
+
+
+def _build_input_required(
+    tool_name: str, safety_class: str, params: dict[str, Any]
+) -> InputRequiredToolResult:
+    """Build the guard's first-round result: an elicitation asking the client
+    to approve or deny the call. The tool name + params + safety_class are
+    sealed into ``request_state`` so the second round can re-evaluate without
+    server-side state.
+    """
+    message = f"Approve {tool_name} ({safety_class})? params={json.dumps(params, default=str)}"
+    request_state = json.dumps(
+        {"tool": tool_name, "safety_class": safety_class, "params": params},
+        default=str,
+    )
+    elicitation = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form", message=message, requested_schema=_APPROVE_SCHEMA
+        ),
+    )
+    return InputRequiredToolResult(
+        InputRequiredResult(
+            input_requests={APPROVE_KEY: elicitation},
+            request_state=request_state,
+        )
+    )
+
 
 class ApprovalMiddleware(Middleware):
-    """Route ``destructive`` tool calls through the webhook ``ApprovalGate``.
+    """Route ``destructive``/``mutating`` tool calls through approval.
 
-    No-op when no webhook is configured (the ``ApprovalGate`` auto-approves).
-    ``dry_run=True`` short-circuits: a preview never needs approval.
+    Three modes, in precedence order:
+
+    1. ``dry_run=True`` → short-circuit (previews never need approval).
+    2. Webhook configured → existing behavior: ``ApprovalGate.require()`` POSTs
+       and raises ``ToolError`` on denial.
+    3. ``require_approval=True`` + no webhook → guard pattern: return an
+       ``InputRequiredResult`` on the first round; on the second round, read
+       the client's answer from ``ctx.input_responses`` and either run the
+       tool (approved) or raise ``PreconditionError(APPROVAL_DENIED)``
+       (denied/declined/cancelled).
+
+    No-op when none of the above apply (the gate auto-approves).
     """
 
     def __init__(self, approval: ApprovalGate) -> None:
         self._approval = approval
 
-    async def on_call_tool(
-        self, context: MiddlewareContext, call_next: Any
-    ) -> Any:
+    async def on_call_tool(self, context: MiddlewareContext, call_next: Any) -> Any:
         args = context.message.arguments or {}
         if args.get("dry_run"):
             return await call_next(context)
@@ -55,13 +120,63 @@ class ApprovalMiddleware(Middleware):
             return await call_next(context)
         if tool is None:
             return await call_next(context)
-        safety_class = (tool.meta or {}).get("safety_class")
-        if safety_class != SafetyClass.DESTRUCTIVE.value:
+        safety_class: str = (tool.meta or {}).get("safety_class") or ""
+        if not _is_gated_safety_class(safety_class):
             return await call_next(context)
-        try:
-            await self._approval.require(
-                context.message.name, safety_class, args
+
+        # Webhook path (issue #153): POST + raise on denial. The webhook is
+        # authoritative when configured; the guard pattern is the no-webhook
+        # fallback for durable, stateless approval.
+        if self._approval.webhook_url:
+            try:
+                await self._approval.require(context.message.name, safety_class, args)
+            except PreconditionError as exc:
+                raise exc.as_tool_error() from exc
+            return await call_next(context)
+
+        # Guard pattern (issue #346): opt-in, no webhook. The first round asks
+        # the client; the second round reads the answer.
+        if self._approval.require_approval:
+            return await self._guard_round(context, call_next, safety_class)
+
+        return await call_next(context)
+
+    async def _guard_round(
+        self,
+        context: MiddlewareContext,
+        call_next: Any,
+        safety_class: str,
+    ) -> Any:
+        """One round of the guard pattern. First round → ask. Later rounds →
+        inspect the answer and run the tool or deny.
+        """
+        fctx = context.fastmcp_context
+        assert fctx is not None  # narrowed by the caller
+        responses = fctx.input_responses
+
+        # First round: no answers yet → ask the client to approve.
+        if responses is None:
+            return _build_input_required(
+                context.message.name, safety_class, context.message.arguments or {}
             )
-        except PreconditionError as exc:
-            raise exc.as_tool_error() from exc
+
+        # Continuation round: the client has answered. Read the approve field.
+        answer = responses.get(APPROVE_KEY)
+        approved = False
+        if answer is not None and getattr(answer, "action", None) == "accept":
+            content = getattr(answer, "content", None) or {}
+            approved = bool(content.get("approve", False))
+
+        if not approved:
+            # Decline, cancel, or an explicit "approve: false" all deny. The
+            # error is a structured PreconditionError → ToolError so the agent
+            # gets an actionable message instead of a stack trace.
+            raise PreconditionError(
+                f"'{context.message.name}' was denied by the human approver.",
+                required="human_approval",
+                error="APPROVAL_DENIED",
+            ).as_tool_error()
+
+        # Approved — run the tool. The tool's own ``confirm``/precondition
+        # gates still run in its body (the guard does not duplicate them).
         return await call_next(context)

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -74,6 +74,12 @@ class ServerConfig(BaseModel):
     approval_webhook: str | None = None
     approval_timeout: float = 30.0
     approval_fail_open: bool = True
+    # Guard-pattern approval (issue #346). Opt-in: with no webhook, a
+    # mutating/destructive tool returns an InputRequiredResult (an elicitation
+    # the client fulfils and re-calls) instead of raising. Durable + stateless;
+    # see .opencode/rules/async-patterns.md. Ignored when a webhook is set
+    # (the webhook path keeps its existing raise-on-deny behavior).
+    approval_require: bool = False
     # HTTP transport auth (issue #226). Opt-in: loopback HTTP is allowed without a
     # token; a non-loopback bind requires a token or the server refuses to start.
     auth_token: str | None = None
@@ -93,6 +99,8 @@ class ServerConfig(BaseModel):
             approval_timeout=float(os.environ.get("GODOT_MCP_APPROVAL_TIMEOUT", 30.0)),
             approval_fail_open=os.environ.get("GODOT_MCP_APPROVAL_FAIL_OPEN", "true").lower()
             != "false",
+            approval_require=os.environ.get("GODOT_MCP_APPROVAL_REQUIRE", "").lower()
+            in ("1", "true", "yes"),
             auth_token=os.environ.get("GODOT_MCP_AUTH_TOKEN"),
         )
 

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -247,13 +247,20 @@ async def post_approval(url: str, request: ApprovalRequest, timeout: float) -> A
 @dataclass
 class ApprovalGate:
     """Optional human approval for destructive (and, if wired, mutating/runtime)
-    tools (issue #153).
+    tools (issue #153, extended by #346).
 
     Opt-in: with ``webhook_url`` unset the gate auto-approves, so evals and
     headless runs are never blocked. When set, :meth:`require` POSTs an
-    :class:`ApprovalRequest` and raises ``PreconditionError(APPROVAL_DENIED)`` on
-    a denial. An unreachable/slow webhook approves when ``fail_open`` (default)
+    :class:`ApprovalRequest` and raises ``PreconditionError(APPROVAL_DENIED)``
+    on a denial. An unreachable/slow webhook approves when ``fail_open`` (default)
     or denies when not. Every decision is logged.
+
+    The guard pattern (issue #346) adds a third mode: when ``require_approval``
+    is set and no webhook is configured, mutating/destructive tools return an
+    ``InputRequiredResult`` (an elicitation the client fulfils and re-calls),
+    rather than raising. This is durable (no server-side state) and works on
+    the sessionless protocol godot-mcp uses by design. See
+    ``.opencode/rules/async-patterns.md``.
     """
 
     webhook_url: str | None = None
@@ -261,6 +268,7 @@ class ApprovalGate:
     fail_open: bool = True
     poster: ApprovalPoster = field(default=post_approval)
     clock: Callable[[], float] = field(default=time.time)
+    require_approval: bool = False
 
     @classmethod
     def from_config(cls, config: ServerConfig) -> ApprovalGate:
@@ -268,6 +276,7 @@ class ApprovalGate:
             webhook_url=config.approval_webhook,
             timeout=config.approval_timeout,
             fail_open=config.approval_fail_open,
+            require_approval=config.approval_require,
         )
 
     async def require(
@@ -277,7 +286,12 @@ class ApprovalGate:
         params: dict[str, Any],
         task_context: str | None = None,
     ) -> None:
-        """Block ``action`` unless the webhook approves it. No-op without a webhook."""
+        """Block ``action`` unless the webhook approves it. No-op without a webhook.
+
+        The guard pattern (``require_approval=True`` + no webhook) is handled by
+        :class:`~mcp_server.approval_middleware.ApprovalMiddleware`, which returns
+        an ``InputRequiredResult`` before reaching this method.
+        """
         if not self.webhook_url:
             return  # opt-in: no webhook configured → auto-approve
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
-    # The MCP framework (PrefectHQ/fastmcp). Pinned to the 4.0 beta (issue #311):
+    # The MCP framework (PrefectHQ/fastmcp). Pinned to the 4.0 beta (issue #311).
+    # 4.0.0b1 already ships the modern-protocol guard pattern (InputRequiredResult,
+    # InputRequiredToolResult, Context.input_responses / request_state) needed by
+    # the durable-approval work (issue #346) — no upgrade required.
     # 2.x→3.x had breaking API changes (#228); the v3→v4 transition is lower-risk
     # for this server (stateless, no ctx.elicit, no session state, canonical imports
     # already in place). Beta pin per the upgrade guide; follow stable 4.x when it ships.

--- a/tests/contract/test_approval_guard.py
+++ b/tests/contract/test_approval_guard.py
@@ -1,0 +1,214 @@
+"""Contract tests for the durable guard-pattern approval flow (issue #346).
+
+The modern-protocol (MCP 2026-07-28) guard pattern returns an
+``InputRequiredResult`` instead of raising on a destructive/mutating tool that
+needs human approval. The client fulfils the request and calls again; the
+second round sees the answer in ``ctx.input_responses`` and either proceeds or
+denies. This is durable (no server-side state, no worker pinning) and works on
+the sessionless protocol godot-mcp uses by design
+(see ``.opencode/rules/async-patterns.md``).
+
+These tests drive the real FastMCP server over the in-memory client with a
+fake addon peer, mirroring ``tests/contract/test_mutation.py``. The approval
+gate is configured with ``require_approval=True`` and **no webhook** (the path
+the issue specifies); a client-side elicitation handler supplies the verdict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.elicitation import ElicitResult
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.safety import ApprovalGate
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    p = cmd.params
+    match cmd.command:
+        case "cmd_get_active_scene":
+            return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
+        case "cmd_get_node_properties":
+            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+        case "cmd_create_node":
+            return ResponseEnvelope.success(
+                cmd.id, {"node_path": f"{p['parent_path']}/{p['name']}", "created": True}
+            )
+        case "cmd_delete_node":
+            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "deleted": True})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected command")
+
+
+def _build(*, approval: ApprovalGate) -> tuple[Any, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge, approval=approval), conn
+
+
+def _commands(conn: FakeAddonConnection) -> list[str]:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+
+
+def _approval_handler(approve: bool) -> Any:
+    """Return a fastmcp elicitation handler that approves or denies every ask."""
+
+    async def handler(
+        message: str,
+        response_type: Any,
+        params: Any,
+        ctx: Any,
+    ) -> ElicitResult:
+        # The guard's elicitation asks for a single boolean "approve" field.
+        return ElicitResult(action="accept", content=response_type(approve=approve))
+
+    return handler
+
+
+async def test_mutating_tool_without_require_approval_runs_directly() -> None:
+    """Baseline: no opt-in means no guard — a mutating tool runs as before."""
+    gate = ApprovalGate()  # no webhook, require_approval defaults False
+    server, conn = _build(approval=gate)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "godot_scene_edit_create_node",
+            {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
+        )
+    assert result.structured_content["created"] is True
+    assert "cmd_create_node" in _commands(conn)
+
+
+async def test_mutating_tool_with_require_approval_returns_input_required() -> None:
+    """Opt-in + no webhook: the first round returns an InputRequiredResult,
+    not the tool's real result. The addon must NOT have been called yet."""
+    gate = ApprovalGate(require_approval=True)
+    server, conn = _build(approval=gate)
+    async with Client(
+        server,
+        mode="auto",
+        elicitation_handler=_approval_handler(approve=True),
+    ) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "godot_scene_edit_create_node",
+            {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
+        )
+    # The handler approved, so the loop drives a second round and the tool runs.
+    assert result.structured_content["created"] is True
+    assert "cmd_create_node" in _commands(conn)
+
+
+async def test_mutating_tool_guard_denied_blocks_and_never_reaches_addon() -> None:
+    """When the client's elicitation handler denies, the second round must
+    surface an APPROVAL_DENIED error and the addon must never see the command."""
+    gate = ApprovalGate(require_approval=True)
+    server, conn = _build(approval=gate)
+    async with Client(
+        server,
+        mode="auto",
+        elicitation_handler=_approval_handler(approve=False),
+    ) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "godot_scene_edit_create_node",
+            {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "APPROVAL_DENIED" in str(result.content)
+    assert "cmd_create_node" not in _commands(conn)
+
+
+async def test_dry_run_short_circuits_the_guard() -> None:
+    """A preview never needs approval (workflow rule); the guard is skipped
+    even when require_approval is set."""
+    gate = ApprovalGate(require_approval=True)
+    server, conn = _build(approval=gate)
+    async with Client(
+        server,
+        mode="auto",
+        elicitation_handler=_approval_handler(approve=True),
+    ) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "godot_scene_edit_create_node",
+            {
+                "parent_path": ".",
+                "node_type": "Node2D",
+                "node_name": "Player",
+                "dry_run": True,
+            },
+        )
+    # dry_run previews — no create_node command, no elicitation round-trip.
+    assert "cmd_create_node" not in _commands(conn)
+    # The preview result is a structured description of what would change.
+    assert result.structured_content is not None
+
+
+async def test_destructive_tool_uses_guard_when_opted_in_and_no_webhook() -> None:
+    """A destructive tool with confirm=True and the guard opted in returns an
+    InputRequiredResult the same way (the guard extends to destructive tools
+    per the issue; the existing confirm gate in the tool body still runs first)."""
+    gate = ApprovalGate(require_approval=True)
+    server, conn = _build(approval=gate)
+    async with Client(
+        server,
+        mode="auto",
+        elicitation_handler=_approval_handler(approve=True),
+    ) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        result = await client.call_tool(
+            "godot_scene_edit_delete_node",
+            {"node_path": "Player", "confirm": True},
+        )
+    assert result.structured_content["deleted"] is True
+    assert "cmd_delete_node" in _commands(conn)
+
+
+async def test_guard_request_state_carries_tool_and_params() -> None:
+    """The InputRequiredResult.request_state carries enough context (tool name,
+    safety_class, params) for a durable client to re-call the tool with the
+    decision on the next round (the issue's 'durable' requirement)."""
+    gate = ApprovalGate(require_approval=True)
+    server, _ = _build(approval=gate)
+    captured: dict[str, Any] = {}
+
+    async def handler(message: str, response_type: Any, params: Any, ctx: Any) -> ElicitResult:
+        # The elicitation message should name the tool and surface the params.
+        captured["message"] = message
+        return ElicitResult(action="accept", content=response_type(approve=True))
+
+    async with Client(server, mode="auto", elicitation_handler=handler) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scene_edit"})
+        await client.call_tool(
+            "godot_scene_edit_create_node",
+            {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
+        )
+    assert "create_node" in captured["message"]
+    # The params being approved are visible in the message (the human knows what
+    # they are approving — the issue's "params being approved" requirement).
+    assert "Player" in captured["message"]
+
+
+async def test_read_only_tool_is_not_gated() -> None:
+    """read_only tools are never gated, even with require_approval on."""
+    gate = ApprovalGate(require_approval=True)
+    server, conn = _build(approval=gate)
+    async with Client(
+        server,
+        mode="auto",
+        elicitation_handler=_approval_handler(approve=True),
+    ) as client:
+        # inspection is enabled by default; list_toolsets is read-only core.
+        result = await client.call_tool("godot_list_toolsets", {})
+    # No elicitation round-trip; the tool ran directly.
+    assert result.structured_content is not None

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -8,8 +8,11 @@ poster is injected, so this is a pure unit test — no network.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from mcp_server.approval_middleware import APPROVE_KEY, _build_input_required
 from mcp_server.config import ServerConfig
 from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
 from mcp_server.safety import (
@@ -147,3 +150,40 @@ async def test_malformed_response_denies_even_when_fail_open() -> None:
             action="godot_scene_edit_delete_node", safety_class="destructive", params={}
         )
     assert exc.value.error == "APPROVAL_DENIED"
+
+
+# --- guard pattern (issue #346) -------------------------------------------
+
+
+async def test_build_input_required_request_state_carries_tool_and_params() -> None:
+    # The durable round-trip depends on InputRequiredResult.request_state carrying
+    # the tool name, safety_class, and params so a stateless client can re-call
+    # the tool with the decision on the next round (issue #346).
+    result = _build_input_required(
+        "godot_scene_edit_create_node",
+        "mutating",
+        {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
+    )
+    payload = json.loads(result.input_required.request_state)
+    assert payload["tool"] == "godot_scene_edit_create_node"
+    assert payload["safety_class"] == "mutating"
+    assert payload["params"] == {
+        "parent_path": ".",
+        "node_type": "Node2D",
+        "node_name": "Player",
+    }
+
+
+async def test_build_input_required_elicitation_asks_approve() -> None:
+    # The elicitation request under APPROVE_KEY carries a yes/no schema the
+    # client renders; its answer arrives in ctx.input_responses[APPROVE_KEY].
+    result = _build_input_required(
+        "godot_scene_edit_delete_node", "destructive", {"node_path": "Enemy"}
+    )
+    requests = result.input_required.input_requests or {}
+    assert APPROVE_KEY in requests
+    params = requests[APPROVE_KEY].params
+    # The schema requires a single boolean "approve" field.
+    schema = params.requested_schema
+    assert schema["properties"]["approve"]["type"] == "boolean"
+    assert schema["required"] == ["approve"]

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -108,6 +108,13 @@ async def test_from_config_reads_fields() -> None:
     assert gate.webhook_url == "http://hook"
     assert gate.timeout == 5.0
     assert gate.fail_open is False
+    assert gate.require_approval is False
+
+
+async def test_from_config_reads_require_approval() -> None:
+    config = ServerConfig(approval_require=True)
+    gate = ApprovalGate.from_config(config)
+    assert gate.require_approval is True
 
 
 async def test_from_config_without_webhook_is_noop() -> None:

--- a/tests/unit/test_approval.py
+++ b/tests/unit/test_approval.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from mcp.types import ElicitRequestFormParams
 
 from mcp_server.approval_middleware import APPROVE_KEY, _build_input_required
 from mcp_server.config import ServerConfig
@@ -164,7 +165,9 @@ async def test_build_input_required_request_state_carries_tool_and_params() -> N
         "mutating",
         {"parent_path": ".", "node_type": "Node2D", "node_name": "Player"},
     )
-    payload = json.loads(result.input_required.request_state)
+    state = result.input_required.request_state
+    assert state is not None  # narrowed for mypy
+    payload = json.loads(state)
     assert payload["tool"] == "godot_scene_edit_create_node"
     assert payload["safety_class"] == "mutating"
     assert payload["params"] == {
@@ -180,9 +183,11 @@ async def test_build_input_required_elicitation_asks_approve() -> None:
     result = _build_input_required(
         "godot_scene_edit_delete_node", "destructive", {"node_path": "Enemy"}
     )
-    requests = result.input_required.input_requests or {}
-    assert APPROVE_KEY in requests
-    params = requests[APPROVE_KEY].params
+    requests = result.input_required.input_requests
+    assert requests is not None  # narrowed for mypy
+    request = requests[APPROVE_KEY]
+    params = request.params
+    assert isinstance(params, ElicitRequestFormParams)  # form-mode elicitation
     # The schema requires a single boolean "approve" field.
     schema = params.requested_schema
     assert schema["properties"]["approve"]["type"] == "boolean"


### PR DESCRIPTION
## Summary

Implements the server-side half of the paired issue with godot-agents #458. Extends `ApprovalMiddleware` with the modern-protocol (MCP 2026-07-28) **guard pattern**: when `require_approval` is set and no webhook is configured, a `mutating`/`destructive` tool returns an `InputRequiredResult` (an elicitation the client fulfils and re-calls) instead of raising `ToolError`. This is durable (no server-side state — the tool name + params + safety_class round-trip through `request_state`, sealed by the framework) and works on the sessionless protocol godot-mcp uses by design (see `.opencode/rules/async-patterns.md`).

> **Replaces #348** which auto-closed when its base branch (`chore/opencode-integration`, PR #347) was merged and deleted. This is the same branch (`feat/approval-guard-346`) rebased onto `main`. The Qodo review on #348 is addressed in the commits below (request_state assertions + mypy narrowing).

## What changed

- **`mcp_server/approval_middleware.py`** — `ApprovalMiddleware` gains a third mode (after `dry_run` short-circuit and webhook). When `require_approval` is set + no webhook: first round returns `InputRequiredToolResult` (an elicitation asking approve/deny, with tool+params+safety_class in `request_state`); second round reads `ctx.input_responses` and either runs the tool (approved) or raises `PreconditionError(APPROVAL_DENIED)` (denied/declined/cancelled).
- **`mcp_server/safety.py`** — `ApprovalGate` gains `require_approval: bool = False` + `from_config` wiring. Docstring documents the three modes.
- **`mcp_server/config.py`** — `ServerConfig.approval_require` + env override `GODOT_MCP_APPROVAL_REQUIRE` (opt-in, default off so evals/headless keep auto-approving).
- **`tests/contract/test_approval_guard.py`** (new) — 7 contract tests driving the real FastMCP server over the in-memory client with a fake addon peer and a client-side elicitation handler.
- **`tests/unit/test_approval.py`** — `from_config` reads the new field; two unit tests assert `request_state` carries tool+safety_class+params (Qodo review) and the elicitation schema is a yes/no.
- **`pyproject.toml`** — note that `fastmcp==4.0.0b1` already ships the guard-pattern surface; no upgrade required.

## Mode precedence

1. `dry_run=True` → short-circuit (previews never need approval — workflow rule).
2. Webhook configured → existing behavior (POST + raise on denial — issue #153).
3. `require_approval=True` + no webhook → guard pattern (ask → re-call → decide — issue #346).

The tool's own `confirm`/precondition gates in the tool body still run (the guard does not duplicate them).

## Acceptance criteria from #346

- [x] Returns `InputRequiredResult` for **mutating** (not just destructive) tools when no webhook + `require_approval`
- [x] `InputRequiredResult` describes: tool name + safety class, params being approved, approve/deny schema
- [x] Webhook configured → keeps current behavior (raise on denial)
- [x] `dry_run=True` → keeps current short-circuit
- [x] No `ctx.elicit()` (raises on sessionless) — uses the guard pattern
- [x] No `ctx.set_state()` / session state — approval state round-trips through `request_state` (sealed by framework), so it's stateless and resume-safe
- [x] `InputRequiredResult` carries enough context (tool + params + safety_class) for the client to re-call with the decision — asserted by unit tests (Qodo review)

## Test plan

- [x] `./.opencode/hooks/check-no-skipped-tests.sh` — clean
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy` — no issues (243 source files; the pre-existing `transforms.py` `Tool.fn` errors were fixed in #347)
- [x] `uv run pytest tests/contract/test_approval_guard.py tests/unit/test_approval.py tests/contract/test_mutation.py` — 39 passed (no regressions)
- [x] `uv run pytest -q --deselect tests/integration/test_import_asset_e2e.py::test_live_asset_import_workflow` — 642 passed (+7 guard + +2 request_state unit tests; the deselected `test_import_asset_e2e` is a pre-existing live-on-disk test-isolation flake, passes in isolation, unrelated to this change)
- [x] `FASTMCP_MCP_CAMELCASE_COMPAT=false uv run pytest tests/contract/test_approval_guard.py tests/unit/test_approval.py tests/contract/test_mutation.py` — 39 passed (camelCase regression gate)

## Notes

- **No FastMCP upgrade needed.** 4.0.0b1 already ships `InputRequiredResult` (`mcp.types`), `InputRequiredToolResult` (`fastmcp.tools.base`), and `Context.input_responses`/`request_state`. Recorded in `pyproject.toml`.
- **Downstream impact** (for @godot-agents #458): the envelope now resolves to an `InputRequiredResult` on the first round for gated tools when the server is started with `GODOT_MCP_APPROVAL_REQUIRE=1`. The client side (`mcp/client.py`, `fluid_executor.py`) needs to handle it as an `MCPResult` with `required: "approval"` and re-call with the decision. Off by default, so existing callers see no change until they opt in.

## Related

- godot-agents #458 — durable replay-safe approval (v2 of #347), the client-side half
- godot-agents #347/#457 — v1 (synchronous blocking approver, merged)
- #347 — opencode-integration (merged; this PR is rebased onto it)
- Supersedes #348 (auto-closed when its base branch was deleted)