### PR TITLE
Bump version to `2026.08.31b3` (beta 3)

### DIFF
--- a/.opencode/rules/enforcement.md
+++ b/.opencode/rules/enforcement.md
@@ -38,4 +38,4 @@ CI does not exist yet (greenfield). Wire these gates into a workflow as part of 
 
 ## Versioning
 
-CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.27b2** (beta 2).
+CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.31b3** (beta 3).

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Bridges a live Godot editor to an MCP server so AI clients can drive scene authoring, inspection, and runtime over a localhost WebSocket."
 author="hybridindie"
-version="2026.08.27b2"
+version="2026.08.31b3"
 script="godot_mcp.gd"
 icon="icon.png"

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -9,7 +9,7 @@ See ``docs/architecture.md`` for the bridge contract.
 """
 
 # CalVer, kept in sync with pyproject.toml and .opencode/rules/enforcement.md.
-__version__ = "2026.08.27b2"
+__version__ = "2026.08.31b3"
 
 # Tool-contract / compatibility version — a monotonic integer, deliberately
 # distinct from the CalVer build version. It expresses the *contract*: bump it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-editor-mcp"
-version = "2026.08.27b2"
+version = "2026.08.31b3"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "godot-editor-mcp"
-version = "2026.8.27b2"
+version = "2026.8.31b3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
### **User description**
## Summary

Version bump for the third beta release (`2026.08.31b3`). Same 5-file set as #376:

- `pyproject.toml`: `2026.08.27b2` → `2026.08.31b3`
- `mcp_server/__init__.py`: `__version__` → `2026.08.31b3`
- `godot/addons/godot_mcp/plugin.cfg`: addon version → `2026.08.31b3`
- `.opencode/rules/enforcement.md`: Current → `2026.08.31b3 (beta 3)`
- `uv.lock`: self-reference resynced

## What's in beta 3

2 commits since [b2](https://github.com/hybridindie/godot-mcp/releases/tag/2026.08.27b2):

- **#379 / #378** — MLflow fully decoupled from godot-mcp. The `mlflow` package isn't installable alongside the FastMCP 4.x pin; eval→MLflow logging now lives with godot-agents. Dev env shrinks 172 → 100 locked packages; the #197 representativeness banner survives as console output in `run_llm_suite`.
- **#377** — Publish CI: addon zip kept out of the PyPI upload; Asset Library icon URL fixed.

`CONTRACT_VERSION` stays at **1** — no tool-surface or bridge-envelope changes.

## Test plan

- [x] `uv build` succeeds (wheel + sdist)
- [x] `uv run pytest -q` → 665 passed, 0 skipped (incl. the CalVer + pyproject-sync version tests)
- [x] `uv run ruff check .` / `uv run mypy` / zero-skip gate → clean


___

### **PR Type**
Other, Documentation


___

### **Description**
- Bump package version to `2026.08.31b3`

- Update addon and rule version metadata

- No runtime or public API changes

- Low-risk CalVer release metadata update


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml"] -- "version bump" --> B["2026.08.31b3"]
  C["mcp_server/__init__.py"] -- "version sync" --> B
  D["godot/addons/godot_mcp/plugin.cfg"] -- "addon version" --> B
  E[".opencode/rules/enforcement.md"] -- "docs update" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py`</strong><dd><code>Update server package version constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`mcp_server/__init__.py`

<ul><li>Updates <code>__version__</code> from <code>2026.08.27b2</code> to <code>2026.08.31b3</code>.<br> <li> Keeps CalVer in sync with package metadata.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plugin.cfg`</strong><dd><code>Update Godot addon plugin version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`godot/addons/godot_mcp/plugin.cfg`

<ul><li>Updates the addon <code>version</code> to <code>2026.08.31b3</code>.<br> <li> Keeps Godot addon metadata aligned with the release.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>`pyproject.toml`</strong><dd><code>Bump project version to beta 3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`pyproject.toml`

<ul><li>Bumps the project version to <code>2026.08.31b3</code>.<br> <li> Updates package metadata for beta 3.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enforcement.md`</strong><dd><code>Update enforcement rule current version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.opencode/rules/enforcement.md`

<ul><li>Updates the current CalVer in the enforcement rule.<br> <li> Replaces beta 2 with beta 3.</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

