### PR TITLE
Declare tool outputSchema and emit structuredContent

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -86,6 +86,27 @@ Every tool is tagged with exactly one:
   `mutating`/`runtime` → `read_only_hint=false, destructive_hint=false`. An annotation set
   explicitly at registration is preserved.
 
+### outputSchema / structuredContent (issue #385)
+
+Every JSON-result tool declares a **standard `outputSchema`** (JSON Schema 2020-12) and
+returns **`structuredContent`** alongside the text content — FastMCP 4.0 derives both
+from the tool's Pydantic return annotation automatically, so the rule is simply:
+
+- **Return a typed Pydantic model** from every tool handler; the schema and the
+  structured emission follow from the annotation. Never return a raw `dict`.
+- The text content remains the faithful JSON serialization of the same object
+  (the serialized fallback per spec) — text-parsing clients see identical data.
+- The one exception is `godot_editor_capture_screenshot`: it returns
+  `ImageContent` (non-JSON), so it declares no schema and no `structuredContent`.
+- A `@model_serializer` on the result model hides fields from pydantic's
+  serialization-mode schema generation (the auto-derived schema degenerates to
+  `{additionalProperties: true}`). When a model needs one, declare the
+  validation-mode schema explicitly:
+  `@mcp.tool(..., output_schema=Model.model_json_schema())` — see `godot_undo`.
+- `tests/contract/test_output_schema.py` pins the contract in both directions:
+  the emitted `structuredContent` validates against the declared schema, and no
+  tool on the surface (image tool aside) ships a degenerate schema.
+
 ### Human-in-the-loop approval (issue #153, centralized via middleware #330)
 
 An optional webhook gates `destructive` tools behind a human decision. It is **opt-in**:

--- a/mcp_server/tools/undo.py
+++ b/mcp_server/tools/undo.py
@@ -13,7 +13,17 @@ from mcp_server.tools._route import route
 
 
 def register_undo(mcp: FastMCP, bridge: Bridge) -> None:
-    @mcp.tool(meta=MUTATING, tags={CORE_TAG})
+    # UndoResult drops mode-irrelevant None fields via a @model_serializer, which
+    # hides its fields from pydantic's serialization-mode schema generation (issue
+    # #385) — FastMCP's auto-derived outputSchema degenerates to
+    # {additionalProperties: true}. Declare the validation-mode (field-derived)
+    # schema explicitly: both emission shapes (real undo, dry-run preview) are
+    # subsets of it, so clients can type-check either.
+    @mcp.tool(
+        meta=MUTATING,
+        tags={CORE_TAG},
+        output_schema=UndoResult.model_json_schema(),
+    )
     async def undo(count: int = 1, dry_run: bool = False) -> UndoResult:
         """Undo the last ``count`` editor actions on the current scene's history.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dev = [
     "pytest-asyncio>=1.4",
     "mypy>=2.1",
     "ruff>=0.15",
+    "jsonschema>=4.26.0",
+    "types-jsonschema>=4.26.0.20260518",
 ]
 
 [build-system]

--- a/tests/contract/test_output_schema.py
+++ b/tests/contract/test_output_schema.py
@@ -120,6 +120,17 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 },
             )
         case "cmd_undo":
+            if p.get("dry_run"):
+                # Preview shape: has_undo / would_undo_next, no undo performed.
+                return ResponseEnvelope.success(
+                    cmd.id,
+                    {
+                        "dry_run": True,
+                        "requested": p.get("count", 1),
+                        "has_undo": True,
+                        "would_undo_next": "Create Node",
+                    },
+                )
             return ResponseEnvelope.success(
                 cmd.id,
                 {"undone": 1, "requested": p.get("count", 1), "last_action": "Create Node"},
@@ -190,21 +201,25 @@ async def test_high_traffic_tools_emit_schema_consistent_structured_content() ->
     object, so text-parsing clients (godot-agents' MCPResult today) are
     unbroken and see identical data.
     """
