### PR TITLE
Fix editor screenshot timeout via deferred capture

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -391,7 +391,7 @@ undoable in the editor.
 
 | Tool | Params | Returns | Class |
 |------|--------|---------|-------|
-| `godot_editor_capture_screenshot` | — | image content (PNG) | `read_only` |
+| `godot_editor_capture_screenshot` | `timeout_ms?` | image content (PNG) | `read_only` |
 
 The addon captures the editor viewport and returns a base64 PNG; the tool decodes it
 into a FastMCP `Image` so a vision-capable client receives an image block (no temp

--- a/godot/addons/godot_mcp/handlers/editor.gd
+++ b/godot/addons/godot_mcp/handlers/editor.gd
@@ -8,6 +8,12 @@ extends RefCounted
 
 var _router: MCPCommandRouter
 
+# Two-phase capture state: the viewport read-back is deferred one rendered
+# frame (get_image() inline can stall the router on some display servers —
+# observed as a server-side timeout on macOS); callers poll until ready.
+var _shot: Dictionary = {}
+var _grab_queued := false
+
 
 
 func _encode_png(image: Image) -> Dictionary:
@@ -30,22 +36,37 @@ func register(handlers: Dictionary) -> void:
 # -- handlers ----------------------------------------------------------------
 
 func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
-	# Split the chain so any null intermediate returns a structured error, never crashes.
+	if not _shot.is_empty():
+		var done := _shot
+		_shot = {}
+		_grab_queued = false
+		return _router._ok(done)
 	var base_control := EditorInterface.get_base_control()
 	if base_control == null:
 		return _router._fail("INTERNAL_ERROR", "Editor base control is unavailable.")
+	var tree := base_control.get_tree()
+	if tree == null:
+		return _router._fail("INTERNAL_ERROR", "Editor scene tree is unavailable.")
+	if not _grab_queued:
+		tree.process_frame.connect(_grab_screenshot.bind(base_control), ConnectFlags.CONNECT_ONE_SHOT)
+		_grab_queued = true
+	return _router._ok({"ready": false})
+
+
+func _grab_screenshot(base_control: Control) -> void:
 	var viewport := base_control.get_viewport()
 	if viewport == null:
-		return _router._fail("INTERNAL_ERROR", "Editor viewport is unavailable.")
+		_shot = {"ready": true, "error": "Editor viewport is unavailable."}
+		return
 	var texture := viewport.get_texture()
 	if texture == null:
-		return _router._fail("INTERNAL_ERROR", "No viewport texture (no rendered frame; is a display available?).")
+		_shot = {"ready": true, "error": "No viewport texture (no rendered frame)."}
+		return
 	var image := texture.get_image()
-	if image == null:
-		return _router._fail("INTERNAL_ERROR", "Could not capture the editor viewport image.")
-	var result := _encode_png(image)
-	if str(result.get("base64", "")).is_empty():
-		return _router._fail("INTERNAL_ERROR", "PNG encoding produced no data.")
-	return _router._ok(result)
+	if image == null or image.is_empty():
+		_shot = {"ready": true, "error": "Could not capture the editor viewport image."}
+		return
+	_shot = _encode_png(image)
+	_shot["ready"] = true
 
 

--- a/mcp_server/defaults.py
+++ b/mcp_server/defaults.py
@@ -18,6 +18,8 @@ DEFAULT_INPUT_RECORDING_TIMEOUT_MS: int = 2000
 DEFAULT_PERF_MONITORS_TIMEOUT_MS: int = 2000
 DEFAULT_RUNTIME_INSPECT_TIMEOUT_MS: int = 2000
 DEFAULT_ASSERT_NODE_TIMEOUT_MS: int = 1500
+# Viewport read-back waits one rendered editor frame; allow a few frames of slack.
+DEFAULT_CAPTURE_TIMEOUT_MS: int = 2000
 
 # -- Polling intervals ----------------------------------------------------------
 DEFAULT_POLL_INTERVAL_SECONDS: float = 0.1

--- a/mcp_server/tools/editor.py
+++ b/mcp_server/tools/editor.py
@@ -2,14 +2,18 @@
 
 Returns a screenshot of the editor viewport as image content so vision-capable
 agents can *see* the result of a change. Read-only; gated `editor` toolset. The
-addon captures the viewport and returns a base64 PNG; this decodes it into a
-FastMCP ``Image`` so the client receives an image block.
+addon defers the viewport read-back one rendered frame (an inline ``get_image``
+can stall the router's main thread on some display servers) and the server
+polls until the capture is ready; this decodes the base64 PNG into a FastMCP
+``Image`` so the client receives an image block.
 """
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
+from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -17,6 +21,8 @@ from fastmcp.utilities.types import Image
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import EDITOR_TAG
+from mcp_server.constraints import TimeoutMs
+from mcp_server.defaults import DEFAULT_CAPTURE_TIMEOUT_MS, DEFAULT_POLL_INTERVAL_SECONDS
 from mcp_server.safety import READ_ONLY
 from mcp_server.tools._route import route
 
@@ -25,16 +31,34 @@ def register_editor(mcp: FastMCP, bridge: Bridge) -> None:
     """Register the editor screenshot tool."""
 
     @mcp.tool(meta=READ_ONLY, tags={EDITOR_TAG})
-    async def capture_editor_screenshot() -> Image:
+    async def capture_editor_screenshot(
+        timeout_ms: TimeoutMs = DEFAULT_CAPTURE_TIMEOUT_MS,
+    ) -> Image:
         """Capture the Godot editor's main viewport and return it as a PNG image, so
-        you can visually inspect the current editor state. Read-only.
+        you can visually inspect the current editor state. Read-only. The capture is
+        taken on the next rendered editor frame; if the editor is fully occluded or
+        not redrawing, the poll expires with an error.
         """
-        result = await route(bridge, "cmd_capture_editor_screenshot")
-        encoded = result.get("base64")
-        if not encoded:
-            raise ToolError("Screenshot capture returned no image data.")
+        deadline = asyncio.get_event_loop().time() + timeout_ms / 1000
+        result: dict[str, Any] = {}
+        while True:
+            result = await route(bridge, "cmd_capture_editor_screenshot")
+            # Done when a payload arrived (``ready`` truthy or a base64 body from
+            # an older addon); ``{"ready": false}`` means "grab still pending".
+            if result.get("base64") or result.get("ready"):
+                break
+            if asyncio.get_event_loop().time() >= deadline:
+                raise ToolError(
+                    f"Editor viewport capture did not complete within {timeout_ms}ms — "
+                    "is the editor window rendering (not fully hidden/minimized)?"
+                )
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
+        if not result.get("base64"):
+            reason = str(result.get("error", "")).strip()
+            detail = f" ({reason})" if reason else ""
+            raise ToolError(f"Screenshot capture returned no image data.{detail}")
         try:
-            data = base64.b64decode(encoded, validate=True)
+            data = base64.b64decode(result["base64"], validate=True)
         except (binascii.Error, ValueError) as exc:
             raise ToolError(f"Screenshot data was not valid base64: {exc}") from exc
         # Normalize e.g. "image/png" → "png".

--- a/tests/contract/test_editor.py
+++ b/tests/contract/test_editor.py
@@ -69,3 +69,41 @@ async def test_capture_returns_image_content() -> None:
     assert block.mime_type == "image/png"
     # The returned data decodes to the same PNG bytes the addon supplied.
     assert base64.b64decode(block.data).startswith(b"\x89PNG\r\n\x1a\n")
+
+
+async def test_deferred_capture_polls_until_ready() -> None:
+    """Two-phase addon (grab pending → done): the tool polls and still returns the image."""
+    calls = {"n": 0}
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ResponseEnvelope.success(cmd.id, {"ready": False})
+        return ResponseEnvelope.success(
+            cmd.id,
+            {"ready": True, "format": "png", "width": 1, "height": 1, "base64": _PNG_B64},
+        )
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    async with Client(create_server(ServerConfig(), bridge=bridge)) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "editor"})
+        result = await client.call_tool("godot_editor_capture_screenshot", {"timeout_ms": 2000})
+    assert calls["n"] >= 2
+    image_blocks = [b for b in result.content if type(b).__name__ == "ImageContent"]
+    assert image_blocks, f"expected an image content block, got {result.content}"
+
+
+async def test_capture_never_ready_times_out_with_actionable_error() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"ready": False})
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    async with Client(create_server(ServerConfig(), bridge=bridge)) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "editor"})
+        result = await client.call_tool(
+            "godot_editor_capture_screenshot", {"timeout_ms": 250}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "did not complete" in str(result.content)


### PR DESCRIPTION
### **User description**
Closes #391

## Summary
`godot_editor_capture_screenshot` timed out (~10s, no response) on macOS because the handler called `ViewportTexture.get_image()` inline on the router's synchronous main thread — the Metal read-back stalls the frame and the router with it. The capture is now two-phase, reusing the repo's established `monitor_property` poll pattern.

## Changes
- **Addon** (`handlers/editor.gd`): first call queues a `CONNECT_ONE_SHOT` `process_frame` grab → `{"ready": false}`; the deferred grab encodes the PNG → `{"ready": true, format, width, height, base64}` (or `ready:true` + `error`). The router never blocks.
- **Server** (`tools/editor.py`): new `timeout_ms` budget (canonical `DEFAULT_CAPTURE_TIMEOUT_MS` in `defaults.py`, shared poll interval) → actionable expiry error naming the hidden/minimized-editor case instead of a generic bridge timeout; grab failures surface the addon's error verbatim.
- **Compat:** single-phase payloads (base64 present, no `ready` key) are still accepted immediately, so new server ↔ old addon keeps working.
- `docs/tool-contracts.md` param row updated.

## Testing (red first)
- 2 new contract tests: deferred `ready:false` → completes with image; never-ready → structured timeout error
- Existing immediate-shape contract tests untouched and green (both wire shapes covered)
- Full suite green, ruff + mypy clean; live consumer observation: old code timed out repeatedly on an idle editor

Refs #391.


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Defer viewport screenshot one rendered frame

- Avoids blocking router during capture

- Add timeout_ms with actionable error

- Keep older single-phase addon compatible


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Editor viewport"] --> B["One-frame deferred grab"]
  B --> C["Server polls until ready"]
  C --> D["PNG image or timeout"]
  E["Old single-phase reply"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults.py</strong><dd><code>Add default capture timeout constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/defaults.py

<ul><li>Adds <code>DEFAULT_CAPTURE_TIMEOUT_MS</code> set to 2000.<br> <li> Documents viewport read-back frame slack.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/395/files#diff-a6ad8c55b88e2cff58f5520c83fd4fa58c918e97c4b263aec70225dd107a867f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>editor.py</strong><dd><code>Poll deferred screenshot with timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/editor.py

<ul><li>Adds optional <code>timeout_ms</code> parameter to screenshot tool.<br> <li> Polls bridge until <code>ready</code> or base64 payload.<br> <li> Raises actionable timeout for hidden/minimized editor.<br> <li> Preserves older single-phase addon compatibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/395/files#diff-df4663cf6f7aeef87f39a65c090b612c9ed40c89341b08670e9ed1440fb44809">+33/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>editor.gd</strong><dd><code>Defer viewport screenshot one frame</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/editor.gd

<ul><li>Defers viewport read-back to one-shot <code>process_frame</code>.<br> <li> Stores pending capture in <code>_shot</code> state.<br> <li> Returns <code>ready:false</code> then encoded PNG or error.<br> <li> Avoids blocking synchronous router inline.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/395/files#diff-eecd8dcd8f25bdbb93ae6b275f8c4a6296d0dd8d8ba5feac2b34410e231bb600">+30/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_editor.py</strong><dd><code>Add deferred screenshot contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_editor.py

<ul><li>Adds deferred capture polling contract test.<br> <li> Adds never-ready timeout contract test.<br> <li> Uses fake addon responder for both wire shapes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/395/files#diff-9d4c09aea5fc6764fc69c3ad22732fa9eda0f844c2dfbb9c2d230a0da10ec9f6">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document optional screenshot timeout parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Updates tool contract row for <code>timeout_ms?</code>.<br> <li> Documents optional timeout parameter.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/395/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

