### PR TITLE
Sync godot-mcp skills to 2026.08.31b3 surface with drift tests

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -4,10 +4,16 @@ godot-mcp ships three AI skills that give your agent expert knowledge when
 building Godot games through the MCP tools. Two categories:
 
 - **MCP workflow skills** — step-by-step recipes for calling the tools
-  correctly (enable toolsets, play-test and debug).
+  correctly (version + bridge check, enable toolsets, play-test and debug).
 - **Engine knowledge skill** — Godot 4.x engine rules and common-bug
   prevention (rendering, physics, autoloads, GDScript gotchas, scene
   authoring).
+
+The skills document the surface as of **2026.08.31b3** (180 tools across
+29 categories, 9 workflow prompts). `godot-getting-started` teaches how to
+check the live server version (`godot_health_check`) — if the server you're
+driving is older or newer, trust `godot_get_server_info()`'s inventory over
+the counts here.
 
 Install them once and your agent has the right guidance at the right time.
 
@@ -77,11 +83,11 @@ editor", "godot-mcp tools aren't showing up", "unknown tool from godot",
 "set up godot-mcp".
 
 **What it teaches:**
-- Confirming the bridge is connected (Godot + addon running)
-- The toolset-gating model (enable a toolset before its tools exist)
+- Checking the server version + bridge connection (`godot_health_check`, `godot_get_server_info`)
+- The toolset-gating model (enable a toolset before its tools exist — 28 gated toolsets)
 - The safety convention (read-only / mutating with `dry_run` / destructive
   with `confirm`)
-- Using built-in workflow prompts (`/build_scene`, `/play_test`, etc.)
+- Using built-in workflow prompts (`/build_scene`, `/play_test`, `/author_resource`, `/export_build`, `/batch_refactor`, etc.)
 - Error recovery (`unknown tool`, `PRECONDITION_FAILED`, `BRIDGE_DISCONNECTED`)
 
 **When to use:** First thing in any session that involves godot-mcp.
@@ -99,13 +105,15 @@ input in Godot", "why does my Godot game crash", "debug the running scene",
 "inspect the live game".
 
 **What it teaches:**
-- Enabling the `runtime`, `input`, `testing`, and `debugger` toolsets
+- The two run modes: headless `run_and_capture` vs. the live play session with probe
+- Enabling the `runtime`, `input`, `testing`, `debugger` (+ `profiling`) toolsets
 - Registering the runtime probe autoload
-- Playing a scene and inspecting the live scene tree
-- Simulating keyboard/mouse/action input
-- Asserting live node state (property comparisons)
+- Playing a scene and inspecting the live scene tree; finding UI elements
+- Simulating keyboard/mouse/action input; recording and replaying input macros
+- Asserting live node state; scenarios, stress fuzz, screenshot diffing
 - Debugging failures (crash on play, parse errors, input does nothing)
-- Using the debugger (breakpoints, stack frames, step-through)
+- The debugger: `force_break`, breakpoints, stack frames, frame variables,
+  stepping (`step_into/over/out`), expression evaluation, continue
 
 **When to use:** When testing a running game, reproducing a bug, or
 diagnosing runtime behavior.
@@ -237,18 +245,24 @@ The workflow skills (`getting-started`, `playtest-and-debug`) teach
 ```
 skills/
 ├── README.md                          # This file
-├── godot-getting-started/             # MCP workflow: bridge + toolsets + safety
-│   └── SKILL.md                       # 46 lines
-├── godot-playtest-and-debug/           # MCP workflow: runtime + debug recipe
-│   └── SKILL.md                       # 62 lines
-└── godot-expert/                       # Engine knowledge: Godot 4.x expert rules
-    ├── SKILL.md                       # 567 lines (10 sections)
+├── godot-getting-started/             # MCP workflow: version + bridge + toolsets + safety
+│   └── SKILL.md
+├── godot-playtest-and-debug/          # MCP workflow: runtime + input + debugger recipe
+│   └── SKILL.md
+└── godot-expert/                      # Engine knowledge: Godot 4.x expert rules
+    ├── SKILL.md                       # 10 sections
     └── references/                    # 7 specialized guides
-        ├── ui-hud.md                  # 170 lines
-        ├── physics-collision.md        # 138 lines
-        ├── testing-gut.md             # 203 lines
-        ├── scene-authoring.md          # 173 lines
-        ├── autoload-architecture.md   # 214 lines
-        ├── scene-templates.md          # 123 lines
-        └── common-bugs.md              # 238 lines
+        ├── ui-hud.md
+        ├── physics-collision.md
+        ├── testing-gut.md
+        ├── scene-authoring.md
+        ├── autoload-architecture.md
+        ├── scene-templates.md
+        └── common-bugs.md
 ```
