### PR TITLE
Bump version to 2026.08.31b4 (beta 4)

### DIFF
--- a/.opencode/rules/enforcement.md
+++ b/.opencode/rules/enforcement.md
@@ -38,4 +38,4 @@ CI does not exist yet (greenfield). Wire these gates into a workflow as part of 
 
 ## Versioning
 
-CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.31b3** (beta 3).
+CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.31b4** (beta 4).

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Bridges a live Godot editor to an MCP server so AI clients can drive scene authoring, inspection, and runtime over a localhost WebSocket."
 author="hybridindie"
-version="2026.08.31b3"
+version="2026.08.31b4"
 script="godot_mcp.gd"
 icon="icon.png"

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -9,7 +9,7 @@ See ``docs/architecture.md`` for the bridge contract.
 """
 
 # CalVer, kept in sync with pyproject.toml and .opencode/rules/enforcement.md.
-__version__ = "2026.08.31b3"
+__version__ = "2026.08.31b4"
 
 # Tool-contract / compatibility version — a monotonic integer, deliberately
 # distinct from the CalVer build version. It expresses the *contract*: bump it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-editor-mcp"
-version = "2026.08.31b3"
+version = "2026.08.31b4"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/godot-getting-started/SKILL.md
+++ b/skills/godot-getting-started/SKILL.md
@@ -5,7 +5,7 @@ description: Connect to and drive a Godot editor through the godot-mcp server. U
 
 # godot: getting started
 
-godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. This skill documents the **2026.08.31b3** surface — 180 tools, 29 categories. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the three most common failures: a version mismatch, missing tools, and unconfirmed destructive edits.
+godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. This skill documents the **2026.08.31b4** surface — 180 tools, 29 categories. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the three most common failures: a version mismatch, missing tools, and unconfirmed destructive edits.
 
 ## 1. Confirm the bridge and the version
 
@@ -16,7 +16,7 @@ godot_health_check()      # bridge connected? which URL? → also returns versio
 godot_get_server_info()   # version, contract_version, toolsets, active scene, next_steps
 ```
 
-- `godot_health_check()` returns `version` — if it isn't **2026.08.31b3**, this skill may be stale; rely on `godot_get_server_info()`'s toolset/tool inventory instead of the counts here.
+- `godot_health_check()` returns `version` — if it isn't **2026.08.31b4**, this skill may be stale; rely on `godot_get_server_info()`'s toolset/tool inventory instead of the counts here.
 - `godot_get_server_info()` returns `contract_version` (tool-surface compatibility, currently 1) — a client is compatible when `min_compatible_contract <= yours <= contract_version`.
 - If disconnected: open the `godot/` project in Godot 4.4+ (validated on 4.7), enable the plugin (Project Settings → Plugins → godot_mcp), and check the status dock.
 

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "godot-editor-mcp"
-version = "2026.8.31b3"
+version = "2026.8.31b4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
### **User description**
## Summary

Version bump for the fourth beta release (`2026.08.31b4`). Same 5-file set as #380, plus the skills drift test catch:

- `pyproject.toml`: `2026.08.31b3` → `2026.08.31b4`
- `mcp_server/__init__.py`: `__version__` → `2026.08.31b4`
- `godot/addons/godot_mcp/plugin.cfg`: addon version → `2026.08.31b4`
- `.opencode/rules/enforcement.md`: Current → `2026.08.31b4 (beta 4)`
- `uv.lock`: self-reference resynced
- `skills/godot-getting-started/SKILL.md`: version references updated (pinned red by `test_getting_started_states_current_version_and_check` from #382 — the drift test did its job)

## What's in beta 4

3 commits since [b3](https://github.com/hybridindie/godot-mcp/releases/tag/2026.08.31b3):

- **#384 (#383)** — LLM eval harness moved to godot-agents (`godot_agent_harness`, godot-agents#482): evals/ keeps only the instruction-staleness self-analysis; eval.yml removed; new `test_evals_surface.py` guard pins the surface. Repo hygiene — the published wheel was never affected (harness was never packaged).
- **#387 (#385)** — **the wire change**: every JSON-result tool now declares a standard `outputSchema` (JSON Schema 2020-12) and emits `structuredContent` with the text content as faithful serialized fallback. `godot_undo`'s schema fixed from degenerate `{additionalProperties: true}` to the field-derived `UndoResult.model_json_schema()` (its `@model_serializer` hid fields from pydantic's serialization-mode schema). `godot_editor_capture_screenshot` is the spec-correct exception (ImageContent, no schema). Pinned in both directions by `tests/contract/test_output_schema.py`, including a whole-surface degenerate-schema guard. This unblocks godot-agents#494 (`MCPResult` prefers `structuredContent`).
- **#388 (#386)** — MCP 2026-07-28 migration plan (docs) + sessionless source-shape guard: the server was already sessionless-native post-#364; drift back toward `session_id` keying now fails preflight.

`CONTRACT_VERSION` stays at **1** — the envelope and command surface are unchanged; `outputSchema`/`structuredContent` are additive (2025-11-25 spec best practice), with text fallback byte-identical for existing clients.

## Test plan

- [x] `uv build` succeeds (wheel + sdist)
- [x] `uv run pytest -q` → 646 passed, 0 skipped (incl. the CalVer, pyproject-sync, plugin.cfg-lockstep, and skill-version-drift tests)
- [x] `uv run ruff check .` / `uv run mypy` / zero-skip gate → clean


___

### **PR Type**
Other, Documentation


___

### **Description**
- Bump CalVer to `2026.08.31b4`

- Sync package, addon, rule versions

- Update getting-started skill version references

- No runtime or public API changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["2026.08.31b4"]
  B["pyproject.toml"] -- "project version" --> A
  C["mcp_server/__init__.py"] -- "server version" --> A
  D["godot/addons/godot_mcp/plugin.cfg"] -- "addon version" --> A
  E[".opencode/rules/enforcement.md"] -- "rule version" --> A
  F["skills/godot-getting-started/SKILL.md"] -- "skill version" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update server package version constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/__init__.py

<ul><li>Updates <code>__version__</code> from <code>2026.08.31b3</code> to <code>2026.08.31b4</code>.<br> <li> Keeps the server package CalVer in sync with release metadata.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/389/files#diff-0ee260f94eefb5341ba2f880808d78577c1e28ab8efa6209e2b12753496409d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plugin.cfg</strong><dd><code>Update Godot addon plugin version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/plugin.cfg

<ul><li>Updates the Godot addon <code>version</code> to <code>2026.08.31b4</code>.<br> <li> Keeps addon metadata aligned with the release.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/389/files#diff-505361f53d50c88c282a85d8bff795aed2e43e41ce9cfe2d4b7d332bfa8c14f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump project version to beta 4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Bumps the project version to <code>2026.08.31b4</code>.<br> <li> Updates package metadata for beta 4.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/389/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>enforcement.md</strong><dd><code>Update enforcement rule current version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.opencode/rules/enforcement.md

<ul><li>Updates the current CalVer in the enforcement rule.<br> <li> Replaces beta 3 with beta 4.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/389/files#diff-688b42a0fee7d33fb02e12946e7605b1b44f14ecfb129ef4cad7226fd37932e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Update getting-started skill version references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/godot-getting-started/SKILL.md

<ul><li>Updates the documented surface version to <code>2026.08.31b4</code>.<br> <li> Updates the <code>godot_health_check()</code> version reference.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/389/files#diff-2e76fc71066ad43d91d7382c6f64f051cfc58f8eba73b4f43c709690e242615f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

