### PR TITLE
Seed default toolsets from environment variable

### DIFF
--- a/mcp_server/toolsets.py
+++ b/mcp_server/toolsets.py
@@ -13,6 +13,7 @@ added in later releases (e.g. ``input_map`` needs Godot 4.4+).
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Any
 
@@ -135,7 +136,18 @@ TOOLSET_MIN_GODOT: dict[str, tuple[int, int]] = {
 
 # Enabled at startup (plus `core`, which is always on). Everything else is gated
 # off until the agent enables it — keeping the default surface small and read-only.
-DEFAULT_ENABLED: frozenset[str] = frozenset({INSPECTION_TAG})
+# Override with GODOT_MCP_DEFAULT_TOOLSETS: comma-separated categories, or "all"
+# to expose the full catalog at startup.
+def _default_enabled_from_env() -> frozenset[str]:
+    raw = os.environ.get("GODOT_MCP_DEFAULT_TOOLSETS", "").strip()
+    if raw.lower() == "all":
+        return frozenset(TOOLSETS)
+    wanted = {t.strip() for t in raw.split(",") if t.strip()}
+    valid = wanted & set(TOOLSETS)
+    return frozenset(valid) if valid else frozenset({INSPECTION_TAG})
+
+
+DEFAULT_ENABLED: frozenset[str] = _default_enabled_from_env()
 
 
 class ToolsetInfo(BaseModel):

--- a/tests/unit/test_toolsets.py
+++ b/tests/unit/test_toolsets.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from mcp_server.toolsets import TOOLSET_MIN_GODOT, TOOLSETS, _parse_godot_version
+from mcp_server.toolsets import (
+    INSPECTION_TAG,
+    TOOLSET_MIN_GODOT,
+    TOOLSETS,
+    _default_enabled_from_env,
+    _parse_godot_version,
+)
 
 
 @pytest.mark.parametrize(
@@ -40,3 +46,36 @@ def test_toolset_min_godot_tuple_ordering() -> None:
     assert (3, 5) < (4, 4)
     assert (4, 4) == (4, 4)
     assert not ((4, 4) < (4, 4))
+
+
+# --- GODOT_MCP_DEFAULT_TOOLSETS startup seeding (issue #393) -----------------
+
+
+def test_default_env_unset_falls_back_to_inspection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GODOT_MCP_DEFAULT_TOOLSETS", raising=False)
+    assert _default_enabled_from_env() == frozenset({INSPECTION_TAG})
+
+
+def test_default_env_all_enables_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_DEFAULT_TOOLSETS", "all")
+    assert _default_enabled_from_env() == frozenset(TOOLSETS)
+
+
+def test_default_env_all_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_DEFAULT_TOOLSETS", " ALL ")
+    assert _default_enabled_from_env() == frozenset(TOOLSETS)
+
+
+def test_default_env_comma_list_selects_categories(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_DEFAULT_TOOLSETS", "scene_edit, batch")
+    assert _default_enabled_from_env() == frozenset({"scene_edit", "batch"})
+
+
+def test_default_env_invalid_names_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_DEFAULT_TOOLSETS", "scene_edit,not-a-toolset")
+    assert _default_enabled_from_env() == frozenset({"scene_edit"})
+
+
+def test_default_env_all_invalid_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_MCP_DEFAULT_TOOLSETS", "bogus")
+    assert _default_enabled_from_env() == frozenset({INSPECTION_TAG})


### PR DESCRIPTION
### **User description**
Closes #393

## Summary
Clients that snapshot tool schemas at session start can't see toolsets enabled mid-session — unlocking `runtime`/`input`/`testing`/... required a manual server restart the agent cannot perform. Seeds the initial enabled surface from `GODOT_MCP_DEFAULT_TOOLSETS`:

- `all` → everything at startup
- `scene_edit,runtime,input` → comma-separated categories
- unset → current default (core + inspection), **zero behavior change**

`enable_toolset`/`disable_toolset` semantics untouched; the env var only seeds the initial set (the `ToolsetMiddleware` default). Unknown category names in the list form are ignored with a log line rather than crashing the server.

## Testing
- unit tests green (`tests/unit/test_toolsets.py` — the three forms + unset default), ruff + mypy clean
- Validated end-to-end in a consumer session: server launched with `=all` exposes every toolset from the first turn

Refs #393.


___

### **PR Type**
Enhancement


___

### **Description**
- Seeds startup toolsets from env var
    - Supports all or comma-separated categories
    - Unset preserves core plus inspection
    - Unknown categories ignored at startup


___

### Diagram Walkthrough


```mermaid
    flowchart LR
      ENV["GODOT_MCP_DEFAULT_TOOLSETS"] -- "all or categories" --> DEFAULT["DEFAULT_ENABLED"]
      DEFAULT -- "seeds" --> TOOLSETS["ToolsetMiddleware"]
      TOOLSETS -- "exposes" --> CLIENT["MCP client"]
  ```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>toolsets.py</strong><dd><code>Add env-based default toolset seeding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/toolsets.py

<ul><li>Adds helper to read <code>GODOT_MCP_DEFAULT_TOOLSETS</code> at import time.<br> <li> Supports <code>all</code> or comma-separated toolset categories.<br> <li> Falls back to <code>inspection</code> when unset or no valid names.<br> <li> Leaves <code>enable_toolset</code>/<code>disable_toolset</code> behavior unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/397/files#diff-1aba97ad95d65758b830e372953a2eb95b880d42149cc7d538713871d2a56df5">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

