### PR TITLE
Return typed safety class listing model

### DIFF
--- a/mcp_server/models/safety.py
+++ b/mcp_server/models/safety.py
@@ -1,0 +1,15 @@
+"""Typed result for the safety-class introspection tool (issue #366)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SafetyClassListing(BaseModel):
+    """Result of ``list_tools_by_safety_class`` — tool names grouped by safety class."""
+
+    tools_by_safety_class: dict[str, list[str]] = Field(
+        description="Tool names keyed by safety_class (read_only / mutating / "
+        "destructive / runtime); unclassified tools (if any) appear under "
+        "'unclassified'."
+    )

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -31,6 +31,7 @@ from mcp_server.bridge import Bridge
 from mcp_server.categories import CORE_TAG
 from mcp_server.models.approval import ApprovalRequest, ApprovalResponse
 from mcp_server.models.envelope import ErrorCode, ResponseEnvelope
+from mcp_server.models.safety import SafetyClassListing
 
 if TYPE_CHECKING:
     from mcp_server.config import ServerConfig
@@ -377,9 +378,11 @@ def register_safety_tools(mcp: FastMCP) -> None:
     """Register the agent-facing safety introspection tool."""
 
     @mcp.tool(meta=READ_ONLY, tags={CORE_TAG})
-    async def list_tools_by_safety_class() -> dict[str, list[str]]:
+    async def list_tools_by_safety_class() -> SafetyClassListing:
         """List every available tool grouped by its safety class
         (read_only / mutating / destructive / runtime). Call this to learn which
         tools are safe to call freely and which need ``dry_run``/``confirm``.
         """
-        return await grouped_by_safety_class(mcp)
+        return SafetyClassListing(
+            tools_by_safety_class=await grouped_by_safety_class(mcp)
+        )

--- a/tests/contract/test_safety_tool.py
+++ b/tests/contract/test_safety_tool.py
@@ -21,7 +21,7 @@ def _server() -> FastMCP:
 async def test_list_tools_by_safety_class_tool() -> None:
     async with Client(_server()) as client:
         result = await client.call_tool("godot_list_tools_by_safety_class", {})
-    grouped = result.structured_content
+    grouped = result.structured_content["tools_by_safety_class"]
 
     # Every tool to date is read_only — including the introspection tool itself.
     read_only = set(grouped["read_only"])
@@ -35,7 +35,7 @@ async def test_list_tools_by_safety_class_tool() -> None:
         "godot_list_tools_by_safety_class",
     }
     assert expected <= read_only
-    # Nothing should be unclassified — every tool carries a safety class.
+    # Nothing should be unclassified — every tool carries a safety Class.
     assert "unclassified" not in grouped
 
 

--- a/tests/contract/test_safety_typed_result.py
+++ b/tests/contract/test_safety_typed_result.py
@@ -1,0 +1,50 @@
+"""Contract: list_tools_by_safety_class returns a typed Pydantic model (issue #366).
+
+The tool previously returned a raw ``dict[str, list[str]]``, violating
+``.opencode/rules/mcp-tools.md`` ("return a typed Pydantic model — never a
+raw ``dict``"). It now returns a :class:`SafetyClassListing` model with one
+field ``tools_by_safety_class``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.safety import SafetyClassListing
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+def _server() -> FastMCP:
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(FakeAddonConnection()))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_returns_typed_model_shape() -> None:
+    """The tool result is a SafetyClassListing — a single-field model, not a
+    flat dict. The structured content carries the ``tools_by_safety_class`` key."""
+    async with Client(_server()) as client:
+        result = await client.call_tool("godot_list_tools_by_safety_class", {})
+    grouped = result.structured_content
+    # The new shape wraps under one key (the Pydantic model's field name).
+    assert "tools_by_safety_class" in grouped
+    by_class = grouped["tools_by_safety_class"]
+    assert isinstance(by_class, dict)
+    # read_only tools are present.
+    assert "read_only" in by_class
+    assert "godot_health_check" in by_class["read_only"]
+
+
+async def test_model_round_trips() -> None:
+    """The Pydantic model round-trips the data faithfully."""
+    async with Client(_server()) as client:
+        result = await client.call_tool("godot_list_tools_by_safety_class", {})
+    listing = SafetyClassListing.model_validate(result.structured_content)
+    assert "read_only" in listing.tools_by_safety_class
+    assert "godot_health_check" in listing.tools_by_safety_class["read_only"]
+    assert "unclassified" not in listing.tools_by_safety_class

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -156,4 +156,5 @@ async def test_get_shader_param_is_read_only() -> None:
         grouped = await client.call_tool(
             "godot_list_tools_by_safety_class", {}
         )
-    assert "godot_shader_get_param" in grouped.structured_content["read_only"]
+    grouped_result = grouped.structured_content["tools_by_safety_class"]["read_only"]
+    assert "godot_shader_get_param" in grouped_result


### PR DESCRIPTION
### **User description**
## Summary

`list_tools_by_safety_class` returned a raw `dict[str, list[str]]`, the only tool in the surface that violated the typed-I/O rule (`.opencode/rules/mcp-tools.md`: "return a typed Pydantic model — never a raw `dict`").

## Changes

- `mcp_server/models/safety.py` (new): `SafetyClassListing` model with one field `tools_by_safety_class: dict[str, list[str]]`.
- `mcp_server/safety.py`: tool returns `SafetyClassListing(tools_by_safety_class=...)` instead of the bare dict.
- `tests/contract/test_safety_typed_result.py` (new): pins the new shape and a model round-trip.
- `tests/contract/test_safety_tool.py`, `tests/contract/test_shader.py`: updated to read the wrapped `tools_by_safety_class` key.

## Wire-shape change

The result changes from a flat `{read_only: [...], ...}` to `{"tools_by_safety_class": {read_only: [...], ...}}`. Downstream `godot-agents` reads `safety_class` from tool `meta`, not from this tool result, so no consumer breakage.

## Test plan

- [x] `uv run pytest -q` → 658 passed
- [x] `uv run ruff check .` → clean
- [x] `uv run mypy` → clean
- [x] `./.opencode/hooks/check-no-skipped-tests.sh` → clean


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Wraps safety listing in typed model

- Changes tool result wire shape

- Consumers must read wrapped key

- Adds contract tests for new shape


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw dict result"] -- "wrap" --> B["SafetyClassListing model"]
  B -- "structured content" --> C["Consumers / tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safety.py</strong><dd><code>Add typed safety listing model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/safety.py

<ul><li>Adds <code>SafetyClassListing</code> Pydantic model<br> <li> Defines <code>tools_by_safety_class</code> field<br> <li> Documents safety class grouping</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/372/files#diff-20464ee74bb50774574db851ef095ec5d65b7ad42579894a72211e4745fdc823">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safety.py</strong><dd><code>Return typed safety class listing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/safety.py

<ul><li>Imports <code>SafetyClassListing</code><br> <li> Changes tool return type to model<br> <li> Wraps grouped result in model</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/372/files#diff-e88413f8a6523dc121b54f76194f08350c3b44a74ac5a3ecabc7db2e6ca0087b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_safety_tool.py</strong><dd><code>Update safety tool test shape</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_safety_tool.py

<ul><li>Updates test to read wrapped key<br> <li> Adjusts assertion for <code>tools_by_safety_class</code><br> <li> Updates related comment wording</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/372/files#diff-de2cca4ea308a05b895e4bbfe1349d5b2fc181c8693f52198ffaf4c81847284a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_safety_typed_result.py</strong><dd><code>Add typed safety result contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_safety_typed_result.py

<ul><li>Adds contract test for typed result<br> <li> Validates <code>tools_by_safety_class</code> key<br> <li> Checks model round-trip behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/372/files#diff-3bd3b2cbc8658a1c1693badacf3da1f60ac95de39b474be65fac2381453d4d2f">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_shader.py</strong><dd><code>Update shader test for wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_shader.py

<ul><li>Updates shader test for wrapped result<br> <li> Reads <code>tools_by_safety_class</code> before <code>read_only</code></ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/372/files#diff-dc4ed87ec99595add7bce4249e632af3522d7a8977bc7dbb11784a823fa57964">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