-    calls: dict[str, dict[str, Any]] = {
-        "godot_inspection_get_project_info": {},
-        "godot_inspection_get_scene_tree": {"max_depth": 2},
-        "godot_inspection_get_node_properties": {"node_path": "Player"},
-        "godot_scripts_list": {},
-        "godot_scripts_get_for_node": {},
-        "godot_runtime_run_and_capture": {},
-        "godot_undo": {},
-    }
+    calls: list[tuple[str, dict[str, Any]]] = [
+        ("godot_inspection_get_project_info", {}),
+        ("godot_inspection_get_scene_tree", {"max_depth": 2}),
+        ("godot_inspection_get_node_properties", {"node_path": "Player"}),
+        ("godot_scripts_list", {}),
+        ("godot_scripts_get_for_node", {}),
+        ("godot_runtime_run_and_capture", {}),
+        # Both of godot_undo's emission shapes must validate against the one
+        # declared schema (PR review): the dry-run preview drops the real-undo
+        # fields and emits has_undo / would_undo_next instead.
+        ("godot_undo", {}),
+        ("godot_undo", {"dry_run": True}),
+    ]
     server = await _build()
     async with Client(server) as client:
         for category in ("scripts", "runtime"):
             await client.call_tool("godot_enable_toolset", {"category": category})
         tools = {t.name: t for t in await client.list_tools()}
-        for name, args in calls.items():
+        for name, args in calls:
             tool = tools[name]
             assert tool.output_schema is not None, f"{name} declares no outputSchema"
             result = await client.call_tool(name, args)
@@ -220,10 +235,23 @@ async def test_high_traffic_tools_emit_schema_consistent_structured_content() ->
             assert json.loads(text) == result.structured_content, f"{name}: text/structured drift"
 
 
-def _loads(text: str) -> Any:
-    import json
+async def test_undo_dry_run_emits_the_preview_shape() -> None:
+    """The dry-run preview's field set differs from the real undo's (Qodo #387).
 
-    return json.loads(text)
+    Guards the serializer's mode split: the preview carries has_undo /
+    would_undo_next and omits the real-undo fields (and vice versa), proving
+    the consistency test above really exercised two distinct shapes.
+    """
+    server = await _build()
+    async with Client(server) as client:
+        real = await client.call_tool("godot_undo", {"count": 1})
+        preview = await client.call_tool("godot_undo", {"dry_run": True})
+    real_sc, preview_sc = real.structured_content, preview.structured_content
+    assert preview_sc["dry_run"] is True and preview_sc["has_undo"] is True
+    assert "would_undo_next" in preview_sc
+    assert "undone" not in preview_sc and "last_action" not in preview_sc
+    assert real_sc["dry_run"] is False and "undone" in real_sc
+    assert "has_undo" not in real_sc
 
 
 async def test_image_tool_emits_content_without_structured_content() -> None:

