### PR TITLE
Add destructive tool confirmation contract tests

### DIFF
--- a/tests/contract/test_destructive_safety_contract.py
+++ b/tests/contract/test_destructive_safety_contract.py
@@ -1,0 +1,132 @@
+"""Contract: every destructive-tagged tool calls require_confirmation (issue #367).
+
+The destructive-tool safety contract is defense-in-depth by convention, not
+enforced: ``ApprovalMiddleware`` gates a call on the tool's ``safety_class``
+meta, but the ``confirm: bool`` gate lives in each tool's body via
+``require_confirmation`` (safety.py:203). A tool tagged ``destructive`` whose
+body forgets the call would be approved by the middleware and proceed without
+``confirm=True`` — silently breaking the contract from mcp-tools.md.
+
+This test pins the invariant statically: for every registered
+``destructive``-tagged tool, the handler's source must call
+``require_confirmation``. A new destructive tool added without the call fails
+this test before it can ship.
+"""
+
+from __future__ import annotations
+
+import inspect
+import textwrap
+
+import pytest
+
+from mcp_server.safety import SafetyClass, _iter_registered_tools
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _destructive_tool_handlers() -> list[tuple[str, object]]:
+    """Return (tool_name, handler) for every destructive-tagged registered tool."""
+    from mcp_server.bridge import Bridge
+    from mcp_server.config import ServerConfig
+    from mcp_server.server import create_server
+
+    conn = FakeAddonConnection()
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    mcp = create_server(ServerConfig(), bridge=bridge)
+    out: list[tuple[str, object]] = []
+    async for tool in _iter_registered_tools(mcp):
+        sc = (tool.meta or {}).get("safety_class")
+        if sc == SafetyClass.DESTRUCTIVE.value:
+            out.append((tool.name, tool.fn))
+    return out
+
+
+async def test_every_destructive_tool_calls_require_confirmation() -> None:
+    """Every destructive-tagged tool's handler must CALL require_confirmation
+    (not just mention it in a comment). A destructive tool without the confirm
+    gate would be approved by the middleware and run without confirm=True —
+    violating the contract. This catches a missing call at contract-test time,
+    before it ships.
+    """
+    import ast
+
+    handlers = await _destructive_tool_handlers()
+    assert handlers, "expected at least one destructive tool to be registered"
+    missing: list[str] = []
+    for name, fn in handlers:
+        src = textwrap.dedent(inspect.getsource(fn))  # type: ignore[arg-type]
+        tree = ast.parse(src)
+        called = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "require_confirmation"
+            for node in ast.walk(tree)
+        )
+        if not called:
+            missing.append(name)
+    assert not missing, (
+        "destructive tools missing a require_confirmation CALL (issue #367): "
+        + ", ".join(missing)
+    )
+
+
+async def test_every_destructive_tool_accepts_dry_run() -> None:
+    """Every destructive-tagged tool must accept ``dry_run`` (mcp-tools.md:
+    destructive tools accept dry_run AND require confirm). Pin the schema."""
+    from fastmcp import Client
+
+    from mcp_server.bridge import Bridge
+    from mcp_server.config import ServerConfig
+    from mcp_server.server import create_server
+
+    conn = FakeAddonConnection()
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    handlers = await _destructive_tool_handlers()
+    assert handlers
+    async with Client(server, mode="legacy") as client:
+        tools = {t.name: t for t in await client.list_tools()}
+    missing: list[str] = []
+    for name, _fn in handlers:
+        tool = tools.get(name)
+        if tool is None:
+            continue
+        props = (tool.input_schema or {}).get("properties", {})
+        if "dry_run" not in props:
+            missing.append(name)
+    assert not missing, (
+        "destructive tools missing dry_run in their schema (issue #367): "
+        + ", ".join(missing)
+    )
+
+
+async def test_every_destructive_tool_accepts_confirm() -> None:
+    """Every destructive-tagged tool must accept ``confirm`` (mcp-tools.md:
+    destructive tools require confirm=True). Pin the schema."""
+    from fastmcp import Client
+
+    from mcp_server.bridge import Bridge
+    from mcp_server.config import ServerConfig
+    from mcp_server.server import create_server
+
+    conn = FakeAddonConnection()
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    handlers = await _destructive_tool_handlers()
+    assert handlers
+    async with Client(server, mode="legacy") as client:
+        tools = {t.name: t for t in await client.list_tools()}
+    missing: list[str] = []
+    for name, _fn in handlers:
+        tool = tools.get(name)
+        if tool is None:
+            continue
+        props = (tool.input_schema or {}).get("properties", {})
+        if "confirm" not in props:
+            missing.append(name)
+    assert not missing, (
+        "destructive tools missing confirm in their schema (issue #367): "
+        + ", ".join(missing)
+    )