+
+The skills are pinned to the server surface by
+`tests/unit/test_skills_metadata.py`: every `godot_*()` call a skill teaches
+must resolve to a registered tool, the prompt lists must cover every registered
+prompt, and the getting-started map must cover every toolset. A version bump
+that changes the surface fails the suite until the skills catch up.

--- a/skills/godot-expert/SKILL.md
+++ b/skills/godot-expert/SKILL.md
@@ -271,11 +271,11 @@ size = Vector2(28, 28)
 shape = SubResource("Rect_1")
 ```
 
-Via the bridge:
-```python
-{"command": "cmd_set_node_property",
- "params": {"node_path": "Player/Collision", "property": "shape",
-            "value": {"type": "RectangleShape2D", "size": {"x": 32, "y": 32}}}}
+Via the MCP tool (the server coerces the shape resource type):
+```
+godot_scene_edit_set_node_property(
+    node_path='Player/Collision', property='shape',
+    value={'type': 'RectangleShape2D', 'size': {'x': 32, 'y': 32}})
 ```
 
 ---
@@ -378,14 +378,13 @@ shape = SubResource("Rect_1")
 - `groups=["player"]` = the node's groups
 - `unique_id` = Godot's internal node ID (auto-generated, don't reuse)
 
-### Editing scenes
+### Editing scenes and scripts
 
-- **Via the bridge:** use `cmd_create_node`, `cmd_set_node_property`,
-  `cmd_attach_script`, `cmd_save_scene`
-- **On disk:** edit the `.tscn` directly, then reload in the editor
-- **Critical:** `cmd_write_script` updates the editor's in-memory copy but
-  does NOT flush to disk until `cmd_save_scene` or `cmd_save_all_scenes`.
-  Always save after writing.
+- **Via the MCP tools:** `godot_scene_edit_create_node`, `godot_scene_edit_set_node_property`, `godot_scene_edit_attach_script`, `godot_scene_edit_save_scene` — enable the right toolsets first (see `godot-getting-started`).
+- **On disk:** edit the `.tscn`/`.gd` file directly, then reload in the editor (`godot_scene_edit_reload_scene` or Project → Reload Current Project).
+- **Saving rules:**
+  - **Scripts** (`godot_scripts_write` / `godot_scripts_patch`) flush to disk immediately — no scene save needed. The editor picks the change up on the next script reload.
+  - **Scene edits** (create/rename/delete nodes, set properties) live in the editor's memory until you call `godot_scene_edit_save_scene()` (or `godot_scene_edit_save_all_scenes()`). Always save before running headless `godot_runtime_run_and_capture` — it runs the files on disk, not the in-memory scene.
 
 ---
 
@@ -424,63 +423,48 @@ A hardcoded `VIEW_RADIUS=12` that works at 1280x720 won't fill 1920x1080.
 
 ---
 
-## 8. MCP bridge workflow
+## 8. MCP tool workflow
 
-### Starting the bridge
+The bridge between the server and the editor is managed for you — the Godot addon connects to the MCP server's WebSocket listener automatically (enable the plugin once in Project Settings → Plugins). Agents never talk to the bridge directly; call the `godot_<toolset>_<action>` tools.
 