--- a/tests/contract/test_output_schema.py
+++ b/tests/contract/test_output_schema.py
@@ -1,0 +1,248 @@
+"""Contract tests for ``outputSchema`` / ``structuredContent`` (issue #385).
+
+The MCP 2025-11-25 spec lets a tool declare an ``outputSchema`` (JSON Schema
+2020-12) and return ``structuredContent`` — machine-parsed JSON — with the
+text content kept as a serialized fallback. FastMCP 4.0 auto-derives both from
+the Pydantic return annotation, so the contract here pins three things:
+
+1. **Declaration**: every tool declares a non-degenerate ``outputSchema`` —
+   one exception, the editor screenshot tool, returns ``ImageContent`` (non-JSON
+   content gets no ``structuredContent`` per spec, so no schema is correct).
+2. **Consistency, both directions** (spec best practice): for the high-traffic
+   tools, the emitted ``structuredContent`` *validates* against the declared
+   schema, and the text fallback is the faithful JSON serialization of the same
+   object — existing clients that parse text stay unbroken.
+3. **No regressions from tool transforms**: schemas must survive the
+   ``godot_`` renaming transform and toolset gating (checked implicitly — the
+   client-facing names below are the post-transform public names).
+
+A degenerate schema — ``{type: object, additionalProperties: true}`` with no
+``properties`` — is useless to a client and fails assertion 1. ``godot_undo``
+degenerated exactly this way (its ``@model_serializer`` hides fields from
+pydantic's serialization-mode schema generation), which is why it is fixed via
+an explicit ``output_schema=UndoResult.model_json_schema()``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.server.providers.base import Provider
+from jsonschema import Draft202012Validator
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.runtime import RunOutput
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+# The one tool whose content is an image, not JSON: the spec says structured
+# content applies to JSON results, so this tool correctly declares no schema.
+# Keyed by the original handler name — Provider.list_tools (all tools, gated
+# included) yields pre-transform names; the public client name is
+# godot_editor_capture_screenshot.
+IMAGE_TOOLS = {"capture_editor_screenshot"}
+
+
+def image_responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    if cmd.command == "cmd_capture_editor_screenshot":
+        png = base64.b64encode(b"\x89PNG-fake").decode()
+        return ResponseEnvelope.success(cmd.id, {"base64": png, "format": "image/png"})
+    return None
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    """Canned addon answers for the high-traffic tools' bridge commands."""
+    p = cmd.params
+    match cmd.command:
+        case "cmd_get_project_info":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "name": "demo",
+                    "godot_version": "4.7",
+                    "main_scene": "res://main.tscn",
+                    "autoloads": {"Game": "res://game.gd"},
+                    "input_actions": ["jump"],
+                },
+            )
+        case "cmd_get_scene_tree":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "tree": {
+                        "name": "Main",
+                        "type": "Node2D",
+                        "path": ".",
+                        "script": None,
+                        "children": [
+                            {
+                                "name": "Player",
+                                "type": "CharacterBody2D",
+                                "path": "Player",
+                                "script": None,
+                                "children": [],
+                            }
+                        ],
+                    }
+                },
+            )
+        case "cmd_get_node_properties":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "type": "Sprite2D",
+                    "script": "res://player.gd",
+                    "properties": {"speed": 200.0},
+                    "children": ["Sprite2D"],
+                },
+            )
+        case "cmd_list_scripts":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"directory": p.get("directory", "res://"), "scripts": ["res://a.gd"]},
+            )
+        case "cmd_get_script_for_node":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": p.get("node_path") or "",
+                    "script_path": "res://player.gd",
+                    "content": "extends Node\n",
+                },
+            )
+        case "cmd_undo":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"undone": 1, "requested": p.get("count", 1), "last_action": "Create Node"},
+            )
+    return None  # bootstrap commands (cmd_ping/…) auto-answered by the fake
+
+
+class _FakeRunner:
+    """Runner double for godot_runtime_run_and_capture (no real Godot)."""
+
+    binary: str | None = "fake-godot"
+
+    async def run(
+        self, project_dir: str, scene: str | None, timeout: float
+    ) -> RunOutput:
+        return RunOutput(command=["fake"], exit_code=0, stdout="hello\n", stderr="")
+
+    async def check_script(
+        self, project_dir: str, script_path: str, timeout: float
+    ) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def export(
+        self, project_dir: str, preset: str, output_path: str, debug: bool, timeout: float
+    ) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+    async def run_tests(
+        self, project_dir: str, test_dir: str, timeout: float
+    ) -> RunOutput:
+        return RunOutput(command=["fake"])
+
+
+async def _build() -> FastMCP:
+    conn = FakeAddonConnection(responder=_responder)
+    config = ServerConfig(godot_project_dir="/tmp/proj")
+    bridge = Bridge(config.bridge, connector=connector_for(conn))
+    return create_server(config, bridge=bridge, runner=_FakeRunner())
+
+
+async def test_every_tool_declares_a_non_degenerate_output_schema() -> None:
+    """Whole surface (180 tools, gated included) declares a useful schema.
+
+    A schema with no ``properties`` (e.g. bare ``{additionalProperties: true}``)
+    is degenerate: a client can't type-check the result. The one allowed
+    exception is the image-capture tool — non-JSON content, spec-correct
+    without a schema.
+    """
+    server = await _build()
+    tools = await Provider.list_tools(server)
+    assert tools, "no tools registered"
+
+    offenders: list[str] = []
+    for tool in tools:
+        if tool.name in IMAGE_TOOLS:
+            assert tool.output_schema is None, (
+                f"{tool.name} returns ImageContent — it must not declare a schema"
+            )
+            continue
+        schema = tool.output_schema
+        if schema is None:
+            offenders.append(f"{tool.name}: no outputSchema")
+        elif not isinstance(schema.get("properties"), dict) or not schema["properties"]:
+            offenders.append(f"{tool.name}: degenerate schema {schema}")
+    assert not offenders, "\n".join(sorted(offenders))
+
+
+async def test_high_traffic_tools_emit_schema_consistent_structured_content() -> None:
+    """Both directions, per the issue's acceptance criteria.
+
+    Direction one: the emitted ``structuredContent`` validates against the
+    declared ``outputSchema`` (Draft 2020-12 — the version the spec names).
+    Direction two: the text fallback is the faithful serialization of the same
+    object, so text-parsing clients (godot-agents' MCPResult today) are
+    unbroken and see identical data.
+    """
+    calls: dict[str, dict[str, Any]] = {
+        "godot_inspection_get_project_info": {},
+        "godot_inspection_get_scene_tree": {"max_depth": 2},
+        "godot_inspection_get_node_properties": {"node_path": "Player"},
+        "godot_scripts_list": {},
+        "godot_scripts_get_for_node": {},
+        "godot_runtime_run_and_capture": {},
+        "godot_undo": {},
+    }
+    server = await _build()
+    async with Client(server) as client:
+        for category in ("scripts", "runtime"):
+            await client.call_tool("godot_enable_toolset", {"category": category})
+        tools = {t.name: t for t in await client.list_tools()}
+        for name, args in calls.items():
+            tool = tools[name]
+            assert tool.output_schema is not None, f"{name} declares no outputSchema"
+            result = await client.call_tool(name, args)
+            # Direction one: schema validates the structured content.
+            assert result.structured_content is not None, f"{name} emitted no structuredContent"
+            errors = sorted(
+                Draft202012Validator(tool.output_schema).iter_errors(
+                    result.structured_content
+                ),
+                key=str,
+            )
+            assert not errors, f"{name}: " + "; ".join(e.message for e in errors)
+            # Direction two: text is the faithful fallback of the same object.
+            text = result.content[0].text
+            assert json.loads(text) == result.structured_content, f"{name}: text/structured drift"
+
+
+def _loads(text: str) -> Any:
+    import json
+
+    return json.loads(text)
+
+
+async def test_image_tool_emits_content_without_structured_content() -> None:
+    """The spec exception: an image result carries ImageContent, no JSON."""
+    conn = FakeAddonConnection(responder=image_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "editor"})
+        result = await client.call_tool("godot_editor_capture_screenshot", {})
+    assert result.structured_content is None
+    types = [type(c).__name__ for c in result.content]
+    assert "ImageContent" in types, f"expected image content, got {types}"

