### PR TITLE
Upgrade FastMCP to 4.0.1 stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,15 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # The MCP framework (PrefectHQ/fastmcp). Pinned to the 4.0 beta (issue #311).
-    # 4.0.0b3 picks up the tool-title default (PrefectHQ/fastmcp#4694 — some clients
-    # drop tools with no `title`) and HTTP-startup/bug fixes over b1 (issue #353).
-    # b1 already shipped the modern-protocol guard pattern (InputRequiredResult,
-    # InputRequiredToolResult, Context.input_responses / request_state) needed by
-    # the durable-approval work (issue #346) — no upgrade required.
-    # 2.x→3.x had breaking API changes (#228); the v3→v4 transition is lower-risk
-    # for this server (stateless, no ctx.elicit, no session state, canonical imports
-    # already in place). Beta pin per the upgrade guide; follow stable 4.x when it ships.
-    "fastmcp[tasks]==4.0.0b3",
+    # The MCP framework (PrefectHQ/fastmcp). FastMCP 4 stable (issue #403) — GA
+    # is built on MCP SDK v2 and the 2026-07-28 sessionless protocol revision
+    # (migration plan: docs/mcp-2026-07-28-migration.md). b3 carried the guard
+    # pattern (InputRequiredResult / request_state) and tool-title defaults our
+    # surface relies on; stable adds the beta-period correctness work (task
+    # snapshots, response caching, auth hardening) with breaking changes we
+    # already migrated ahead of: no ctx.elicit (guard pattern since #346), no
+    # session state (#364), canonical imports.
+    "fastmcp[tasks]==4.0.1",
     # WebSocket transport for the addon/server bridge (issue #3).
     "websockets>=16.0",
     # Domain models and typed tool I/O (issue #7).