-```bash
-# Start the bridge listener (waits for the Godot addon to connect):
-nohup uv run python /tmp/bridge_cmd.py > /tmp/bridge.out 2>/tmp/bridge.err &
+### Session start (every session)
 
-# Verify the addon connected:
-cat /tmp/bridge.err | tail -5
-# Should show: "addon connected" and "ping ok=True"
+```
+godot_health_check()        # bridge connected? server version
+godot_get_server_info()    # toolsets + tool counts, active scene, next_steps
+godot_list_toolsets()      # what's enabled / each toolset's min Godot version
+godot_enable_toolset('scene_edit')
+godot_enable_toolset('scripts')
 ```
 
-### Sending commands
+If the bridge is offline: open the `godot/` project in Godot 4.4+ with the addon enabled — the status dock shows the connection state.
 
-The bridge reads a JSON array from `/tmp/bridge_cmds.json` and writes
-results to `/tmp/bridge_results.json`:
+### Common tool calls
 
-```python
-python3 -c "
-import json
-cmds = [
-    {'command': 'cmd_ping'},
-    {'command': 'cmd_get_project_info'},
-    {'command': 'cmd_create_node', 'params': {'parent_path': '.', 'node_type': 'CharacterBody2D', 'name': 'Player'}},
-]
-with open('/tmp/bridge_cmds.json', 'w') as f:
-    json.dump(cmds, f)
-" && sleep 3 && cat /tmp/bridge_results.json
-```
-
-### Common commands
-
-| Command | Purpose |
-|---------|---------|
-| `cmd_ping` | Liveness check |
-| `cmd_get_project_info` | Project name, path, autoloads, input actions |
-| `cmd_get_scene_tree` | Current scene tree (max_depth) |
-| `cmd_get_active_scene` | Which scene is active |
-| `cmd_create_scene` | Create a new .tscn file |
-| `cmd_open_scene` | Open a scene in the editor |
-| `cmd_create_node` | Add a node to the active scene |
-| `cmd_set_node_property` | Set a property (handles type coercion) |
-| `cmd_attach_script` | Attach a .gd script to a node |
-| `cmd_write_script` | Write/overwrite a .gd file |
-| `cmd_add_to_group` | Add a node to a group |
-| `cmd_save_scene` | Save the active scene to disk |
-| `cmd_save_all_scenes` | Save all open scenes |
-| `cmd_play_scene` | Play the scene in the editor |
-| `cmd_close_scene` | Close a scene tab (destructive, needs confirm) |
+| Tool | Purpose |
+|------|---------|
+| `godot_inspection_get_project_info()` | Project name, autoloads, input actions |
+| `godot_inspection_get_scene_tree()` | Current scene tree (max_depth) |
+| `godot_scene_edit_open_scene()` | Open a scene in the editor |
+| `godot_scene_edit_create_node()` | Add a node to the active scene |
+| `godot_scene_edit_set_node_property()` | Set a property (handles type coercion) |
+| `godot_scene_edit_attach_script()` | Attach a .gd script to a node |
+| `godot_scripts_write()` | Write/overwrite a .gd file (flushes to disk) |
+| `godot_scene_edit_add_to_group()` | Add a node to a group |
+| `godot_scene_edit_save_scene()` | Save the active scene to disk |
+| `godot_scene_edit_save_all_scenes()` | Save all open scenes |
+| `godot_runtime_play_scene()` | Play the scene in the editor |
+| `godot_runtime_run_and_capture()` | Headless run + captured errors/output |
+| `godot_scene_edit_close_scene()` | Close a scene tab (destructive, needs confirm) |
+| `godot_undo()` | Undo the last editor action (always-on core) |
 
 ### Gotchas
 
-- `cmd_write_script` updates editor memory; **always `cmd_save_scene` after**
-- Changing `project.godot` on disk requires **Project → Reload Current Project**
-- The bridge process dies if stdin closes; use the file-based bridge_cmd.py
-- `cmd_play_scene` plays the active editor scene; pass `scene_path` to be explicit
+- **Scene edits need an explicit save** (`godot_scene_edit_save_scene()`); script writes don't — they hit disk immediately
+- Changing `project.godot` on disk requires **Project → Reload Current Project** (or `godot_scene_edit_reload_scene()` for the scene)
+- `godot_runtime_run_and_capture()` runs the **files on disk** — save the scene first
+- Every mutation is undoable in the editor's undo history; `godot_undo()` steps back one action
+- Live inspection/input during play needs the `MCPRuntimeProbe` autoload in the game (see `godot-playtest-and-debug`)
 
 ---
 
@@ -540,9 +524,9 @@ func test_player_starts_with_full_health() -> void:
 - [ ] Dynamically spawned entities are children of the scene root, not the autoload
 - [ ] Full-screen overlay `Control` has `mouse_filter = IGNORE` (2)
 - [ ] Custom input actions are in `project.godot` and project was reloaded
-- [ ] All scripts parse clean: `godot --headless --check-only --script <path>`
-- [ ] GUT tests pass: `godot --headless -s addons/gut/gut_cmdln.gd -gexit`
-- [ ] Scene saved to disk: `cmd_save_scene` after any `cmd_write_script`
+- [ ] All scripts parse clean: `godot --headless --check-only --script <path>` or `godot_scripts_get_parse_errors()`
+- [ ] GUT tests pass: `godot_testing_run_tests()` or `godot --headless -s addons/gut/gut_cmdln.gd -gexit`
+- [ ] Scene saved to disk: `godot_scene_edit_save_scene()` after scene edits (scripts flush on write)
 
 ---
 

--- a/skills/godot-getting-started/SKILL.md
+++ b/skills/godot-getting-started/SKILL.md
@@ -1,43 +1,53 @@
 ---
 name: godot-getting-started
-description: Connect to and drive a Godot editor through the godot-mcp server. Use at the start of any Godot task via godot-mcp — it teaches the toolset-gating model (enable a toolset before its tools exist), the dry_run/confirm safety convention, and how to verify the bridge. Triggers on "use godot-mcp", "drive Godot", "control the Godot editor", "godot-mcp tools aren't showing up", "unknown tool from godot", "set up godot-mcp".
+description: Connect to and drive a Godot editor through the godot-mcp server. Use at the start of any Godot task via godot-mcp — it teaches the version check, the toolset-gating model (enable a toolset before its tools exist), the dry_run/confirm safety convention, and how to verify the bridge. Triggers on "use godot-mcp", "drive Godot", "control the Godot editor", "godot-mcp tools aren't showing up", "unknown tool from godot", "set up godot-mcp".
 ---
 
 # godot: getting started
 
-godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the two most common failures: missing tools and unconfirmed destructive edits.
+godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. This skill documents the **2026.08.31b3** surface — 180 tools, 29 categories. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the three most common failures: a version mismatch, missing tools, and unconfirmed destructive edits.
 
-## 1. Confirm the bridge is up
+## 1. Confirm the bridge and the version
 
 The server talks to a running Godot editor over a WebSocket bridge. If Godot isn't open with the addon enabled, every editor tool fails.
 
 ```
