### PR TITLE
Use ErrorCode enum for approval denial

### DIFF
--- a/mcp_server/approval_middleware.py
+++ b/mcp_server/approval_middleware.py
@@ -31,6 +31,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.base import InputRequiredToolResult
 from mcp.types import ElicitRequest, ElicitRequestFormParams, InputRequiredResult
 
+from mcp_server.models.envelope import ErrorCode
 from mcp_server.safety import ApprovalGate, PreconditionError, SafetyClass
 
 logger = logging.getLogger(__name__)
@@ -174,7 +175,7 @@ class ApprovalMiddleware(Middleware):
             raise PreconditionError(
                 f"'{context.message.name}' was denied by the human approver.",
                 required="human_approval",
-                error="APPROVAL_DENIED",
+                error=ErrorCode.APPROVAL_DENIED,
             ).as_tool_error()
 
         # Approved — run the tool. The tool's own ``confirm``/precondition

--- a/tests/unit/test_approval_errorcode.py
+++ b/tests/unit/test_approval_errorcode.py
@@ -1,0 +1,45 @@
+"""Regression: approval middleware must use ErrorCode.APPROVAL_DENIED, not a
+string literal (issue #368).
+
+`PreconditionError.__init__` accepts ``ErrorCode | str``, so both type-check,
+but the enum form is the convention (every other call site uses it). A string
+literal is a drift risk: rename the enum value and this site silently keeps
+the old string while ``safety.py`` stays correct.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mcp_server.approval_middleware import ApprovalMiddleware
+from mcp_server.models.envelope import ErrorCode
+
+
+def test_guard_round_uses_errorcode_enum() -> None:
+    """The ``PreconditionError`` raised on guard denial must use
+    ``ErrorCode.APPROVAL_DENIED``, not the string literal ``"APPROVAL_DENIED"``.
+
+    Inspects the source of ``ApprovalMiddleware._guard_round`` (the only place
+    the middleware raises a denial) and asserts the ``error=`` kwarg is the
+    enum, not a bare string.
+    """
+    src = inspect.getsource(ApprovalMiddleware._guard_round)
+    # The enum member must appear in the source.
+    assert "ErrorCode.APPROVAL_DENIED" in src, (
+        "ApprovalMiddleware._guard_round must use ErrorCode.APPROVAL_DENIED, "
+        "not the string literal 'APPROVAL_DENIED' (issue #368)."
+    )
+    # And the bare string literal must NOT appear as the error= value.
+    # Match `error="APPROVAL_DENIED"` (with quotes) to catch the bug; the enum
+    # form `ErrorCode.APPROVAL_DENIED` does not contain a quoted string.
+    assert 'error="APPROVAL_DENIED"' not in src, (
+        "ApprovalMiddleware._guard_round passes error=\"APPROVAL_DENIED\" "
+        "(string literal) instead of ErrorCode.APPROVAL_DENIED (issue #368)."
+    )
+
+
+def test_errorcode_approval_denied_is_str_enum() -> None:
+    """Sanity: the enum value still serializes to the stable string so the
+    wire envelope is unchanged after the fix."""
+    assert ErrorCode.APPROVAL_DENIED == "APPROVAL_DENIED"
+    assert isinstance(ErrorCode.APPROVAL_DENIED, ErrorCode)


### PR DESCRIPTION
### **User description**
## Summary

`ApprovalMiddleware._guard_round` passed `error="APPROVAL_DENIED"` (a `str`) to `PreconditionError`, while every other call site (`safety.py:321`) uses `ErrorCode.APPROVAL_DENIED`. `PreconditionError.__init__` accepts `ErrorCode | str` so both type-check, but the literal is a drift risk: rename the enum value and this site silently keeps the old string while `safety.py` stays correct.

## Changes

- `mcp_server/approval_middleware.py`: import `ErrorCode`, replace `error="APPROVAL_DENIED"` with `error=ErrorCode.APPROVAL_DENIED`.
- `tests/unit/test_approval_errorcode.py` (new): pins the invariant via source inspection of `_guard_round` (the enum form is required; the bare quoted string is forbidden) plus a sanity check that the enum still serializes to the stable wire string `"APPROVAL_DENIED"` so the envelope is unchanged.

## Test plan

- [x] `uv run pytest -q` → 658 passed
- [x] `uv run ruff check .` → clean
- [x] `uv run mypy` → clean
- [x] `./.opencode/hooks/check-no-skipped-tests.sh` → clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replaces string literal with enum

- Keeps wire error string unchanged

- Adds regression test for enum use

- Reduces future rename drift risk


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Approval middleware"] -- "raises denial" --> B["PreconditionError"]
  B -- "uses enum" --> C["ErrorCode.APPROVAL_DENIED"]
  D["Regression test"] -- "pins enum use" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>approval_middleware.py</strong><dd><code>Use enum for approval denial error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/approval_middleware.py

<ul><li>Imports ErrorCode from envelope models<br> <li> Replaces string error with ErrorCode.APPROVAL_DENIED<br> <li> Preserves serialized error value for clients</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/371/files#diff-1edc08c378a29ab6418d703edb50346a3b2b814f39676b5b52a1fc8c27349603">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_approval_errorcode.py</strong><dd><code>Add approval error code regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_approval_errorcode.py

<ul><li>Adds source-inspection regression test<br> <li> Asserts enum form is required<br> <li> Verifies enum serializes to stable string</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/371/files#diff-d0edbdefcdfed4512e4d8f07588e67ca3dcc0bd8ff4c08f2e60033c0b3501ce3">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

