### PR TITLE
release: Bump version to 2026.08.26b1

### DIFF
--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot MCP"
 description="Bridges a live Godot editor to an MCP server so AI clients can drive scene authoring, inspection, and runtime over a localhost WebSocket."
 author="hybridindie"
-version="2026.06.01"
+version="2026.08.26b1"
 script="godot_mcp.gd"

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -9,7 +9,7 @@ See ``docs/architecture.md`` for the bridge contract.
 """
 
 # CalVer, kept in sync with pyproject.toml and .opencode/rules/enforcement.md.
-__version__ = "2026.06.01"
+__version__ = "2026.08.26b1"
 
 # Tool-contract / compatibility version — a monotonic integer, deliberately
 # distinct from the CalVer build version. It expresses the *contract*: bump it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-mcp"
-version = "2026.06.01"
+version = "2026.08.26b1"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ADDON_DIR = REPO_ROOT / "godot" / "addons" / "godot_mcp"
 PLUGIN_CFG = ADDON_DIR / "plugin.cfg"
 PROJECT_GODOT = REPO_ROOT / "godot" / "project.godot"
-CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:-\d+)?$")
+CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|[abrc]\d+))?$")
 
 
 @pytest.fixture

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ADDON_DIR = REPO_ROOT / "godot" / "addons" / "godot_mcp"
 PLUGIN_CFG = ADDON_DIR / "plugin.cfg"
 PROJECT_GODOT = REPO_ROOT / "godot" / "project.godot"
-CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|[abrc]\d+))?$")
+CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|(?:a|b|rc)\d+))?$")
 
 
 @pytest.fixture

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|[abrc]\d+))?$")
+CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|(?:a|b|rc)\d+))?$")
 
 
 def test_package_imports() -> None:

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:-\d+)?$")
+CALVER = re.compile(r"^\d{4}\.\d{2}\.\d{2}(?:[-.]?(?:\d+|[abrc]\d+))?$")
 
 
 def test_package_imports() -> None:


### PR DESCRIPTION
### **User description**
## Summary

First beta release of godot-mcp. Version `2026.08.26b1` (CalVer + PEP 440 prerelease suffix) reflects the FastMCP `4.0.0b3` dependency still in beta. Follow stable 4.x when FastMCP ships a final release.

## Changes

- `pyproject.toml`: `version = "2026.08.26b1"`
- `mcp_server/__init__.py`: `__version__ = "2026.08.26b1"`
- `godot/addons/godot_mcp/plugin.cfg`: `version="2026.08.26b1"`
- Updated CalVer regex in `test_smoke.py` and `test_addon_manifest.py` to accept PEP 440 prerelease suffixes (`b1`, `a1`, `rc1`) in addition to the existing `-N` suffix.

## Package

```
dist/godot_mcp-2026.8.26b1-py3-none-any.whl  (190KB)
dist/godot_mcp-2026.8.26b1.tar.gz           (6.4MB)
```

Entry point: `godot-mcp = "mcp_server.main:main"`

Install:
```bash
pip install dist/godot_mcp-2026.8.26b1-py3-none-any.whl
godot-mcp  # starts the MCP server
```

## Test plan

- [x] `uv run pytest` — 650 passed, 0 skipped
- [x] `uv run mypy` — clean (244 files)
- [x] `uv run ruff check .` — clean
- [x] `uv build` — wheel + sdist built successfully
- [x] Version-matching tests pass (`test_version_is_calver`, `test_version_matches_pyproject`, `test_addon_version_matches_package`)
- [x] Entry point imports correctly (`from mcp_server import __version__` → `2026.08.26b1`)
- [ ] Qodo review


___

### **PR Type**
Other, Tests


___

### **Description**
- Bump version to `2026.08.26b1` across package manifests

- Update CalVer regex for PEP 440 prerelease suffixes

- Sync Python package and Godot addon versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pyproject["pyproject.toml"] --> init["mcp_server/__init__.py"]
  pyproject --> plugin["godot/addons/godot_mcp/plugin.cfg"]
  tests["tests/unit/test_*.py"] --> validate["Validate version format"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump package version to 2026.08.26b1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bump `version` from `2026.06.01` to `2026.08.26b1`


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/359/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Bump package version to 2026.08.26b1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/__init__.py

- Bump `__version__` from `2026.06.01` to `2026.08.26b1`


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/359/files#diff-0ee260f94eefb5341ba2f880808d78577c1e28ab8efa6209e2b12753496409d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plugin.cfg</strong><dd><code>Bump Godot addon version to 2026.08.26b1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/plugin.cfg

- Bump addon `version` from `2026.06.01` to `2026.08.26b1`


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/359/files#diff-505361f53d50c88c282a85d8bff795aed2e43e41ce9cfe2d4b7d332bfa8c14f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_smoke.py</strong><dd><code>Update CalVer regex for prerelease suffixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_smoke.py

- Update `CALVER` regex to accept PEP 440 prerelease suffixes


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/359/files#diff-008371c35537b64b848b5bf9bbbdde45d83123a288bf5e4b763733844a17bcb8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_addon_manifest.py</strong><dd><code>Update CalVer regex for prerelease suffixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_addon_manifest.py

- Update `CALVER` regex to accept PEP 440 prerelease suffixes


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/359/files#diff-7b97e94c7bcb49783c2153046c691734b56f1f1b47497ab3d9e41aa815e6e135">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