-godot_health_check()      # bridge connected? which URL?
-godot_get_server_info()   # toolsets, active scene, next_steps, common errors
+godot_health_check()      # bridge connected? which URL? → also returns version
+godot_get_server_info()   # version, contract_version, toolsets, active scene, next_steps
 ```
 
-If disconnected: open the `godot/` project in Godot 4.4+, enable the plugin (Project Settings → Plugins → godot_mcp), and check the status dock.
+- `godot_health_check()` returns `version` — if it isn't **2026.08.31b3**, this skill may be stale; rely on `godot_get_server_info()`'s toolset/tool inventory instead of the counts here.
+- `godot_get_server_info()` returns `contract_version` (tool-surface compatibility, currently 1) — a client is compatible when `min_compatible_contract <= yours <= contract_version`.
+- If disconnected: open the `godot/` project in Godot 4.4+ (validated on 4.7), enable the plugin (Project Settings → Plugins → godot_mcp), and check the status dock.
 
 ## 2. Toolsets are gated — enable before you use
 
-Only `core` (diagnostics/toolset management) and `inspection` (read-only reading) are on by default. **Every other capability is hidden until you enable it.** Calling a hidden tool returns `ToolError: unknown tool` — there is no fallback.
+Only `core` (always on) and `inspection` (read-only) are enabled by default. **Every other capability is hidden until you enable it.** Calling a hidden tool returns `unknown tool` — there is no fallback. Some toolsets require Godot 4.4+ (`scene_edit`, `input_map`, `tilemap`, `scene_3d`); `godot_list_toolsets()` reports `min_godot` per toolset.
 
 ```
