### PR TITLE
Fix PyPI publish by separating addon zip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,14 +37,24 @@ jobs:
           # Create a zip containing only the addons/godot_mcp/ directory,
           # structured so it extracts into the project root (addons/godot_mcp/...).
           # This is the format Godot's Asset Library and manual install expect.
+          # Built into a separate directory (addon_dist/) so it is NOT uploaded to
+          # PyPI — pypa/gh-action-pypi-publish uploads everything in its packages
+          # dir, and the addon zip is not a Python distribution.
+          mkdir -p addon_dist
           cd godot
-          zip -r ../dist/godot_mcp_addon.zip addons/godot_mcp/
+          zip -r ../addon_dist/godot_mcp_addon.zip addons/godot_mcp/
 
-      - name: Upload artifacts
+      - name: Upload Python dist artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Upload Godot addon zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: addon_dist
+          path: addon_dist/
 
   publish-pypi:
     needs: build
@@ -74,11 +84,17 @@ jobs:
       contents: write  # Attach artifacts to the GitHub release.
       actions: read   # download-artifact
     steps:
-      - name: Download artifacts
+      - name: Download Python dist artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Download Godot addon zip
+        uses: actions/download-artifact@v4
+        with:
+          name: addon_dist
+          path: addon_dist/
 
       - name: Upload to GitHub release
         uses: softprops/action-gh-release@v2
@@ -86,7 +102,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/godot_mcp_addon.zip
+            addon_dist/godot_mcp_addon.zip
           tag_name: ${{ github.event.release.tag_name || inputs.tag }}
 
   publish-assetlib:
@@ -95,11 +111,11 @@ jobs:
     permissions:
       actions: read  # download-artifact
     steps:
-      - name: Download artifacts
+      - name: Download Godot addon zip
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: addon_dist
+          path: addon_dist/
 
       - name: Publish to Godot Asset Library
         env:
@@ -122,7 +138,7 @@ jobs:
             -F "version=$VERSION" \
             -F "download_url=$DOWNLOAD_URL" \
             -F "browse_url=https://github.com/${{ github.repository }}" \
-            -F "icon_url=https://raw.githubusercontent.com/${{ github.repository }}/main/godot/addons/godot_mcp/icon.svg" \
+            -F "icon_url=https://raw.githubusercontent.com/${{ github.repository }}/main/godot/addons/godot_mcp/icon.png" \
             -F "category=2" \
             -F "godot_version=4.4"
 


### PR DESCRIPTION
### **User description**
## Summary

The `2026.08.27b2` release publish failed: the addon zip (`godot_mcp_addon.zip`) was built into `dist/` alongside the wheel and sdist, so `pypa/gh-action-pypi-publish` tried to upload it to PyPI and rejected it (`InvalidDistribution: No PKG-INFO`). The addon zip was added to the build in commit `9913263` (after b1), so b1 published fine but b2 hit this.

## Changes

- Build the addon zip into a separate `addon_dist/` directory + artifact, so `publish-pypi` (which uploads everything in `dist/`) only sees Python distributions.
- `publish-github` and `publish-assetlib` download `addon_dist` separately and attach it to the GitHub release / Asset Library.
- Fix the Asset Library icon URL: the addon switched from `icon.svg` to `icon.png` (commit `158a1e2`) — the Asset Library requires raster format.

## Test plan

- [x] YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Re-triggering the publish workflow after merge should succeed

This is a CI-only fix; no production code change. Blocking the b2 release.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix failed PyPI release publish

- Build addon zip outside dist

- Fix Asset Library icon URL

- No public API changes, low risk


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build job"] -- "separate addon_dist" --> B["Addon zip"]
  A -- "Python dist" --> C["PyPI"]
  B -- "GitHub/AssetLib" --> D["Release"]
  B -- "PNG icon URL" --> E["Asset Library"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yml</strong><dd><code>Separate addon zip from PyPI publish</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yml

<ul><li>Build addon zip into addon_dist instead of dist<br> <li> Upload/download addon_dist separately for GitHub and Asset Library<br> <li> Keep PyPI upload limited to Python distributions<br> <li> Update Asset Library icon URL from SVG to PNG</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/377/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+24/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

