### PR TITLE
MCP 2026-07-28 sessionless migration plan and invariant guard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,9 @@ This document is the contract for the seam between the two halves of godot-mcp. 
 authoritative for the **transport** and the **JSON envelope**; the tool/resource/prompt
 surface is specified in [`tool-contracts.md`](tool-contracts.md). The grounding rules in
 [`../.opencode/rules/`](../.opencode/rules/) govern *how* code on each side is written.
+The server is sessionless by design (MCP 2026-07-28 shape, issue #386); the spec-migration
+plan and the session-affinity inventory live in
+[`mcp-2026-07-28-migration.md`](mcp-2026-07-28-migration.md).
 
 > Status: the bridge is implemented (issue #3) with the connection direction inverted
 > (#276): the **server listens, the editor connects out**. Server side:

--- a/docs/mcp-2026-07-28-migration.md
+++ b/docs/mcp-2026-07-28-migration.md
@@ -1,0 +1,113 @@
+# MCP 2026-07-28 Migration Plan
+
+> Tracking issue: [#386](https://github.com/hybridindie/godot-mcp/issues/386) ·
+> Status: **planned** — no implementation work is gated on this document.
+> Related: godot-agents client follow-up (see §5), pinned FastMCP `4.0.0b3` (#311).
+
+## 1. What the spec changed
+
+The MCP spec's **2026-07-28 revision** removes sessions and the `initialize`
+handshake entirely:
+
+- **Stateless protocol** — no session lifecycle, no server-initiated requests
+  riding a session back-channel.
+- **Per-request `_meta`** carries version/capabilities instead of the
+  handshake negotiation.
+- **Cross-call state** moves to **explicit handles**: server-minted tokens
+  passed as ordinary tool arguments (the pattern `request_state` already uses).
+- **`server/discover`** replaces handshake capability probing.
+
+Prior revisions (2025-11-25 / 2025-06-18) remain published; we are pinned to
+FastMCP 4.0.0b3, which speaks 2025-era session semantics — but FastMCP 4.0's
+`Client` already **negotiates sessionless by default**, which is why the real
+client traffic godot-mcp sees is the sessionless `2026-07-28` protocol.
+
+## 2. Inventory: what rides on session affinity
+
+Audited via graph query + source scan (`grep session_id|on_initialize` under
+`mcp_server/`). **Finding: the server is already sessionless-native.** The
+issue's premise — "ToolsetMiddleware keys enable/disable on
+`context.session_id`" — was fixed in #370/#364 (merged 2026-08-27), which
+removed per-session isolation as dead code on the sessionless protocol.
+
+| Stateful surface | Where it lives | Session dependency | Status |
+|---|---|---|---|
+| Toolset enable/disable | `ToolsetMiddleware` (`toolset_middleware.py`) | **None** — single server-global enabled set (#364) | 2026-native |
+| Destructive-tool approval guard | `ApprovalMiddleware` (`approval_middleware.py`) | **None** — `InputRequiredResult` + `request_state` round-trip, "durable, no server-side state" (#346) | 2026-native (handles pattern) |
+| `ctx.info` / `ctx.report_progress` | `tools/_progress.py` `safe_info` / `safe_progress` | **None** — guarded no-op in the detached task session (`task=True`, #331) | 2026-tolerant |
+| Bridge request/response correlation | `bridge.py` (`id` → waiter) | **None** — envelope `id` correlation, concurrency-safe | Protocol-agnostic |
+| ReadCache / `gather_reads` | `harness.py` | Client process state — not server state; client decides scoping | N/A (client-side) |
+
+Two invariants are **enforced by contract tests**:
+
+- `tests/contract/test_toolset_global_state.py` — no `on_initialize` override;
+  enable/disable persist across independent sessionless clients.
+- `tests/contract/test_approval_guard.py` — the guard round-trips tool +
+  params + safety class through `request_state`; second round reads
+  `ctx.input_responses`.
+
+And a **source-shape guard** added by this issue:
+
+- `tests/contract/test_sessionless_invariants.py` — AST scan over
+  `mcp_server/**`: no module may read `.session_id` / `.session`, name a
+  `session_id` binding, or define `on_initialize` / `on_new_session` /
+  `on_session_end`. A drift back toward session keying fails preflight, not
+  production.
+
+## 3. The design: explicit handles, not session affinity
+
+The 2026-native equivalent of "enable + mutate share one session" is already
+the *shape* the server exposes — but the mechanism is deliberately **coarser
+and simpler** than the spec's per-consumer handles:
+
+### Decision
+
+- **No `session_handle` / `toolset_grant` token.** godot-mcp is a
+  **single-user, local server** (one client per Godot instance, localhost-only,
+  no auth in v1). A server-global enabled set (#364) is the correct scope:
+  minting per-call handles would add a token-passing tax to every gated call
+  and re-introduce the failure mode it exists to avoid (a sessionless client
+  dropping the handle → gating silently no-ops).
+- **`request_state` is our handle pattern** for anything that genuinely needs
+  per-call round-trip state (today: the approval guard). The spec's
+  server-minted-handles recommendation is satisfied by this where it matters.
+- **The one behavioral inversion vs. the spec's default**: where a
+  spec-default server would scope a grant to the caller, godot-mcp's grants
+  are visible to every client of the process. This is documented, intended
+  (#364), and tested.
+
+### Risks
+
+| Risk | Assessment |
+|---|---|
+| **Silent gating bypass in sessionless clients** (the issue's named risk) | **Eliminated by #364's design.** With server-global state there is no affinity scope to lose: a stateless client that enables in call N sees the grant in call N+1 even across reconnects. The no-op bypass existed only under `session_id` keying. |
+| Concurrent multi-client interference | Accepted: single-user server, documented. A long-lived client A enabling a toolset changes what client B sees in `list_tools` — that is the design. If godot-mcp ever grows multi-tenant, the handle design becomes mandatory; until then the global set keeps the surface honest. |
+| FastMCP removes session-era APIs we still touch | Low: the server relies on no session APIs (see §2). The migration surface is FastMCP's, not ours. |
+| `task=True` detached sessions (`ctx.session is None`) | Handled by `safe_info`/`safe_progress` guards (#331) and the guard-pattern rule in `.opencode/rules/async-patterns.md` (no `ctx.elicit()`, no `Middleware.on_initialize`). |
+
+## 4. FastMCP dependency
+
+**Blocking for implementation, not for the plan** (per the issue). Nothing in
+`mcp_server/` needs to change when FastMCP ships 2026-spec support:
+
+- The handshake / `_meta` / `server/discover` mechanics are framework-owned.
+- Our contract tests exercise the server through FastMCP's `Client`, which
+  already negotiates sessionless — the tests stay valid across the transition.
+- Watch: PrefectHQ/fastmcp's 4.0 stable release and its 2026-07-28 revision
+  support timeline. When it lands, re-run the contract suite; expected delta
+  is zero. If FastMCP instead removes session-era defaults (e.g. forces
+  `_meta` versioning), the surfaces to touch are the middleware base classes
+  only — the source-shape guard keeps application code clean in the meantime.
+
+## 5. godot-agents follow-up (client side)
+
+godot-agents' AGENTS.md documented the sessionless bypass risk under
+per-session keying; **that concern is void** — with server-global state, its
+`_ensure_or_return_error` pattern (enable → verify visible → mutate) works
+regardless of affinity scope, including across fresh connections. The
+remaining client-side follow-up (filed on merge of this plan):
+
+- Prefer `structuredContent` over text parsing in `MCPResult` (#385's
+  client half).
+- Drop any residual assumption that enable+mutate must share one
+  `ClientSession` — a reconnect between them no-ops nothing.

--- a/tests/contract/test_sessionless_invariants.py
+++ b/tests/contract/test_sessionless_invariants.py
@@ -1,0 +1,97 @@
+"""Sessionless-surface guard (issue #386).
+
+The MCP spec's 2026-07-28 revision removes sessions and the ``initialize``
+handshake. godot-mcp committed to the sessionless shape in #364/#370: toolset
+gating is a single server-global set (no ``context.session_id`` keying, no
+``Middleware.on_initialize``), and the approval guard is durable via
+``request_state`` round-trips (no server-side per-session state).
+
+The behavior is pinned by ``test_toolset_global_state.py`` and
+``test_approval_guard.py``. This guard pins the **source shape**: no module
+under ``mcp_server/`` may key server state on session identity again — a drift
+back toward ``session_id`` / ``ctx.session`` / per-session middleware hooks
+would silently break on the sessionless protocol (a fresh ``session_id`` per
+call makes per-session state a no-op), the exact failure mode #386 exists to
+avoid discovering late.
+
+The scan is AST-based (not a text grep) so docstrings/comments mentioning
+"sessions" — which are legion and correct — don't trip it. Only *code* that
+reads a ``.session_id`` / ``.session`` attribute, names a binding
+``session_id``, or defines an ``on_initialize`` / ``on_new_session`` /
+``on_session_end`` method counts as a violation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+MCP_SERVER_DIR = Path(__file__).resolve().parents[2] / "mcp_server"
+
+# Middleware hooks that assume session lifecycle (2025-era semantics).
+_SESSION_HOOKS = {"on_initialize", "on_new_session", "on_session_end"}
+
+# Attribute names that read session identity off a context/ctx object.
+_SESSION_ATTRS = {"session_id", "session"}
+
+VIOLATION_READS_SESSION = "ctx_id = ctx.session_id"
+VIOLATION_HOOK = "class M:\n    def on_initialize(self, ctx):\n        pass\n"
+
+
+def _violations(tree: ast.Module, rel: Path) -> list[str]:
+    """Return human-readable session-keying violations in one module."""
+    found: list[str] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Attribute(self, node: ast.Attribute) -> None:
+            if node.attr in _SESSION_ATTRS:
+                found.append(f"{rel}: reads .{node.attr} (line {node.lineno})")
+            self.generic_visit(node)
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if node.id == "session_id":
+                found.append(f"{rel}: names `session_id` (line {node.lineno})")
+            self.generic_visit(node)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            if node.name in _SESSION_HOOKS:
+                found.append(f"{rel}: defines `{node.name}` (line {node.lineno})")
+            self.generic_visit(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            if node.name in _SESSION_HOOKS:
+                found.append(f"{rel}: defines `{node.name}` (line {node.lineno})")
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return found
+
+
+def _all_server_modules() -> list[tuple[Path, ast.Module]]:
+    modules: list[tuple[Path, ast.Module]] = []
+    for py in sorted(MCP_SERVER_DIR.rglob("*.py")):
+        modules.append((py, ast.parse(py.read_text(encoding="utf-8"), filename=str(py))))
+    return modules
+
+
+def test_no_server_code_keys_state_on_session_identity() -> None:
+    """No ``mcp_server/`` module reads session identity or defines session hooks."""
+    assert MCP_SERVER_DIR.is_dir()
+    violations: list[str] = []
+    for py, tree in _all_server_modules():
+        rel = py.relative_to(MCP_SERVER_DIR)
+        violations.extend(_violations(tree, rel))
+    assert not violations, "\n".join(sorted(violations))
+
+
+def test_guard_trips_on_a_deliberate_violation() -> None:
+    """The guard is not vacuous: injected session keying is caught.
+
+    This is the red-first proof for the guard itself — the same detection the
+    main test runs over real modules, exercised against code that actually
+    reads ``ctx.session_id`` and defines an ``on_initialize`` hook.
+    """
+    v1 = _violations(ast.parse(VIOLATION_READS_SESSION), Path("fake.py"))
+    v2 = _violations(ast.parse(VIOLATION_HOOK), Path("fake2.py"))
+    assert any(".session_id" in v for v in v1)
+    assert any("on_initialize" in v for v in v2)


### PR DESCRIPTION
### **User description**
## Summary

Plans the MCP 2026-07-28 (sessions removal) migration per #386 — a **plan, not an implementation**. The headline finding: **the issue's premise was stale** — #370/#364 (merged 2026-08-27) already removed `session_id` keying from `ToolsetMiddleware`; the enabled set is a single server-global set, and the approval guard (#346) is durable via `request_state` round-trips. The server is already sessionless-native, which is the protocol FastMCP 4.0's `Client` negotiates by default.

## Acceptance criteria (#386)

- [x] **Inventory of session-affinity-dependent behavior** — `docs/mcp-2026-07-28-migration.md` §2: every stateful surface audited (toolset gating, approval guard, `safe_info`/`safe_progress`, bridge `id`-correlation, client-side ReadCache) with session dependency + status each; all pinned by existing contract tests
- [x] **Chosen design with risks** — §3: **no `session_handle`/`toolset_grant` token** — godot-mcp is a single-user local server, so a server-global enabled set is the correct scope; `request_state` is our handle pattern where per-call state matters. Risk table: the issue's named risk (**silent gating bypass in sessionless clients**) is **eliminated** by the server-global design — there is no affinity scope to lose; concurrent-client interference is the accepted, documented trade-off
- [x] **FastMCP dependency tracked** — §4: the handshake/`_meta`/`server/discover` mechanics are framework-owned; nothing in `mcp_server/` needs changing; contract tests exercise the sessionless `Client` so they stay valid across the transition

## New guard

`tests/contract/test_sessionless_invariants.py` — AST scan over `mcp_server/` for session keying (reads of `.session_id`/`.session`, `session_id` bindings, `on_initialize`/`on_new_session`/`on_session_end` hooks), with a deliberate-violation self-trip proof so the guard isn't vacuous. Drift back toward session affinity now fails preflight, not production.

## Test plan

- [x] Guard green over the migrated tree (2 passed) + self-trip red-check
- [x] Full suite: 645 passed (on the stacked tree); this branch re-verified: sessionless guard, toolset-global-state, approval-guard all green
- [x] `ruff check` / `mypy` / zero-skip clean
- [x] Graphify refreshed — no new cross-layer edges

## Follow-up

godot-agents client follow-up (filing there on merge): their documented sessionless-bypass concern is void under server-global state — enable+mutate no longer needs one `ClientSession`; the `structuredContent` preference in `MCPResult` is #385's client half.

## Notes for reviewers

- §1 of the plan doc quotes the spec changes (sessions removal, per-request `_meta`, explicit handles, `server/discover`) for context
- `docs/architecture.md` cross-links the plan
- No `session_handle` minting was implemented — that is a deliberate design decision documented in §3, not scope-cutting


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Add MCP 2026-07-28 migration plan

- Document sessionless design and risks

- Add AST guard against session keying

- No runtime behavior changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Plan["MCP 2026-07-28 migration plan"]
  Inventory["Session-affinity inventory"]
  Design["Server-global design decision"]
  Guard["Sessionless AST guard"]
  Arch["Architecture cross-link"]
  Plan -- "documents" --> Inventory
  Plan -- "chooses" --> Design
  Plan -- "adds" --> Guard
  Arch -- "references" --> Plan
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sessionless_invariants.py</strong><dd><code>Add sessionless invariant AST guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_sessionless_invariants.py

<ul><li>Adds an AST-based contract guard over <code>mcp_server/</code><br> <li> Flags session identity reads, <code>session_id</code> bindings, and session hooks<br> <li> Includes a self-trip test proving the guard detects violations</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/388/files#diff-9791f95fbb43cf6d3d94750d5800eb963cdd83fc26df49699575324a3a75cc01">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>architecture.md</strong><dd><code>Cross-link sessionless migration plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/architecture.md

<ul><li>Notes that the server is sessionless by design<br> <li> Adds a cross-link to the MCP 2026-07-28 migration plan</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/388/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp-2026-07-28-migration.md</strong><dd><code>Add MCP 2026-07-28 migration plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/mcp-2026-07-28-migration.md

<ul><li>Documents the MCP 2026-07-28 spec changes and migration status<br> <li> Inventories stateful surfaces and their session dependencies<br> <li> Chooses server-global state over session-scoped handles<br> <li> Tracks FastMCP dependency and the godot-agents client follow-up</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/388/files#diff-44f7bba2ecf8a97d74b658b596835562c03ba47617a04c47f6d70e2f854032e2">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