-godot_list_toolsets()                 # what exists / what's enabled
+godot_list_toolsets()                 # what exists / what's enabled / min Godot
 godot_enable_toolset('scene_edit')    # turn on what you need, then call its tools
 ```
 
-Quick map: edit scenes → `scene_edit` · scripts → `scripts` · live play → `runtime` (+ `input`) · debug breakpoints → `debugger` (+ `runtime`) · physics → `physics` · autoloads/resources → `resources_edit` · export → `export` · many-node changes → `batch`.
+Quick map (all 28 gated toolsets):
+
+- **Scene building** — edit nodes/scenes/signals → `scene_edit` · macro edits in one round-trip → `composite` · 3D scenes (meshes, cameras, lights, GridMap) → `scene_3d` · UI themes → `theme_ui` · tilemaps → `tilemap` · particles → `particles` · navigation → `navigation` · physics → `physics` · animation → `animation` · audio buses → `audio` · shaders → `shader` · visual shader graphs → `visual_shader`
+- **Code & data** — GDScript files → `scripts` · resources (.tres) + autoloads → `resources_edit` · project files/settings/UIDs → `project` · new project skeleton → `project_scaffold`
+- **Run & verify** — headless run + output capture → `runtime` · live play-test + input sim → `input` · input actions in project settings → `input_map` · automated assertions/screenshots → `testing` · breakpoints/stepping → `debugger` · performance monitors → `profiling`
+- **Bulk & ship** — batch/cross-scene ops → `batch` · static analysis → `analysis` · export presets → `export` · import external assets → `asset_import` · editor screenshots (vision clients) → `editor`
+
+Always-on `core` extras: `godot_undo` (undo the last editor action), `godot_list_tools_by_safety_class()`, `godot_debug_workflow()` (diagnostics recipe), the toolset tools, and the two checks above.
 
 ## 3. The safety convention
 
 - **Read-only** tools never mutate — no flags needed.
 - **Mutating** tools accept `dry_run=True` — they report what *would* change and do nothing. Preview when unsure.
 - **Destructive** tools (delete/overwrite, e.g. `godot_scene_edit_delete_node`) require `confirm=True` or they refuse; they also support `dry_run`.
+- **Runtime** tools control game execution (play/stop/breakpoints) — no `dry_run`.
 
 ## 4. Use the built-in workflow prompts
 
-The server ships step-by-step recipes as MCP prompts (slash commands like `/mcp__godot-mcp__build_scene`): `toolset_discovery`, `build_scene`, `play_test`, `script_edit`, `debug_scene`, `troubleshoot`. Reach for them, or use the companion skills `godot-playtest-and-debug` and `godot-expert`.
+The server ships step-by-step recipes as MCP prompts (slash commands like `/mcp__godot-mcp__build_scene`): `toolset_discovery`, `build_scene`, `play_test`, `script_edit`, `debug_scene`, `troubleshoot`, `author_resource`, `export_build`, `batch_refactor`. Reach for them, or use the companion skills `godot-playtest-and-debug` and `godot-expert`.
 
 ## When something fails
 

--- a/skills/godot-playtest-and-debug/SKILL.md
+++ b/skills/godot-playtest-and-debug/SKILL.md
@@ -5,20 +5,27 @@ description: Run, inspect, and debug a live Godot game through the godot-mcp ser
 
 # godot: play-test and debug
 
-Drive a live game session with the `runtime`, `input`, and `testing` toolsets, and diagnose failures. Godot must be open with the addon enabled (see `godot-getting-started`). The server's `/mcp__godot-mcp__play_test`, `/mcp__godot-mcp__debug_scene`, and `/mcp__godot-mcp__troubleshoot` prompts cover the parameterized flows.
+Drive a live game session and diagnose failures. Godot must be open with the addon enabled (see `godot-getting-started`). The server's `/mcp__godot-mcp__play_test`, `/mcp__godot-mcp__debug_scene`, and `/mcp__godot-mcp__troubleshoot` prompts cover the parameterized flows.
+
+**Two run modes — pick the right one:**
+
+- **Headless smoke test** (`runtime` toolset): `godot_runtime_run_and_capture(scene='res://scenes/main.tscn', timeout_seconds=5)` runs the project headless (no editor play session, no probe needed) and returns `errors`/`warnings`/`output` + exit code. Use it to answer "does it run at all".
+- **Live play session** (`runtime` + `input` + `testing` + `debugger` toolsets): everything below — interactive inspection, input simulation, assertions, breakpoints. This needs the runtime probe.
 
 ## 1. Enable the toolsets
 
 ```
-godot_enable_toolset('runtime')
-godot_enable_toolset('input')
-godot_enable_toolset('testing')
-godot_enable_toolset('resources_edit')   # to register the runtime probe if needed
+godot_enable_toolset('runtime')         # play/stop/is_playing, run_and_capture
+godot_enable_toolset('input')           # key/mouse/action input, sequences, recording
+godot_enable_toolset('testing')         # assertions, scenarios, screenshots, stress
+godot_enable_toolset('debugger')        # breakpoints, stepping, expressions
+godot_enable_toolset('resources_edit')  # to register the runtime probe if needed
+godot_enable_toolset('profiling')       # optional: FPS/draw calls/memory while running
 ```
 
 ## 2. Make sure the runtime probe is registered
 
-Live inspection/input needs the `MCPRuntimeProbe` autoload.
+Live inspection and input need the `MCPRuntimeProbe` autoload **in the consuming game's project** (it runs in the game, not the editor, and no-ops in exported builds).
 
 ```
 godot_inspection_get_project_info()        # check autoloads for 'MCPRuntimeProbe'