--- a/tests/contract/test_destructive_safety_contract.py
+++ b/tests/contract/test_destructive_safety_contract.py
@@ -27,7 +27,13 @@ pytestmark = pytest.mark.asyncio
 
 
 async def _destructive_tool_handlers() -> list[tuple[str, object]]:
-    """Return (tool_name, handler) for every destructive-tagged registered tool."""
+    """Return (tool_name, tool_object) for every destructive-tagged registered tool.
+
+    Yields the registered Tool object (not the raw fn) so callers can read
+    ``parameters`` (the JSON schema) directly — a client's ``list_tools``
+    only shows enabled toolsets, so a gated destructive tool would be absent
+    and a schema test would pass vacuously (issue #367 review feedback).
+    """
     from mcp_server.bridge import Bridge
     from mcp_server.config import ServerConfig
     from mcp_server.server import create_server
@@ -39,7 +45,7 @@ async def _destructive_tool_handlers() -> list[tuple[str, object]]:
     async for tool in _iter_registered_tools(mcp):
         sc = (tool.meta or {}).get("safety_class")
         if sc == SafetyClass.DESTRUCTIVE.value:
-            out.append((tool.name, tool.fn))
+            out.append((tool.name, tool))
     return out
 
 
@@ -55,7 +61,8 @@ async def test_every_destructive_tool_calls_require_confirmation() -> None:
     handlers = await _destructive_tool_handlers()
     assert handlers, "expected at least one destructive tool to be registered"
     missing: list[str] = []
-    for name, fn in handlers:
+    for name, tool in handlers:
+        fn = getattr(tool, "fn", tool)
         src = textwrap.dedent(inspect.getsource(fn))  # type: ignore[arg-type]
         tree = ast.parse(src)
         called = any(
@@ -74,26 +81,18 @@ async def test_every_destructive_tool_calls_require_confirmation() -> None:
 
 async def test_every_destructive_tool_accepts_dry_run() -> None:
     """Every destructive-tagged tool must accept ``dry_run`` (mcp-tools.md:
-    destructive tools accept dry_run AND require confirm). Pin the schema."""
-    from fastmcp import Client
+    destructive tools accept dry_run AND require confirm). Pin the schema.
 
