### PR TITLE
Rename PyPI package and CLI to godot-editor-mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "godot-mcp"
+name = "godot-editor-mcp"
 version = "2026.08.26b1"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
@@ -53,7 +53,7 @@ Issues = "https://github.com/hybridindie/godot-mcp/issues"
 Changelog = "https://github.com/hybridindie/godot-mcp/releases"
 
 [project.scripts]
-godot-mcp = "mcp_server.main:main"
+godot-editor-mcp = "mcp_server.main:main"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1259,8 +1259,8 @@ wheels = [
 ]
 
 [[package]]
-name = "godot-mcp"
-version = "2026.6.1"
+name = "godot-editor-mcp"
+version = "2026.8.26b1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
### **User description**
## Summary

The PyPI name `godot-mcp` is already registered by a different project (v0.1.1). Renamed the package and CLI entry point to `godot-editor-mcp` — available on PyPI and descriptive (it controls the Godot editor via MCP).

## Changes

- `pyproject.toml`: `name = "godot-editor-mcp"`, entry point `godot-editor-mcp`
- Repo name, GitHub org, internal module names (`mcp_server`), and addon directory (`godot_mcp`) are unchanged — only the PyPI package name and CLI command changed.

## Install

```bash
pip install godot-editor-mcp --pre
godot-editor-mcp  # starts the MCP server
```

## Test plan

- [x] `uv build` — `godot_editor_mcp-2026.8.26b1` wheel + sdist built
- [x] `uv run pytest` — 650 passed
- [x] `uv run mypy` / `ruff` — clean
- [ ] Qodo review


___

### **PR Type**
Bug fix


___

### **Description**
- Rename PyPI package to `godot-editor-mcp`

- Update CLI entry point name accordingly

- Internal modules and repo stay unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  conflict["PyPI name conflict"] --> rename["Rename to godot-editor-mcp"]
  rename --> cli["Update CLI entry point"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Rename PyPI package and CLI entry point</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Change package name from <code>godot-mcp</code> to <code>godot-editor-mcp</code><br> <li> Rename CLI script entry point to <code>godot-editor-mcp</code></ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/361/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