--- a/tests/contract/test_output_schema.py
+++ b/tests/contract/test_output_schema.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -133,14 +132,10 @@ class _FakeRunner:
 
     binary: str | None = "fake-godot"
 
-    async def run(
-        self, project_dir: str, scene: str | None, timeout: float
-    ) -> RunOutput:
+    async def run(self, project_dir: str, scene: str | None, timeout: float) -> RunOutput:
         return RunOutput(command=["fake"], exit_code=0, stdout="hello\n", stderr="")
 
-    async def check_script(
-        self, project_dir: str, script_path: str, timeout: float
-    ) -> RunOutput:
+    async def check_script(self, project_dir: str, script_path: str, timeout: float) -> RunOutput:
         return RunOutput(command=["fake"])
 
     async def export(
@@ -148,9 +143,7 @@ class _FakeRunner:
     ) -> RunOutput:
         return RunOutput(command=["fake"])
 
-    async def run_tests(
-        self, project_dir: str, test_dir: str, timeout: float
-    ) -> RunOutput:
+    async def run_tests(self, project_dir: str, test_dir: str, timeout: float) -> RunOutput:
         return RunOutput(command=["fake"])
 
 
@@ -218,9 +211,7 @@ async def test_high_traffic_tools_emit_schema_consistent_structured_content() ->
             # Direction one: schema validates the structured content.
             assert result.structured_content is not None, f"{name} emitted no structuredContent"
             errors = sorted(
-                Draft202012Validator(tool.output_schema).iter_errors(
-                    result.structured_content
-                ),
+                Draft202012Validator(tool.output_schema).iter_errors(result.structured_content),
                 key=str,
             )
             assert not errors, f"{name}: " + "; ".join(e.message for e in errors)

--- a/uv.lock
+++ b/uv.lock
@@ -580,10 +580,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -597,10 +599,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "mypy", specifier = ">=2.1" },
     { name = "pytest", specifier = ">=9.1" },
     { name = "pytest-asyncio", specifier = ">=1.4" },
     { name = "ruff", specifier = ">=0.15" },
+    { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
 ]
 
 [[package]]
@@ -1797,6 +1801,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **User description**
## Summary

Implements the MCP 2025-11-25/2026-07-28 spec best practice from #385: every JSON-result tool declares a standard `outputSchema` (JSON Schema 2020-12) and emits `structuredContent`, with the text content kept as the faithful serialized fallback.

