### PR TITLE
Add PyPI and GitHub release publish workflow with package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. 2026.08.26b1)"
+        required: true
+
+permissions:
+  contents: read
+  id-token: write  # Required for PyPI trusted publishing (OIDC).
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # PyPI trusted publishing (OIDC — no API token needed).
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Prereleases (b1, a1, rc1) go to PyPI as-is — pip install --pre picks them up.
+          # PyPI accepts prerelease versions natively.
+          skip-existing: true
+
+  publish-github:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Attach artifacts to the GitHub release.
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload to GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          tag_name: ${{ github.event.release.tag_name || inputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # Required for PyPI trusted publishing (OIDC).
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # upload-artifact
     steps:
       - uses: actions/checkout@v4
 
@@ -42,6 +44,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # PyPI trusted publishing (OIDC — no API token needed).
+      actions: read   # download-artifact
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -61,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Attach artifacts to the GitHub release.
+      actions: read   # download-artifact
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,23 @@ description = "MCP server that drives a live Godot editor for AI-driven game dev
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
+authors = [{ name = "John Doh", email = "johnd@johndstudios.net" }]
+keywords = ["godot", "mcp", "ai", "game-development", "model-context-protocol", "editor-automation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Testing",
+    "Typing :: Typed",
+]
 dependencies = [
     # The MCP framework (PrefectHQ/fastmcp). Pinned to the 4.0 beta (issue #311).
     # 4.0.0b3 picks up the tool-title default (PrefectHQ/fastmcp#4694 — some clients
@@ -27,6 +44,13 @@ dependencies = [
     # (FastMCP raises httpx2 exceptions, so `except httpx.` would silently never match).
     "httpx2>=2.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/hybridindie/godot-mcp"
+Repository = "https://github.com/hybridindie/godot-mcp"
+Documentation = "https://github.com/hybridindie/godot-mcp#readme"
+Issues = "https://github.com/hybridindie/godot-mcp/issues"
+Changelog = "https://github.com/hybridindie/godot-mcp/releases"
 
 [project.scripts]
 godot-mcp = "mcp_server.main:main"


### PR DESCRIPTION
### **User description**
## Summary

Adds automated package publishing and proper PyPI metadata so `godot-mcp` can be installed via `pip install godot-mcp` and released through GitHub.

### PyPI metadata (pyproject.toml)

- `authors`, `keywords`, `classifiers` (Beta, Python 3.11-3.13, MIT, Games/Entertainment, Testing, Typed)
- `project.urls` (Homepage, Repository, Documentation, Issues, Changelog)

### Publish workflow (.github/workflows/publish.yml)

Triggered on GitHub release publish (or manual `workflow_dispatch`):

1. **Build** — `uv build` produces wheel + sdist
2. **Publish to PyPI** — via OIDC trusted publishing (no API token — configure at pypi.org → manage account → publishing with repo `hybridindie/godot-mcp` + workflow `publish.yml` + environment `pypi`)
3. **Publish to GitHub** — uploads wheel + sdist as release artifacts

### Setup required (one-time)

Before the first publish, configure PyPI trusted publishing:
1. Go to https://pypi.org/manage/account/publishing/
2. Add a publisher: `hybridindie/godot-mcp`, workflow `publish.yml`, environment `pypi`
3. Create the `pypi` environment in GitHub repo settings (Settings → Environments → New environment → `pypi`)

### Usage

```bash
# Create a release (triggers the publish workflow):
gh release create 2026.08.26b1 dist/godot_mcp-2026.8.26b1-*.whl dist/godot_mcp-2026.8.26b1.tar.gz \
  --title "2026.08.26b1" --notes "First beta release"

# Install:
pip install godot-mcp --pre  # prerelease
pip install godot-mcp        # once a stable version ships
```

## Test plan

- [x] `uv build` — wheel + sdist built successfully
- [x] Package metadata verified (classifiers, URLs, keywords, author)
- [x] `uv run pytest` — 650 passed
- [x] `uv run mypy` / `ruff` — clean
- [ ] PyPI trusted publisher configured (one-time setup)
- [ ] First release triggers publish workflow


___

### **PR Type**
Enhancement


___

### **Description**
- Add automated PyPI and GitHub release publishing workflow

- Enrich `pyproject.toml` with PyPI metadata and project URLs

- Use OIDC trusted publishing for secure PyPI deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["GitHub release / workflow_dispatch"] --> build["Build wheel + sdist"]
  build --> pypi["Publish to PyPI (OIDC)"]
  build --> github["Upload to GitHub release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yml`</strong><dd><code>Add automated PyPI and GitHub release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/publish.yml`

<ul><li>New workflow triggered on release publish or manual <code>workflow_dispatch</code><br> <li> Builds package with <code>uv build</code> and uploads artifacts<br> <li> Publishes to PyPI via OIDC trusted publishing (no API token)<br> <li> Uploads wheel and sdist to GitHub release assets</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>`pyproject.toml`</strong><dd><code>Add PyPI metadata and project URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`pyproject.toml`

<ul><li>Added <code>authors</code>, <code>keywords</code>, and Trove <code>classifiers</code> (Beta, Python <br>3.11–3.13, MIT)<br> <li> Added <code>project.urls</code> block linking Homepage, Repository, Documentation, <br>Issues, and Changelog</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

