### PR TITLE
Bump version to 2026.08.27b2

### DIFF
--- a/.opencode/rules/enforcement.md
+++ b/.opencode/rules/enforcement.md
@@ -38,4 +38,4 @@ CI does not exist yet (greenfield). Wire these gates into a workflow as part of 
 
 ## Versioning
 
-CalVer `YYYY.MM.DD[-N]`. Current: **2026.06.01**.
+CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.27b2** (beta 2).

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Bridges a live Godot editor to an MCP server so AI clients can drive scene authoring, inspection, and runtime over a localhost WebSocket."
 author="hybridindie"
-version="2026.08.26b1"
+version="2026.08.27b2"
 script="godot_mcp.gd"
 icon="icon.png"

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -9,7 +9,7 @@ See ``docs/architecture.md`` for the bridge contract.
 """
 
 # CalVer, kept in sync with pyproject.toml and .opencode/rules/enforcement.md.
-__version__ = "2026.08.26b1"
+__version__ = "2026.08.27b2"
 
 # Tool-contract / compatibility version — a monotonic integer, deliberately
 # distinct from the CalVer build version. It expresses the *contract*: bump it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-editor-mcp"
-version = "2026.08.26b1"
+version = "2026.08.27b2"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1260,7 +1260,7 @@ wheels = [
 
 [[package]]
 name = "godot-editor-mcp"
-version = "2026.8.26b1"
+version = "2026.8.27b2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
### **User description**
## Summary

Version bump for the second beta release (`2026.08.27b2`). Updates:
- `pyproject.toml`: `2026.08.26b1` -> `2026.08.27b2`
- `.opencode/rules/enforcement.md`: stale "Current: 2026.06.01" -> `2026.08.27b2 (beta 2)`

## What's in beta 2

19 commits since b1. User-facing:
- 6 graphify-driven safety/toolset fixes (#364, #366, #368, #369, #367, #365) — server-global toolset gating, typed `list_tools_by_safety_class`, `ErrorCode.APPROVAL_DENIED` enum, middleware lookup-error handling, destructive-tool confirm contract tests, lightweight `cmd_node_exists` probe
- Addon icon + Asset Library publish CI
- Docs reorganization (consumer-first README, transport security, Docker setup)
- MCP status dock moved to bottom panel
- graphify MCP server wired into opencode config

## Test plan

- [x] `uv build` succeeds (wheel + sdist)
- [x] `uv run pytest -q` -> 672 passed
- [x] `uv run ruff check .` / `uv run mypy` / zero-skip -> clean


___

### **PR Type**
Other, Documentation


___

### **Description**
- Bump package version to 2026.08.27b2

- Update enforcement rule current version

- No runtime or public API changes

- Low risk release metadata update


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml"] -- "version bump" --> B["2026.08.27b2"]
  C[".opencode/rules/enforcement.md"] -- "docs update" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump package version to beta 2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Bumps <code>pyproject.toml</code> version from 2026.08.26b1 to 2026.08.27b2.<br> <li> Updates package metadata for beta 2 release.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/376/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enforcement.md</strong><dd><code>Update enforcement rule current version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.opencode/rules/enforcement.md

<ul><li>Updates current CalVer version in <code>.opencode/rules/enforcement.md</code>.<br> <li> Replaces stale 2026.06.01 with 2026.08.27b2.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/376/files#diff-688b42a0fee7d33fb02e12946e7605b1b44f14ecfb129ef4cad7226fd37932e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

