### PR TITLE
Fix import asset e2e test race

### DIFF
--- a/tests/integration/test_import_asset_e2e.py
+++ b/tests/integration/test_import_asset_e2e.py
@@ -65,8 +65,14 @@ async def _run() -> None:
         assert imported["target_path"] == IMPORTED_PNG
         assert imported["detected_type"] == "Texture2D"
 
-        # Check import status.
-        status = await _ok(bridge, "cmd_get_import_status", {"target_path": IMPORTED_PNG})
+        # Check import status. `cmd_import_asset` only kicks EditorFileSystem.scan()
+        # (async); the .import sidecar appears a few frames later. Poll with a bounded
+        # budget instead of asserting immediately (the inline check raced the scan).
+        for _ in range(20):
+            status = await _ok(bridge, "cmd_get_import_status", {"target_path": IMPORTED_PNG})
+            if status["imported"]:
+                break
+            await asyncio.sleep(0.5)
         assert status["imported"] is True
         # Godot imports a PNG as a CompressedTexture2D (a Texture2D subtype); accept
         # either the base or the concrete imported type.


### PR DESCRIPTION
### **User description**
Closes #398

## Summary
`test_import_asset_e2e` asserted import status immediately after `cmd_import_asset`, but the import handler only kicks the async `EditorFileSystem.scan()` — the `.import` sidecar that `cmd_get_import_status` checks lands a few frames later. With a cold/wiped `godot/.godot` cache the test fails consistently (`imported: false`); it had been passing on warm state where the sidecar already existed.

## Change
Test-only: bounded poll (≤10s, 0.5s steps) around the status check; assertion semantics unchanged.

## Testing
- Before: fails in 2.17s, 100% reproducible after `rm -rf godot/.godot`
- After: passes in 2.66s (sidecar usually appears within the first poll interval)
- Full suite green with this change (no other test uses `cmd_get_import_status`)

Mentioned in #394-#397 follow-up testing; independent of those diffs.


___

### **PR Type**
Tests, Bug fix


___

### **Description**
- Fixes import status test race

- Adds bounded 10s polling wait

- No production API behavior changes

- Reduces flakiness on cold caches


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import asset"] --> B["Async scan"]
  B --> C["Status check"]
  C --> D["Poll up to 10s"]
  D --> E["Assert imported"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_import_asset_e2e.py</strong><dd><code>Poll import status in e2e test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_import_asset_e2e.py

<ul><li>Replaces immediate import status assertion with a bounded poll<br> <li> Polls <code>cmd_get_import_status</code> up to 20 times at 0.5s intervals<br> <li> Breaks early once <code>imported</code> status becomes true<br> <li> Keeps original assertion semantics after the poll completes</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/399/files#diff-067af61aefa016a7ddf3127f3809964130a9fe003fd05d2823d8bb541be33dcf">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

