### PR TITLE
Use lightweight node existence probe for mutations

### DIFF
--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -21,6 +21,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_scene_tree"] = _cmd_get_scene_tree
 	handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
+	handlers["cmd_node_exists"] = _cmd_node_exists
 	handlers["cmd_get_node_property"] = _cmd_get_node_property
 	handlers["cmd_get_node_property_list"] = _cmd_get_node_property_list
 	handlers["cmd_get_node_groups"] = _cmd_get_node_groups
@@ -110,6 +111,22 @@ func _cmd_get_node_properties(params: Dictionary) -> Dictionary:
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
 	return _router._ok(Inspect.node_info(node, root))
+
+
+func _cmd_node_exists(params: Dictionary) -> Dictionary:
+	# Lightweight existence probe (issue #365): returns only {exists: bool},
+	# no property serialization. Used by require_node_exists to avoid the
+	# heavy cmd_get_node_properties round-trip on every node-targeted mutation.
+	if not params.has("node_path"):
+		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	var root: Node = EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _router._fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	var node_path := Inspect.normalize_node_path(str(params["node_path"]))
+	var node: Node = root.get_node_or_null(NodePath(node_path))
+	if node == null:
+		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
+	return _router._ok({"exists": true})
 
 
 func _cmd_get_node_property(params: Dictionary) -> Dictionary:

--- a/mcp_server/harness.py
+++ b/mcp_server/harness.py
@@ -32,6 +32,7 @@ READ_ONLY_COMMANDS: frozenset[str] = frozenset(
         "cmd_get_scene_tree",
         "cmd_get_selected_node",
         "cmd_get_node_properties",
+        "cmd_node_exists",
         "cmd_get_node_property_list",
         "cmd_find_nodes_by_type",
         "cmd_get_dependencies",

--- a/mcp_server/safety.py
+++ b/mcp_server/safety.py
@@ -175,9 +175,15 @@ async def require_active_scene(bridge: Bridge) -> None:
 
 
 async def require_node_exists(bridge: Bridge, node_path: str) -> None:
-    """Fail fast if ``node_path`` does not resolve in the active scene."""
+    """Fail fast if ``node_path`` does not resolve in the active scene.
+
+    Uses the lightweight ``cmd_node_exists`` probe (returns ``{exists: bool}``,
+    no property serialization) rather than the heavy ``cmd_get_node_properties``
+    — every node-targeted mutation then pays one round-trip for the existence
+    check plus one for the mutation itself, not two heavy round-trips (issue #365).
+    """
     require_bridge_connected(bridge)
-    response = await bridge.send("cmd_get_node_properties", {"node_path": node_path})
+    response = await bridge.send("cmd_node_exists", {"node_path": node_path})
     if response.ok:
         return
     # Only a genuine not-found means "fix the path"; other failures (TIMEOUT,

--- a/tests/contract/test_animation.py
+++ b/tests/contract/test_animation.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_create_animation":
             return ResponseEnvelope.success(

--- a/tests/contract/test_animation.py
+++ b/tests/contract/test_animation.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_animation":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_approval_guard.py
+++ b/tests/contract/test_approval_guard.py
@@ -37,7 +37,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
-        case "cmd_get_node_properties":
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
         case "cmd_create_node":
             return ResponseEnvelope.success(

--- a/tests/contract/test_approval_guard.py
+++ b/tests/contract/test_approval_guard.py
@@ -38,7 +38,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_node":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": f"{p['parent_path']}/{p['name']}", "created": True}

--- a/tests/contract/test_audio.py
+++ b/tests/contract/test_audio.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_add_audio_player":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_audio.py
+++ b/tests/contract/test_audio.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_add_audio_player":
             return ResponseEnvelope.success(

--- a/tests/contract/test_composite.py
+++ b/tests/contract/test_composite.py
@@ -25,7 +25,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
-        case "cmd_get_node_properties":
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             if p.get("node_path") == "Ghost":
                 return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Ghost'.")
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})

--- a/tests/contract/test_composite.py
+++ b/tests/contract/test_composite.py
@@ -28,7 +28,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             if p.get("node_path") == "Ghost":
                 return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Ghost'.")
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_compose_node":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -27,7 +27,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://m.tscn"})
-        case "cmd_get_node_properties":
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             if p.get("node_path") == "Ghost":
                 return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Ghost'.")
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
@@ -192,7 +192,7 @@ def _addon_base(cmd: CommandEnvelope) -> ResponseEnvelope:
     """Handle bootstrap commands and node checks for suggestion tests."""
     if cmd.command == "cmd_get_active_scene":
         return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://main.tscn"})
-    if cmd.command == "cmd_get_node_properties":
+    if cmd.command == "cmd_node_exists":  # require_node_exists precondition (issue #365)
         return ResponseEnvelope.success(
             cmd.id, {"node_path": cmd.params["node_path"], "type": "Node2D"}
         )