-    from mcp_server.bridge import Bridge
-    from mcp_server.config import ServerConfig
-    from mcp_server.server import create_server
-
-    conn = FakeAddonConnection()
-    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
-    server = create_server(ServerConfig(), bridge=bridge)
+    Reads the schema from the registered tool directly (via the unfiltered
+    local provider), not from a client's ``list_tools`` — a client sees only
+    enabled toolsets, so a gated destructive tool would be absent and the test
+    would pass vacuously (issue #367 review feedback).
+    """
     handlers = await _destructive_tool_handlers()
     assert handlers
-    async with Client(server, mode="legacy") as client:
-        tools = {t.name: t for t in await client.list_tools()}
     missing: list[str] = []
-    for name, _fn in handlers:
-        tool = tools.get(name)
-        if tool is None:
-            continue
-        props = (tool.input_schema or {}).get("properties", {})
+    for name, tool in handlers:
+        props = (getattr(tool, "parameters", {}) or {}).get("properties", {})
         if "dry_run" not in props:
             missing.append(name)
     assert not missing, (
@@ -104,26 +103,16 @@ async def test_every_destructive_tool_accepts_dry_run() -> None:
 
 async def test_every_destructive_tool_accepts_confirm() -> None:
     """Every destructive-tagged tool must accept ``confirm`` (mcp-tools.md:
-    destructive tools require confirm=True). Pin the schema."""
-    from fastmcp import Client
+    destructive tools require confirm=True). Pin the schema.
 
-    from mcp_server.bridge import Bridge
-    from mcp_server.config import ServerConfig
-    from mcp_server.server import create_server
-
-    conn = FakeAddonConnection()
-    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
-    server = create_server(ServerConfig(), bridge=bridge)
+    Reads the schema from the registered tool directly (via the unfiltered
+    local provider), not from a client's ``list_tools``.
+    """
     handlers = await _destructive_tool_handlers()
     assert handlers
-    async with Client(server, mode="legacy") as client:
-        tools = {t.name: t for t in await client.list_tools()}
     missing: list[str] = []
-    for name, _fn in handlers:
-        tool = tools.get(name)
-        if tool is None:
-            continue
-        props = (tool.input_schema or {}).get("properties", {})
+    for name, tool in handlers:
+        props = (getattr(tool, "parameters", {}) or {}).get("properties", {})
         if "confirm" not in props:
             missing.append(name)
     assert not missing, (


### PR DESCRIPTION
### **User description**
## Summary

The destructive-tool safety contract is defense-in-depth by convention, not enforced: `ApprovalMiddleware` gates a call on the tool's `safety_class` meta, but the `confirm: bool` gate lives in each tool's body via `require_confirmation` (`safety.py:203`). A tool tagged `destructive` whose body forgets the call would be approved by the middleware and proceed without `confirm=True` — silently breaking the contract from `mcp-tools.md`.

This PR adds a contract test that pins the invariant before it can ship.

## Changes

`tests/contract/test_destructive_safety_contract.py` (new) pins three invariants for every registered `destructive`-tagged tool:
1. The handler **calls** `require_confirmation` — AST check, not substring, so a comment mentioning it does not satisfy the test.
2. The schema accepts `dry_run`.
3. The schema accepts `confirm`.

## Verification

- Red-then-green confirmed: removing the `require_confirmation` call from `delete_node` makes `test_every_destructive_tool_calls_require_confirmation` fail with the offending tool name; restoring it passes.
- All three invariants currently hold across the surface (no production code change needed).

## Test plan

- [x] `uv run pytest -q` -> 659 passed (no production change; +3 contract tests)
- [x] `uv run ruff check .` -> clean
- [x] `uv run mypy` -> clean
- [x] `./.opencode/hooks/check-no-skipped-tests.sh` -> clean


___

### **PR Type**
Tests


___

### **Description**
- Adds destructive tool contract tests

- Verifies require_confirmation calls via AST

- Checks dry_run and confirm schemas

- No production behavior change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Destructive tools"]
  B["require_confirmation called"]
  C["dry_run accepted"]
  D["confirm accepted"]
  A -- "AST check" --> B
  A -- "schema check" --> C
  A -- "schema check" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_destructive_safety_contract.py</strong><dd><code>Add destructive safety contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_destructive_safety_contract.py

<ul><li>Adds async contract tests for destructive tools<br> <li> Uses AST to verify require_confirmation call<br> <li> Asserts dry_run exists in tool schemas<br> <li> Asserts confirm exists in tool schemas</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/374/files#diff-748d651fb193f11c3eb6406a86ab2e3d2e9d6272878e5734caf8cbd9c9815bcc">+132/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