@@ -69,16 +68,14 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# FastMCP 4.0 beta pinning: fastmcp is a thin wrapper over fastmcp-slim at the
-# same version. uv won't infer the slim prerelease from the wrapper prerelease,
-# so constrain it alongside (per the upgrade guide). The rest of the graph
-# stays on stable releases. The background-tasks spike (#315) adds fastmcp-tasks
-# at the same prerelease; fastmcp-slim 4.0.0b3 already depends on the *final*
-# mcp-types 2.0.0 / mcp 2.0.0 (not the 2.0.0b2 prerelease the upgrade guide lists —
-# that pin is unsatisfiable: slim declares mcp-types>=2.0.0 which excludes b2),
-# so only fastmcp-tasks needs the prerelease pin here.
+# FastMCP 4 stable pinning (issue #403): fastmcp is a thin wrapper over
+# fastmcp-slim at the same version, and background tasks live in fastmcp-tasks.
+# All three ride the same 4.0.1 stable release now, so the constraint block is
+# belt-and-suspenders rather than a prerelease-resolution workaround (its
+# original purpose at the b3 pin, issue #311) — kept so the slim/tasks pins can
+# never drift below the wrapper pin.
 [tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b3", "fastmcp-tasks==4.0.0b3"]
+constraint-dependencies = ["fastmcp-slim==4.0.1", "fastmcp-tasks==4.0.1"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -39,18 +39,21 @@ def test_version_matches_pyproject() -> None:
     assert mcp_server.__version__ == pyproject["project"]["version"]
 
 
-def test_fastmcp_pinned_to_4_beta() -> None:
-    # fastmcp is pinned to the 4.0 beta (issue #311). The v3→v4 transition is
-    # lower-risk for this server than 2→3 was (#228): stateless, no ctx.elicit,
-    # no session state, canonical imports already in place. The pin is exact
-    # during the beta window; follow stable 4.x when it ships. Bumped b1→b3
-    # for the tool-title default + bug fixes (issue #353).
+def test_fastmcp_pinned_to_4_stable() -> None:
+    # fastmcp is pinned to the 4.0 stable line (issue #403, closing the #311
+    # promise "follow stable 4.x when it ships"). GA is built on MCP SDK v2 and
+    # the 2026-07-28 sessionless protocol revision. The pin is exact — the
+    # slim/tasks constraint block in [tool.uv] must move in lockstep, which the
+    # upgrade updates alongside this test. 4.0.1 = GA + ClientGroup reentrancy.
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
     dependencies = pyproject["project"]["dependencies"]
     fastmcp = next((d for d in dependencies if d.replace(" ", "").startswith("fastmcp")), None)
     assert fastmcp is not None, "fastmcp dependency missing from pyproject"
     spec = fastmcp.replace(" ", "")
-    assert "4.0.0b3" in spec, f"fastmcp must pin the 4.0.0b3 beta, got {fastmcp!r}"
+    assert "4.0.1" in spec, f"fastmcp must pin the 4.0.1 stable release, got {fastmcp!r}"
+    constraints = pyproject["tool"]["uv"]["constraint-dependencies"]
+    assert "fastmcp-slim==4.0.1" in constraints, "slim must ride the same stable pin"
+    assert "fastmcp-tasks==4.0.1" in constraints, "tasks must ride the same stable pin"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -50,7 +50,9 @@ def test_fastmcp_pinned_to_4_stable() -> None:
     fastmcp = next((d for d in dependencies if d.replace(" ", "").startswith("fastmcp")), None)
     assert fastmcp is not None, "fastmcp dependency missing from pyproject"
     spec = fastmcp.replace(" ", "")
-    assert "4.0.1" in spec, f"fastmcp must pin the 4.0.1 stable release, got {fastmcp!r}"
+    assert spec == "fastmcp[tasks]==4.0.1", (
+        f"fastmcp must pin exactly fastmcp[tasks]==4.0.1, got {fastmcp!r}"
+    )
     constraints = pyproject["tool"]["uv"]["constraint-dependencies"]
     assert "fastmcp-slim==4.0.1" in constraints, "slim must ride the same stable pin"
     assert "fastmcp-tasks==4.0.1" in constraints, "tasks must ride the same stable pin"

--- a/uv.lock
+++ b/uv.lock
@@ -13,8 +13,8 @@ resolution-markers = [
 
 [manifest]
 constraints = [
-    { name = "fastmcp-slim", specifier = "==4.0.0b3" },
-    { name = "fastmcp-tasks", specifier = "==4.0.0b3" },
+    { name = "fastmcp-slim", specifier = "==4.0.1" },
+    { name = "fastmcp-tasks", specifier = "==4.0.1" },
 ]
 
 [[package]]
@@ -485,14 +485,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "4.0.0b3"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/01/be88a40071d7bdce1b207c1acd2522167425393cbad33c40a778ce1f656d/fastmcp-4.0.0b3.tar.gz", hash = "sha256:1edea49ef12f6a47721ec69324bba31302eb0faccff939f2851026992fa62f93", size = 42163497, upload-time = "2026-08-14T17:48:01.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/d8/55fa434420f6404d4157b7a069289ad86f6519e43fccda24ab38e2c3467a/fastmcp-4.0.1.tar.gz", hash = "sha256:3e24d349c8513917db3d2c4bbbc3028370aa4e66d69b975ec0ca599979d2d0d0", size = 42301880, upload-time = "2026-09-02T00:20:47.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/0c/6cb98b816b0836fd8ad120761c5cb76e1c5a3a71dfd3b0549b37a3b52a54/fastmcp-4.0.0b3-py3-none-any.whl", hash = "sha256:4a68fb3877f160ca18ca5be4ee80c0d68c89f922b927734c36e6e99827d814fc", size = 8089, upload-time = "2026-08-14T17:47:58.59Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d7/ba0f88ff281f5ebb4f0213edc5fbfbb77f51396f1fb4626784638a92322c/fastmcp-4.0.1-py3-none-any.whl", hash = "sha256:b60d0dbbc8991b74592702c07e01ae99f6df5d2d6cae5f8fee24a58d8ff61945", size = 8075, upload-time = "2026-09-02T00:20:45.257Z" },
 ]
 
 [package.optional-dependencies]
@@ -502,7 +502,7 @@ tasks = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "4.0.0b3"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp-types" },
@@ -513,9 +513,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/35/01d59a0a8c4a7a7125f1f3b01f22b7283fea1942b7e1c5cea171bea624cc/fastmcp_slim-4.0.0b3.tar.gz", hash = "sha256:0647126ce70ebf0890912954ffb5cd162fb63bb9169a81b078ae960c8c09830e", size = 674255, upload-time = "2026-08-14T17:47:36.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/44/119fae9348a86388465cac7e2cfd3e52ddf28801ce3e56fa7b985de62b8b/fastmcp_slim-4.0.1.tar.gz", hash = "sha256:23f87109b4fe3bc78661ff36a140c05b69f59d3dda421313e2f66b09fc105c87", size = 684027, upload-time = "2026-09-02T00:20:22.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fa/63bc5d73f77bcf52ae05c184d18ad2ff9c5b35da0d9b55500e74a5377fef/fastmcp_slim-4.0.0b3-py3-none-any.whl", hash = "sha256:59ea0be9978b45cfe3ab47f3b7413b36a5b4b929dff723d48235899eada8bb42", size = 846345, upload-time = "2026-08-14T17:47:34.541Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/be/71e0663ba44eb085e7539b909d0975a693bcd7fc80780934cc66fbf94770/fastmcp_slim-4.0.1-py3-none-any.whl", hash = "sha256:68d1d0597c7b17ade432ff5165dfaa25e4c8f1a890914cb09f805d2d3816ceae", size = 858065, upload-time = "2026-09-02T00:20:20.805Z" },
 ]
 
 [package.optional-dependencies]
@@ -554,16 +554,16 @@ server = [
 
 [[package]]
 name = "fastmcp-tasks"
-version = "4.0.0b3"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "fastmcp-slim", extra = ["server"] },
     { name = "pydocket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/a2/fe63f980f5cd79512fb1a7f0e39cf0314cfca52ef834a3ff941ff4abda60/fastmcp_tasks-4.0.0b3.tar.gz", hash = "sha256:92929a6444e5ec99addffade9f953a755a56ada91f9d04c10854736ef117e051", size = 54235, upload-time = "2026-08-14T17:47:57.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/58/518267d2850b74f503a2b9a2116e7c1a3008a44422f12f9c5fd4b77dba91/fastmcp_tasks-4.0.1.tar.gz", hash = "sha256:6b3cc7148b5c4ac4bd5ebbddbc24c239b17eabd1cc3ff3d5ac4ca99d90668ca6", size = 54249, upload-time = "2026-09-02T00:20:44.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/59/1f81ddabc2fee157532dfcbdd286dae3936f549fc7a95bc45497d8cdeceb/fastmcp_tasks-4.0.0b3-py3-none-any.whl", hash = "sha256:8b595dbd4382bec3a0b8767b04194a961dffecf01ca613ad987aae95f80355bc", size = 65414, upload-time = "2026-08-14T17:47:56.507Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/e84070b83dbc199a719e4db6f23edf83605bf1f58bd6ed6f70f419134cc6/fastmcp_tasks-4.0.1-py3-none-any.whl", hash = "sha256:ac522bec8b8c860ca46de2def45e154c4dbb4b349ec6f6ef81f161b456ce627c", size = 65404, upload-time = "2026-09-02T00:20:43.026Z" },
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", extras = ["tasks"], specifier = "==4.0.0b3" },
+    { name = "fastmcp", extras = ["tasks"], specifier = "==4.0.1" },
     { name = "httpx2", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pypng", specifier = ">=0.20" },


### PR DESCRIPTION
### **User description**
## Summary

Closes the #311 promise ("follow stable 4.x when it ships"): **FastMCP 4 went stable** — v4.0.0 GA on 2026-08-31, v4.0.1 patch on 2026-09-02. We move off the beta pin onto the stable line, built on **MCP SDK v2 + the 2026-07-28 sessionless protocol** — the exact migration issue #386 planned for and found we were already shaped for.

## Changes

- `fastmcp[tasks]==4.0.1` + lockstep `[tool.uv] constraint-dependencies` (`fastmcp-slim`/`fastmcp-tasks` → 4.0.1); constraint-block comment rewritten — its original purpose (prerelease resolution workaround, #311) is gone; kept as drift-prevention
- Pin-drift test renamed/updated: `test_fastmcp_pinned_to_4_stable` now also asserts the slim/tasks constraints ride the same version
- Pin comments updated to describe the stable posture

## Breaking-change audit (issue #403's table)

| GA breaking change | Our exposure |
|---|---|
| `ctx.elicit()` old-protocol-only | Already migrated — #346 `InputRequiredResult` guard pattern |
| Server-initiated sampling/roots removed | Not used |
| FastMCP 3 deprecated APIs removed | None in use — `create_server`/`ToolTransform`/middleware all on 4.x APIs |
| snake_case MCP model fields | Already snake_case (`structured_content`…) — no camelCase access found |
| Background tasks → `fastmcp-tasks` | Pin moved in lockstep; `task=True` tools covered by `test_background_tasks.py` |
| `Client("")` bare-string deprecated | Not used |

## The result

**689 passed unchanged** except the pin-drift test itself — the #386 migration plan's "expected delta ≈ zero" prediction verified on GA. The only warning is FastMCP-internal (`send_log_message`, kept deliberately per their compat directive, removed with their multi-round-trip follow-up) — not an API we call.

## Test plan

- [x] Red-first honored: the pin-drift test (`test_fastmcp_pinned_to_4_beta`) failed on the bump before being updated to pin 4.0.1 + lockstep constraints
- [x] Full suite: 689 passed, 0 skipped
- [x] `ruff check` / `mypy` / zero-skip clean
- [x] `uv lock` resolves 101 packages; server imports and runs on 4.0.1

## Release note

Per #403's plan: on merge this lands with the 7 post-b4 fix commits in `2026.09.02b1` — the first release on stable FastMCP. Moving out of beta is the maintainer's call at that point.


___

### **PR Type**
Enhancement


___

### **Description**
- Upgrade FastMCP to 4.0.1 stable

- Move slim/tasks constraints to 4.0.1

- Update pin-drift test for stable

- No public API behavior changes expected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FastMCP 4.0.0b3"] -- "upgrade" --> B["FastMCP 4.0.1 stable"]
  B -- "lockstep constraints" --> C["fastmcp-slim and fastmcp-tasks"]
  B -- "pin verification" --> D["test_fastmcp_pinned_to_4_stable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_smoke.py</strong><dd><code>Update FastMCP pin-drift test for stable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_smoke.py

<ul><li>Renames <code>test_fastmcp_pinned_to_4_beta</code> to <br><code>test_fastmcp_pinned_to_4_stable</code>.<br> <li> Asserts the <code>fastmcp</code> dependency pins <code>4.0.1</code> instead of <code>4.0.0b3</code>.<br> <li> Adds assertions that <code>fastmcp-slim</code> and <code>fastmcp-tasks</code> constraints match <br>the stable pin.<br> <li> Updates comments to describe the stable 4.0 line and sessionless <br>protocol context.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/404/files#diff-008371c35537b64b848b5bf9bbbdde45d83123a288bf5e4b763733844a17bcb8">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump FastMCP dependency to stable 4.0.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Bumps <code>fastmcp[tasks]</code> from <code>4.0.0b3</code> to <code>4.0.1</code>.<br> <li> Updates <code>[tool.uv] constraint-dependencies</code> to <code>fastmcp-slim==4.0.1</code> and <br><code>fastmcp-tasks==4.0.1</code>.<br> <li> Rewrites pin comments from a beta workaround to stable drift <br>prevention.<br> <li> Notes that stable 4.0 is built on MCP SDK v2 and the sessionless <br>protocol.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/404/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+16/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