--- a/tests/contract/test_mutation.py
+++ b/tests/contract/test_mutation.py
@@ -30,7 +30,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             if p.get("node_path") == "Ghost":
                 return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'Ghost'.")
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_node":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": f"{p['parent_path']}/{p['name']}", "created": True}
@@ -193,9 +193,7 @@ def _addon_base(cmd: CommandEnvelope) -> ResponseEnvelope:
     if cmd.command == "cmd_get_active_scene":
         return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://main.tscn"})
     if cmd.command == "cmd_node_exists":  # require_node_exists precondition (issue #365)
-        return ResponseEnvelope.success(
-            cmd.id, {"node_path": cmd.params["node_path"], "type": "Node2D"}
-        )
+        return ResponseEnvelope.success(cmd.id, {"exists": True})
     # Return failure for bootstrap commands so FakeAddonConnection auto-replaces
     # cmd_ping / cmd_get_project_info with its default responder.
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", f"Unknown command '{cmd.command}'.")

--- a/tests/contract/test_navigation.py
+++ b/tests/contract/test_navigation.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_setup_navigation_region":
             return ResponseEnvelope.success(

--- a/tests/contract/test_navigation.py
+++ b/tests/contract/test_navigation.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_setup_navigation_region":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_node_ops.py
+++ b/tests/contract/test_node_ops.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # used by require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_duplicate_node":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": f"{p['node_path']}2", "source_path": p["node_path"]}

--- a/tests/contract/test_node_ops.py
+++ b/tests/contract/test_node_ops.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # used by require_node_exists precondition
+        case "cmd_node_exists":  # used by require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_duplicate_node":
             return ResponseEnvelope.success(

--- a/tests/contract/test_particles.py
+++ b/tests/contract/test_particles.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_particles":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_particles.py
+++ b/tests/contract/test_particles.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_create_particles":
             return ResponseEnvelope.success(

--- a/tests/contract/test_physics.py
+++ b/tests/contract/test_physics.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_setup_physics_body":
             return ResponseEnvelope.success(

--- a/tests/contract/test_physics.py
+++ b/tests/contract/test_physics.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_setup_physics_body":
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "properties": {"mass": 5.0}}

--- a/tests/contract/test_require_node_exists_probe.py
+++ b/tests/contract/test_require_node_exists_probe.py
@@ -1,0 +1,94 @@
+"""Contract: require_node_exists uses a cheap cmd_node_exists probe (issue #365).
+
+Previously require_node_exists sent cmd_get_node_properties (fetching every
+property) for every node-targeted mutation, doubling the bridge round-trip.
+It now sends a lightweight cmd_node_exists that returns only {exists: bool}.
+The precondition envelope (RESOURCE_NOT_FOUND for missing, TIMEOUT/other
+propagated) is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.safety import PreconditionError, require_node_exists
+from tests.fakes import FakeAddonConnection, Responder, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _connected(responder: Responder) -> Bridge:
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(BridgeConfig(), connector=connector_for(conn))
+    await bridge.connect()
+    return bridge
+
+
+def _sent_commands(conn: FakeAddonConnection) -> list[str]:
+    return [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+
+
+async def test_uses_cmd_node_exists_not_get_node_properties() -> None:
+    """require_node_exists must send the cheap cmd_node_exists probe, not the
+    heavy cmd_get_node_properties (issue #365)."""
+    seen: list[str] = []
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        seen.append(cmd.command)
+        return ResponseEnvelope.success(cmd.id, {"exists": True})
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(BridgeConfig(), connector=connector_for(conn))
+    await bridge.connect()
+    await require_node_exists(bridge, "Player")
+    await bridge.close()
+
+    assert "cmd_node_exists" in seen, (
+        "require_node_exists must send cmd_node_exists, not "
+        "cmd_get_node_properties (issue #365). Sent: " + ", ".join(seen)
+    )
+    assert "cmd_get_node_properties" not in seen
+
+
+async def test_present_returns_without_error() -> None:
+    """A present node returns silently (no PreconditionError)."""
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"exists": True})
+
+    bridge = await _connected(responder)
+    await require_node_exists(bridge, "Player")  # must not raise
+    await bridge.close()
+
+
+async def test_missing_raises_resource_not_found() -> None:
+    """A missing node raises PreconditionError with error=RESOURCE_NOT_FOUND
+    and required=node_exists (envelope unchanged)."""
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.failure(cmd.id, "RESOURCE_NOT_FOUND", "No node at 'X'.")
+
+    bridge = await _connected(responder)
+    with pytest.raises(PreconditionError) as exc:
+        await require_node_exists(bridge, "X")
+    assert exc.value.error == "RESOURCE_NOT_FOUND"
+    assert exc.value.required == "node_exists"
+    await bridge.close()
+
+
+async def test_other_failures_propagate_unchanged() -> None:
+    """A TIMEOUT (or other non-not-found failure) propagates with its own
+    error/required — not mislabeled as node_exists."""
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.failure(cmd.id, "TIMEOUT", "No response from Godot.")
+
+    bridge = await _connected(responder)
+    with pytest.raises(PreconditionError) as exc:
+        await require_node_exists(bridge, "Player")
+    assert exc.value.error == "TIMEOUT"
+    assert exc.value.required != "node_exists"
+    await bridge.close()

--- a/tests/contract/test_scene_3d.py
+++ b/tests/contract/test_scene_3d.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
         case "cmd_add_mesh_instance":
             return ResponseEnvelope.success(
@@ -158,7 +158,7 @@ async def test_gridmap_missing_library_preserves_required() -> None:
     # When the addon returns a structured precondition (required=mesh_library),
     # route() preserves it so the agent learns what to satisfy.
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
-        if cmd.command == "cmd_get_node_properties":
+        if cmd.command == "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": "GridMap", "type": "GridMap"})
         if cmd.command == "cmd_gridmap_set_cell":
             return ResponseEnvelope.failure(

--- a/tests/contract/test_scene_3d.py
+++ b/tests/contract/test_scene_3d.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_add_mesh_instance":
             return ResponseEnvelope.success(
                 cmd.id,
@@ -159,7 +159,7 @@ async def test_gridmap_missing_library_preserves_required() -> None:
     # route() preserves it so the agent learns what to satisfy.
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         if cmd.command == "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": "GridMap", "type": "GridMap"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         if cmd.command == "cmd_gridmap_set_cell":
             return ResponseEnvelope.failure(
                 cmd.id, "VALIDATION_ERROR", "GridMap has no mesh_library.", required="mesh_library"

--- a/tests/contract/test_scene_session.py
+++ b/tests/contract/test_scene_session.py
@@ -25,7 +25,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://world.tscn"})
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_open_scene":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_scene_session.py
+++ b/tests/contract/test_scene_session.py
@@ -24,7 +24,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     match cmd.command:
         case "cmd_get_active_scene":
             return ResponseEnvelope.success(cmd.id, {"is_open": True, "path": "res://world.tscn"})
-        case "cmd_get_node_properties":
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Node2D"})
         case "cmd_open_scene":
             return ResponseEnvelope.success(

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -18,9 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(
-                cmd.id, {"node_path": p["node_path"], "type": "Sprite2D"}
-            )
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_shader":
             return ResponseEnvelope.success(
                 cmd.id, {"shader_path": p["shader_path"], "created": True}

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "type": "Sprite2D"}
             )

--- a/tests/contract/test_theme_ui.py
+++ b/tests/contract/test_theme_ui.py
@@ -18,7 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Panel"})
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_create_theme":
             return ResponseEnvelope.success(
                 cmd.id,

--- a/tests/contract/test_theme_ui.py
+++ b/tests/contract/test_theme_ui.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "type": "Panel"})
         case "cmd_create_theme":
             return ResponseEnvelope.success(

--- a/tests/contract/test_tilemap.py
+++ b/tests/contract/test_tilemap.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.asyncio
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
-        case "cmd_get_node_properties":  # require_node_exists precondition
+        case "cmd_node_exists":  # require_node_exists precondition (issue #365)
             return ResponseEnvelope.success(
                 cmd.id, {"node_path": p["node_path"], "type": "TileMapLayer"}
             )

--- a/tests/contract/test_tilemap.py
+++ b/tests/contract/test_tilemap.py
@@ -18,9 +18,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
         case "cmd_node_exists":  # require_node_exists precondition (issue #365)
-            return ResponseEnvelope.success(
-                cmd.id, {"node_path": p["node_path"], "type": "TileMapLayer"}
-            )
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
         case "cmd_tilemap_set_cell":
             return ResponseEnvelope.success(
                 cmd.id,


### PR DESCRIPTION
### **User description**
## Summary

`require_node_exists` sent `cmd_get_node_properties` (fetching every property) for every node-targeted mutation, doubling the bridge round-trip. It now sends a lightweight `cmd_node_exists` that returns only `{exists: true}`, no property serialization. Every node-targeted mutation now pays one cheap existence round-trip plus the mutation itself, not two heavy round-trips. The precondition envelope (RESOURCE_NOT_FOUND for missing, TIMEOUT/other propagated) is unchanged.

## `[Both]` change

- `mcp_server/safety.py`: `require_node_exists` sends `cmd_node_exists`.
- `godot/addons/godot_mcp/handlers/scene_inspect.gd`: new `_cmd_node_exists` handler (`get_node_or_null`, returns `{exists: true}` or `RESOURCE_NOT_FOUND`). Read-only, no UndoRedo.
- `mcp_server/harness.py`: `cmd_node_exists` added to `READ_ONLY_COMMANDS` so it can pipeline with other reads.
- Contract test responders updated: the precondition shim in 14 contract test files now answers `cmd_node_exists` instead of `cmd_get_node_properties`. `test_inspection.py` keeps `cmd_get_node_properties` (the real tool's path).

## Relationship to #166

#166 (closed by #190) removed the *duplicate* preflight round-trip in `_preflight_validate`. This issue is distinct: it's about the *single remaining* `require_node_exists` probe using a heavier command than needed. #166 left this one in place because `require_*` is the safety layer; it didn't audit the cost of the probe itself.

## Test plan

- [x] `uv run pytest -q` -> 660 passed (was 600 pass / 60 fail mid-fix; the 60 were contract tests whose responders needed updating to the new command)
- [x] `uv run ruff check .` -> clean
- [x] `uv run mypy` -> clean
- [x] `./.opencode/hooks/check-no-skipped-tests.sh` -> clean
- [x] GDScript parse check: `cmd_node_exists` handler loads in the live editor (e2e suite passes)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace heavy node property probe with existence check

- Add lightweight `cmd_node_exists` addon handler

- Mark new command read-only for pipelining

- Precondition errors unchanged; requires updated addon


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["require_node_exists"] -- "send" --> B["cmd_node_exists"]
  B -- "returns exists" --> C["Mutation tools"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>harness.py</strong><dd><code>Add node existence command to read-only set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-3038079a10c9053c435609fbf90e4c179432ffd9e40d630b8648ecb8fbb89b9b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>safety.py</strong><dd><code>Use lightweight node existence probe in precondition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-e88413f8a6523dc121b54f76194f08350c3b44a74ac5a3ecabc7db2e6ca0087b">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_inspect.gd</strong><dd><code>Add lightweight node existence command handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-93f640e48d1dd80cc0c6e5b70a9d2a9f3102ed5b878c2d99d5f78fc7698a7f42">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>test_animation.py</strong><dd><code>Update animation contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-e510b4fc9c27d39080ae483d156210eb4469e46ef9d762bebc46cbc05a13341c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_approval_guard.py</strong><dd><code>Update approval guard responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-6250241b76bd219b2a746a67f30f601c5d1ad330ea2fd8c9b5b18a53dc13272d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_audio.py</strong><dd><code>Update audio contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-f383bfe7953949be93a283f2ff93566ac3b1f228b161235af8a7488ee8d16ee0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_composite.py</strong><dd><code>Update composite contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-5d7559d925b2c8a44e4268f55ba5ee50b61637704a4ab9ce50f41a63c17fdd34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_mutation.py</strong><dd><code>Update mutation contract responders to existence probe</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-513326e4b7276e9b75b130175d62e897fae2fb16b472c2870ed3f0d7847bc088">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_navigation.py</strong><dd><code>Update navigation contract responder to existence probe</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-b5c60317400f94fbdf9304eccc9ac8820bc2391fae31632522ea4f4bcc4c6a20">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_node_ops.py</strong><dd><code>Update node operations responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-bf982e3ae0a5ab4389671933e500d1f7c5c3523b1f685f1802445b4919750fe4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_particles.py</strong><dd><code>Update particles contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-4b9ba42d59c718f6cdc0618386d600c3e3d467a57cb47ecd9449d7437dbb9dba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_physics.py</strong><dd><code>Update physics contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-c536df4c3f2490808c881b44290ce2d818e762df08bfc3c83d360d5257dcae74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_require_node_exists_probe.py</strong><dd><code>Add contract tests for node existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-18c3479b27479f2cce833cb7c34690e126af6742e39bb8bc40d77beb4da50bfe">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scene_3d.py</strong><dd><code>Update 3D scene responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-ef9f48900c610cb5331eed17136b6c82a8b9ca06e8cbe741b5b21fc6ae8491d2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_scene_session.py</strong><dd><code>Update scene session responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-d99de244ec964255a71be9c31d9f637f9f9bd2e3802ceeb3337fbeb1e1f81796">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_shader.py</strong><dd><code>Update shader contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-dc4ed87ec99595add7bce4249e632af3522d7a8977bc7dbb11784a823fa57964">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_theme_ui.py</strong><dd><code>Update theme UI responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-f91816214519320a0d6202ecb9fbdaa82c6af38389def58c36a8ddf26ba2c507">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tilemap.py</strong><dd><code>Update tilemap contract responder to existence probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/375/files#diff-0b82b4bb7835cbd79a2805fe6ea6dad331766785e71a5a66f8b66946ab90cdda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