@@ -32,9 +39,10 @@ godot_resources_edit_register_autoload(
 ```
 godot_runtime_play_scene(scene_path='res://scenes/main.tscn')
 godot_runtime_is_playing()                 # → {'playing': true}
-godot_runtime_get_game_scene_tree()        # the live hierarchy
+godot_runtime_get_game_scene_tree()        # the LIVE hierarchy (not the editor tree)
 godot_runtime_monitor_property(node_path='/root/Main/Player', property='position', samples=30)
-godot_runtime_get_property_samples()        # collect the sampled values
+godot_runtime_get_property_samples()       # [{frame, value}] once the capture completes
+godot_runtime_find_ui_elements(text='Start')  # locate a Control by its text
 ```
 
 ## 4. Simulate input
@@ -43,20 +51,32 @@ godot_runtime_get_property_samples()        # collect the sampled values
 godot_input_simulate_action(action='ui_right', pressed=true)   # hold
 godot_input_simulate_action(action='ui_right', pressed=false)  # release
 godot_input_simulate_key(key='Space', pressed=true)
-godot_input_play_sequence(events=[...], delay_ms=100)          # replay a macro
+godot_input_simulate_mouse(x=200, y=150, button='left')        # move / click
+godot_input_play_sequence(events=[...], delay_ms=100)          # replay a recorded macro
+godot_input_record()                       # start capturing (include_motion=false)
+godot_input_stop_recording()               # → captured events: feed them to play_sequence
+godot_input_get_stats()                    # how many events the game acknowledged
 ```
 
-## 5. Assert state, then stop
+## 5. Assert, measure, then stop
 
 ```
-godot_testing_assert_node_state(node_path='/root/Main/Player', property='visible', expected=true)
+godot_testing_assert_node_state(node_path='/root/Main/Player', property='visible', expected=true)   # op='==' default; also '>=','<=' etc.
+godot_testing_run_test_scenario(scene_path='res://scenes/main.tscn', events=[...],
+                                 assertions=[{'node_path': '...', 'property': '...', 'expected': ...}])
+godot_testing_run_stress_test()                        # fuzz with random input
+godot_testing_compare_screenshots(image_a='<base64>', image_b='<base64>', tolerance=0.0)
+godot_profiling_get_performance_monitors(scope='game')  # FPS, draw calls, memory
 godot_runtime_stop_scene()
 ```
+
+`godot_editor_capture_screenshot()` (the `editor` toolset) provides base64 PNGs for the diff tool.
 
 ## Debugging failures
 
 - **Crash on play** → `godot_runtime_run_and_capture(scene='res://scenes/main.tscn', timeout_seconds=5)`, then read `errors`/`warnings` (null refs, missing nodes, bad signal connections).
 - **Script won't parse** → `godot_scripts_get_parse_errors(script_path='res://scripts/x.gd')`, fix the reported line/column.
-- **Input does nothing** → confirm `godot_runtime_is_playing()` is true and the probe autoload is present (step 2).
-- **Step through code** → enable `debugger` + `runtime`, set a breakpoint, inspect the stack.
+- **Input does nothing** → confirm `godot_runtime_is_playing()` is true and the probe autoload is present (step 2); check a full-screen overlay isn't eating input (`mouse_filter`).
+- **Break and step through code** → pause on the spot with `godot_debugger_force_break()`, or pre-arm `godot_debugger_set_breakpoint(path='res://scripts/player.gd', line=42)`. Then read `godot_debugger_get_stack_frames()`, `godot_debugger_get_frame_variables()`, `godot_debugger_evaluate_expression(expression='player.health')`, and step with `godot_debugger_step_into()` / `godot_debugger_step_over()` / `godot_debugger_step_out()`. Resume with `godot_debugger_continue_execution()`. Clean up with `godot_debugger_remove_breakpoint(path=..., line=...)` or `godot_debugger_clear_breakpoints()`.
+  - Note: `force_break` only lands if the game's main loop calls `check_force_break()` (the probe sets `force_break_pending`); breakpoints trigger on their own line.
 - Stuck? Run `godot_get_server_info()` and follow `next_steps`, or use the `troubleshoot` prompt.

--- a/tests/unit/test_skills_metadata.py
+++ b/tests/unit/test_skills_metadata.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+from mcp_server import __version__
 from mcp_server.server import create_server, register_tool_transform
 from tests.helpers import list_all_tools
 
@@ -103,3 +104,90 @@ def test_skill_tool_references_exist() -> None:
         if missing:
             unknown[skill.name] = missing
     assert not unknown, f"Skills reference unknown tools: {unknown}"
+
+
+# -- Drift guards (issue #381): skills stay in lockstep with the live surface --
+
+
+def _body(skill_name: str) -> str:
+    text = (SKILLS_DIR / skill_name / "SKILL.md").read_text(encoding="utf-8")
+    return text[text.find("\n---", 3) + 4 :]
+
+
+async def _toolsets() -> set[str]:
+    from mcp_server.toolsets import TOOLSETS
+
+    return set(TOOLSETS)
+
+
+async def _prompt_names() -> set[str]:
+    server: Any = create_server()
+    names = {p.name for p in await server.local_provider.list_prompts()}
+    return names
+
+
+def test_getting_started_map_covers_every_toolset() -> None:
+    """The quick-map names every gated toolset — a stale map teaches the agent
+    to hunt for tools that were renamed or added since the skill was written."""
+    body = _body("godot-getting-started")
+    for toolset in sorted(asyncio.run(_toolsets())):
+        assert toolset in body, (
+            f"getting-started quick-map is missing the '{toolset}' toolset"
+        )
+
+
+def test_skill_prompt_lists_cover_registered_prompts() -> None:
+    """Every registered MCP prompt is named in a workflow skill — agents reach
+    for the canned recipes; a prompt missing from the skills is one they never
+    discover."""
+    combined = _body("godot-getting-started") + _body("godot-playtest-and-debug")
+    prompts = asyncio.run(_prompt_names())
+    missing = {p for p in prompts if p not in combined}
+    assert not missing, f"Skills never mention these registered prompts: {missing}"
+
+
+def test_getting_started_states_current_version_and_check() -> None:
+    """The skill tells the agent which version this surface documents and how to
+    verify the server it talks to matches (health_check → version)."""
+    body = _body("godot-getting-started")
+    assert __version__ in body, (
+        f"getting-started must name the current server version {__version__}"
+    )
+    assert "godot_health_check(" in body, (
+        "getting-started must show the version check via godot_health_check()"
+    )
+
+
+def test_playtest_skill_names_debugger_tools() -> None:
+    """The debugger recipe names the real breakpoint/stepping tools instead of
+    a vague 'set a breakpoint'."""
+    body = _body("godot-playtest-and-debug")
+    for tool in (
+        "godot_debugger_set_breakpoint(",
+        "godot_debugger_force_break(",
+        "godot_debugger_get_stack_frames(",
+    ):
+        assert tool in body, f"playtest-and-debug must show {tool}"
+
+
+def test_expert_skill_has_no_raw_bridge_workflow() -> None:
+    """§8 predates the MCP server: the /tmp/bridge_cmd.py raw-bridge workflow is
+    obsolete — agents call godot_* tools, never the bridge files."""
+    body = _body("godot-expert")
+    assert "bridge_cmd.py" not in body, (
+        "godot-expert still teaches the obsolete raw-bridge bridge_cmd.py workflow"
+    )
+
+
+def test_expert_skill_script_save_claim_is_accurate() -> None:
+    """The handler writes scripts to disk immediately (FileAccess in the
+    UndoRedo do-method); only unsaved *scene edits* need save_scene. The old
+    'write_script does not flush to disk' claim was wrong."""
+    body = _body("godot-expert")
+    assert "write_script" not in body and "cmd_write_script" not in body, (
+        "godot-expert must not claim write_script/cd_write_script skips the disk"
+    )
+    # The corrected rule must still teach that scene edits need an explicit save.
+    assert "godot_scene_edit_save_scene(" in body or "save_scene" in body, (
+        "godot-expert must teach save_scene for scene edits"
+    )


### PR DESCRIPTION
### **User description**
## Summary

The shipped skills had drifted from the current surface (2026.08.31b3 — 180 tools, 29 categories, 9 prompts). This syncs them and — more importantly — adds **drift guards** so the next surface change fails the suite until the skills catch up.

## Changes

**`godot-getting-started`**
- New step 1: version awareness — `godot_health_check()` → `version`, `godot_get_server_info()` → `contract_version` (compat range), with the current version stated inline
- Toolset quick-map now covers **all 28 gated toolsets** (was 11), grouped by job; `min_godot` note for the 4.4+ toolsets
- Prompt list covers all 9 registered prompts (`author_resource`, `export_build`, `batch_refactor` added)
- Always-on core extras documented: `godot_undo`, `godot_list_tools_by_safety_class()`, `godot_debug_workflow()`
- `runtime` safety class added to the safety convention

**`godot-playtest-and-debug`**
- New "two run modes" section: headless `godot_runtime_run_and_capture()` (no probe) vs. the live play-session rails
- Debugger recipe names the real tools: `force_break`, `set_breakpoint`, `get_stack_frames`, `get_frame_variables`, `evaluate_expression`, `step_into/over/out`, `continue_execution`, `remove_breakpoint`, `clear_breakpoints` — plus the `check_force_break()` caveat
- Added tools: `find_ui_elements`, `simulate_mouse`, `input_record`/`stop_recording` → `play_input_sequence` macro replay, `get_stats`, `run_test_scenario`, `run_stress_test`, `compare_screenshots`, `profiling_get_performance_monitors`

**`godot-expert`**
- §8 rewritten for the MCP-tool era — drops the obsolete raw-bridge `/tmp/bridge_cmd.py` + JSON-file workflow; session-start recipe + common-tools table now use `godot_*` tools
- **Factual fix:** removed the false claim that `write_script`/`cmd_write_script` doesn't flush to disk (the UndoRedo `_write_file_text` handler writes via `FileAccess` immediately). Corrected rule: scripts flush on write; only **scene edits** need `save_scene` (and headless `run_and_capture` runs disk state). Checklist fixed accordingly
- `cmd_set_node_property` raw-bridge example → `godot_scene_edit_set_node_property`

**`skills/README.md`** — version header (how to check the live server version), refreshed summaries, dropped the rot-prone line-count table in favor of the test-pin note

**Drift guards** (`tests/unit/test_skills_metadata.py`, red-first — 6 failing tests before the skill edits, green after):
- every `godot_*()` call a skill teaches must resolve to a registered tool (pre-existing)
- prompt lists must cover every registered prompt
- the getting-started map must cover every gated toolset
- getting-started must state the current version **in lockstep with `mcp_server.__version__`** — a version bump now fails the suite until the skill catches up
- playtest skill must name the real debugger tools
- expert skill must not teach the raw-bridge workflow nor the write_script claim

## Test plan

- [x] 6 new drift tests red before the skill rewrites, green after (evidence in the commit sequence)
- [x] `uv run pytest -q` → **671 passed, 0 skipped**
- [x] `uv run ruff check .` / `uv run mypy` / zero-skip gate → clean

Closes #381


___

### **PR Type**
Documentation, Tests


___

### **Description**
- No public API changes; tests fail on drift

- Sync skills to 2026.08.31b3 surface

- Add drift-guard tests for skills

- Fix script save factual error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Skills"] -- "sync to surface" --> B["getting-started"]
  A -- "run modes + debugger" --> C["playtest-and-debug"]
  A -- "MCP workflow + save fix" --> D["godot-expert"]
  E["Drift tests"] -- "fail on surface drift" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_skills_metadata.py</strong><dd><code>Add skill surface drift guard tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_skills_metadata.py

<ul><li>Adds drift-guard tests pinning skills to the live server surface.<br> <li> Checks toolset coverage, prompt names, version, and debugger tools.<br> <li> Asserts expert skill drops raw bridge workflow and script save claim.<br> <li> Imports server version for lockstep validation.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/382/files#diff-148034ce3818b396ba3d1b82d3dbe03e6a29886ff085b1a02d22275f5c97fc36">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update skills README for current surface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/README.md

<ul><li>Updates skill summaries for version checks, run modes, and debugger <br>tools.<br> <li> States the documented surface version and prompt/toolset counts.<br> <li> Removes the rot-prone line-count table and adds a test pin note.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/382/files#diff-4d647326e823e7202ff18d96504599a2f17893ead7e40499f82899106dbad2c7">+37/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Rewrite expert skill for MCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-expert/SKILL.md

<ul><li>Rewrites section 8 from raw bridge workflow to MCP tool calls.<br> <li> Corrects script save behavior: scripts flush immediately; scene edits <br>need save.<br> <li> Replaces cmd_* examples with godot_* tools and updates gotchas.<br> <li> Updates checklist to use MCP tools for parse errors and saves.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/382/files#diff-a83af1b709fd17ca32465ae4631478300926bde34db868bff9409509fb9982f5">+51/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Add version and full toolset map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-getting-started/SKILL.md

<ul><li>Adds version-awareness step using health check and server info.<br> <li> Expands toolset quick-map to all 28 gated toolsets plus core extras.<br> <li> Lists all registered workflow prompts and runtime safety class.<br> <li> Documents min Godot requirements and compatibility contract.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/382/files#diff-2e76fc71066ad43d91d7382c6f64f051cfc58f8eba73b4f43c709690e242615f">+21/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Expand playtest and debug skill coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-playtest-and-debug/SKILL.md

<ul><li>Distinguishes headless run_and_capture from live probe play session.<br> <li> Names real debugger tools for breakpoints, stepping, expressions, <br>resume.<br> <li> Adds UI finding, mouse input, input recording/replay, stats.<br> <li> Documents testing scenarios, stress, screenshot diff, profiling <br>monitors.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/382/files#diff-d50079596d627c10c479101c8cfa3620f6bb009232a8d1fa89d6bcc0e2a87eb4">+34/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

