### PR TITLE
fix(gut): parse GUT 9.7+ all-pass output (omits "Failing Tests" line)

### DIFF
--- a/mcp_server/gut_parse.py
+++ b/mcp_server/gut_parse.py
@@ -32,15 +32,20 @@ def _counts(text: str) -> tuple[int, int, int] | None:
     if passing and failing:
         p, f = int(passing.group(1)), int(failing.group(1))
         return p, f, p + f
-    # GUT 9.7+ omits the "Failing Tests" line when there are zero failures.
-    # If we have a passing count but no failing line, assume 0 failures.
-    if passing:
-        p = int(passing.group(1))
-        return p, 0, p
+    # The "X of Y tests failed" fallback is checked before the passing-only
+    # inference so that a GUT variant with a passing count but no "Failing
+    # Tests" line (yet still reporting failures via this fallback) is not
+    # misread as a clean run.
     of_y = _OF_Y_RE.search(text)
     if of_y:
         failed, total = int(of_y.group(1)), int(of_y.group(2))
         return total - failed, failed, total
+    # GUT 9.7+ omits the "Failing Tests" line when there are zero failures.
+    # If we have a passing count but no failing line and no "of Y" fallback,
+    # assume 0 failures.
+    if passing:
+        p = int(passing.group(1))
+        return p, 0, p
     return None
 
 

--- a/mcp_server/gut_parse.py
+++ b/mcp_server/gut_parse.py
@@ -32,6 +32,11 @@ def _counts(text: str) -> tuple[int, int, int] | None:
     if passing and failing:
         p, f = int(passing.group(1)), int(failing.group(1))
         return p, f, p + f
+    # GUT 9.7+ omits the "Failing Tests" line when there are zero failures.
+    # If we have a passing count but no failing line, assume 0 failures.
+    if passing:
+        p = int(passing.group(1))
+        return p, 0, p
     of_y = _OF_Y_RE.search(text)
     if of_y:
         failed, total = int(of_y.group(1)), int(of_y.group(2))

--- a/tests/unit/test_gut_parse.py
+++ b/tests/unit/test_gut_parse.py
@@ -84,3 +84,41 @@ def test_unparseable_output_is_safe() -> None:
     assert r.ran is True
     assert r.passed == 0 and r.failed == 0 and r.total == 0
     assert r.failures == []
+
+
+# GUT 9.7+ omits the "Failing Tests" line when all tests pass (no failures to
+# report). The parser must still extract the passing count in that case.
+_GUT_97_ALL_PASS = """\
+Godot Engine v4.7.2.stable.official
+res://tests/unit/test_player.gd
+* test_player_starts_with_full_health
+6/6 passed.
+res://tests/unit/test_game_manager.gd
+* test_game_starts_in_menu_state
+8/8 passed.
+
+==============================================
+= Run Summary
+==============================================
+
+Totals
+------
+Scripts               3
+Tests                24
+Passing Tests        24
+Asserts              48
+Time              6.455s
+
+
+---- All tests passed! ----
+"""
+
+
+def test_parses_gut_97_no_failing_line() -> None:
+    # Regression: GUT 9.7 omits "Failing Tests" when zero failures.
+    r = parse_gut_results(_GUT_97_ALL_PASS)
+    assert r.ran is True
+    assert r.passed == 24
+    assert r.failed == 0
+    assert r.total == 24
+    assert r.failures == []


### PR DESCRIPTION
## Summary

GUT 9.7+ omits the "Failing Tests" summary line when zero tests fail, so the parser's `_counts()` — which required both "Passing" and "Failing" matches — returned `(0, 0, 0)` on a clean run instead of `(N, 0, N)`. The MCP `run_tests` tool reported `passed=0 / total=0` even though all tests passed.

## Fix

When only the "Passing Tests" line is present (no "Failing Tests" line), infer 0 failures and return `(N, 0, N)`.

## Test

Added regression test `test_parses_gut_97_no_failing_line` with captured GUT 9.7 output (24/24 passing, no "Failing Tests" line in the summary).

## Test plan

- [x] `uv run pytest tests/unit/test_gut_parse.py` — 4 passed (was 3)
- [x] `uv run pytest` — 650 passed (was 649, +1 regression test)
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` — clean
- [ ] Qodo review