**Verified live on the pinned FastMCP 4.0.0b3** rather than assumed: schema and structured emission auto-derive from the Pydantic return annotation, and survive the `godot_` naming transform + toolset gating. A whole-surface scan found exactly **one real gap** — `godot_undo`:

- `UndoResult` drops mode-irrelevant `None` fields via `@model_serializer`, which hides its fields from pydantic's serialization-mode schema generation — the auto-derived schema degenerated to `{additionalProperties: true}` (useless to clients).
- Fix: declare the validation-mode (field-derived) schema explicitly: `output_schema=UndoResult.model_json_schema()`. Both emission shapes (real undo, dry-run preview) validate against it.
- `godot_editor_capture_screenshot` is the spec-correct exception: `ImageContent` is non-JSON content, so it declares no schema and emits no `structuredContent`.

## Acceptance criteria (#385)

- [x] High-traffic tools declare `outputSchema` and return validating `structuredContent` — get_scene_tree, get_node_properties, list_scripts, get_script_for_node, get_project_info, run_and_capture (+ undo)
- [x] Text fallback unchanged (existing clients unbroken) — asserted `json.loads(text) == structuredContent` per tool
- [x] Tool-contract test asserts schema↔structuredContent consistency (both directions) — `tests/contract/test_output_schema.py`, incl. a whole-surface degenerate-schema guard over all 180 tools
- [x] godot-agents follow-up noted: prefer `structuredContent` in `MCPResult` when present (client-side change, belongs there)

## Notes for reviewers

- The issue's premise ("we declare no outputSchema") predates the FastMCP 4.0 auto-derive — the real work was verifying it end-to-end, finding the serializer-degenerate `godot_undo` case, and pinning the contract so it can't regress
- Dev deps: `jsonschema` (Draft 2020-12 validation in tests) + `types-jsonschema` (mypy stubs)
- `docs/tool-contracts.md` gains an "outputSchema / structuredContent" section documenting the rules (typed return models, serializer caveat, image exception)

## Test plan

- [x] Red-first: whole-surface test failed only on `undo: degenerate schema` before the fix
- [x] Full suite green: 643 passed
- [x] `ruff check` / `mypy` / zero-skip scan clean
- [x] Graphify refreshed; god nodes unchanged (Bridge/route/create_server core intact)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Declare `outputSchema` for JSON tools

- Emit `structuredContent` with text fallback

- Fix `godot_undo` schema degeneration

- Add contract tests and docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tool handlers"] -- "Pydantic return annotation" --> B["FastMCP outputSchema"]
  B -- "structuredContent" --> C["MCP clients"]
  D["UndoResult serializer"] -- "explicit schema" --> B
  E["Contract tests"] -- "validate schema and content" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>undo.py</strong><dd><code>Declare explicit undo output schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/undo.py

<ul><li>Adds explicit <code>output_schema=UndoResult.model_json_schema()</code> to the <code>undo</code> <br>tool.<br> <li> Prevents the auto-derived schema from degenerating because of <br><code>@model_serializer</code>.<br> <li> Keeps both real undo and dry-run preview results schema-valid.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/387/files#diff-1cdfb81f3c8aa8f80638149212b1cbc3fe436be79ef00229b6dc8abf9b739f59">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_output_schema.py</strong><dd><code>Add output schema contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_output_schema.py

<ul><li>Adds contract tests for <code>outputSchema</code> and <code>structuredContent</code> behavior.<br> <li> Asserts every non-image tool declares a non-degenerate schema.<br> <li> Validates high-traffic tool structured content against Draft 2020-12 <br>schemas.<br> <li> Pins text fallback equality and the image tool exception.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/387/files#diff-5d4a2f0168e0b9392a53dd6c0be634a7f1d7af79cc4f86ff270f316a7f535105">+239/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document outputSchema and structuredContent contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Documents the <code>outputSchema</code> / <code>structuredContent</code> tool contract.<br> <li> Requires typed Pydantic returns and preserves the text fallback.<br> <li> Notes <code>godot_editor_capture_screenshot</code> as the image exception.<br> <li> Explains the explicit schema workaround for serializer-hidden fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/387/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add JSON schema test dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Adds <code>jsonschema</code> and <code>types-jsonschema</code> to dev dependencies.<br> <li> Enables Draft 2020-12 validation in contract tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/387/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

