### PR TITLE
Release 2026.09.02: first stable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # Prereleases (b1, a1, rc1) go to PyPI as-is — pip install --pre picks them up.
-          # PyPI accepts prerelease versions natively.
+          # Stable releases go to PyPI as-is; if a prerelease (b1, rc1) is ever
+          # cut again, pip install --pre picks those up — PyPI accepts
+          # prerelease versions natively.
           skip-existing: true
 
   publish-github:

--- a/.opencode/rules/enforcement.md
+++ b/.opencode/rules/enforcement.md
@@ -38,4 +38,4 @@ CI does not exist yet (greenfield). Wire these gates into a workflow as part of 
 
 ## Versioning
 
-CalVer `YYYY.MM.DD[-N]`. Current: **2026.08.31b4** (beta 4).
+CalVer `YYYY.MM.DD[-N]`. Current: **2026.09.02** (first stable).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > **Status:** feature-complete across the planned ecosystem. **180 tools** across **29 categories** — always-on `core` plus 28 toggleable toolsets, of which only `inspection` is enabled by default (the other 27 are gated off). Every capability is documented, tested, and ready for agent use.
 >
-> **Package:** `godot-editor-mcp` on [PyPI](https://pypi.org/project/godot-editor-mcp/) · **Docker:** `ghcr.io/hybridindie/godot-mcp` · **Version:** `2026.08.26b1` (beta)
+> **Package:** `godot-editor-mcp` on [PyPI](https://pypi.org/project/godot-editor-mcp/) · **Docker:** `ghcr.io/hybridindie/godot-mcp` · **Version:** `2026.09.02` (first stable)
 
 ---
 
@@ -82,7 +82,7 @@ The server is **game-agnostic** — it knows Godot, not your game. A tower-defen
 ### Option A: Install from PyPI
 
 ```bash
-pip install godot-editor-mcp --pre
+pip install godot-editor-mcp
 godot-editor-mcp  # starts the MCP server (stdio mode)
 ```
 
@@ -804,7 +804,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, workflow, conventions, and r
 
 ## Resources
 
-- [PyPI package](https://pypi.org/project/godot-editor-mcp/) — `pip install godot-editor-mcp --pre`
+- [PyPI package](https://pypi.org/project/godot-editor-mcp/) — `pip install godot-editor-mcp`
 - [Docker image](https://github.com/hybridindie/godot-mcp/pkgs/container/godot-mcp) — `docker pull ghcr.io/hybridindie/godot-mcp:latest`
 - [Model Context Protocol spec](https://modelcontextprotocol.io)
 - [FastMCP docs](https://gofastmcp.com)

--- a/godot/addons/godot_mcp/plugin.cfg
+++ b/godot/addons/godot_mcp/plugin.cfg
@@ -3,6 +3,6 @@
 name="Godot MCP"
 description="Bridges a live Godot editor to an MCP server so AI clients can drive scene authoring, inspection, and runtime over a localhost WebSocket."
 author="hybridindie"
-version="2026.08.31b4"
+version="2026.09.02"
 script="godot_mcp.gd"
 icon="icon.png"

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -9,7 +9,7 @@ See ``docs/architecture.md`` for the bridge contract.
 """
 
 # CalVer, kept in sync with pyproject.toml and .opencode/rules/enforcement.md.
-__version__ = "2026.08.31b4"
+__version__ = "2026.09.02"
 
 # Tool-contract / compatibility version — a monotonic integer, deliberately
 # distinct from the CalVer build version. It expresses the *contract*: bump it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-editor-mcp"
-version = "2026.08.31b4"
+version = "2026.09.02"
 description = "MCP server that drives a live Godot editor for AI-driven game development"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,7 +8,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "John Doh", email = "johnd@johndstudios.net" }]
 keywords = ["godot", "mcp", "ai", "game-development", "model-context-protocol", "editor-automation"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: AsyncIO",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",

--- a/skills/godot-getting-started/SKILL.md
+++ b/skills/godot-getting-started/SKILL.md
@@ -5,7 +5,7 @@ description: Connect to and drive a Godot editor through the godot-mcp server. U
 
 # godot: getting started
 
-godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. This skill documents the **2026.08.31b4** surface — 180 tools, 29 categories. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the three most common failures: a version mismatch, missing tools, and unconfirmed destructive edits.
+godot-mcp exposes the Godot editor (inspection, scene edits, scripts, runtime) over MCP. This skill documents the **2026.09.02** surface — 180 tools, 29 categories. Tools are named `godot_<toolset>_<action>`. Read this once at the start of a Godot session — it prevents the three most common failures: a version mismatch, missing tools, and unconfirmed destructive edits.
 
 ## 1. Confirm the bridge and the version
 
@@ -16,7 +16,7 @@ godot_health_check()      # bridge connected? which URL? → also returns versio
 godot_get_server_info()   # version, contract_version, toolsets, active scene, next_steps
 ```
 
-- `godot_health_check()` returns `version` — if it isn't **2026.08.31b4**, this skill may be stale; rely on `godot_get_server_info()`'s toolset/tool inventory instead of the counts here.
+- `godot_health_check()` returns `version` — if it isn't **2026.09.02**, this skill may be stale; rely on `godot_get_server_info()`'s toolset/tool inventory instead of the counts here.
 - `godot_get_server_info()` returns `contract_version` (tool-surface compatibility, currently 1) — a client is compatible when `min_compatible_contract <= yours <= contract_version`.
 - If disconnected: open the `godot/` project in Godot 4.4+ (validated on 4.7), enable the plugin (Project Settings → Plugins → godot_mcp), and check the status dock.
 

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "godot-editor-mcp"
-version = "2026.8.31b4"
+version = "2026.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
### **User description**
## Summary

The first **stable** release. Beta is over because the last prerelease dependency is gone: FastMCP moved from `4.0.0b3` to `4.0.1` stable in #404, and a lockfile scan confirms **zero prerelease versions remain in the graph** — the only one left was our own self-reference.

## Version bump (same file set as #380/#389, plus stable posture)

- `pyproject.toml`: `2026.08.31b4` → `2026.09.02` + classifier `Development Status :: 5 - Production/Stable`
- `mcp_server/__init__.py` / `godot/addons/godot_mcp/plugin.cfg`: → `2026.09.02`
- `.opencode/rules/enforcement.md`: Current → `2026.09.02 (first stable)`
- `uv.lock`: self-reference → `2026.9.2`
- `skills/godot-getting-started/SKILL.md`: version references (drift test catches this red — it did in b4)
- **README**: `pip install godot-editor-mcp --pre` → `pip install godot-editor-mcp` (two spots) — the `--pre` flag would actively *hide* the stable release from fresh installs
- `publish.yml` comment updated (prerelease framing → stable)

## What's in 2026.09.02 (since b4)

8 commits — the consumer-hardening batch (#394–#402, by @MuhamadBarzani) plus the FastMCP stable upgrade:

- **#394** — argument coercion middleware: repairs stringified JSON args per tool input schema (OpenCode-style clients); every `properties`/`value`/`events`/`dry_run` tool unblocked
- **#395** — screenshot: deferred two-phase capture; macOS Metal read-back no longer stalls the router
- **#396** — `force_break` pauses non-cooperating games (probe self-service in `_process`)
- **#397** — `GODOT_MCP_DEFAULT_TOOLSETS` env seeding
- **#399/#401** — import/scan race: bounded e2e poll + `wait_for_scan`/`wait_ms`/`scan_complete`
- **#402** — mypy strict conformance for the merge batch
- **#404 (#403)** — **FastMCP 4.0.1 stable** (MCP SDK v2, 2026-07-28 sessionless protocol); breaking-change audit clean, 689 tests unchanged

`CONTRACT_VERSION` remains **1** — additive-only changes throughout.

## Test plan

- [x] `uv build` → wheel metadata verified: `Version: 2026.9.2`, `Development Status :: 5 - Production/Stable`, `fastmcp[tasks]==4.0.1`
- [x] 689 passed, 0 skipped (incl. CalVer, pyproject-sync, plugin.cfg-lockstep, skill-version-drift)
- [x] `ruff check` / `mypy` / zero-skip clean
- [x] Lockfile: zero prerelease versions


___

### **PR Type**
Documentation, Other


___

### **Description**
- Bump version to 2026.09.02 stable

- Mark package production/stable in metadata

- Update install docs without prerelease flag

- No public API behavior changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["2026.08.31b4"] -- "version bump" --> B["2026.09.02"]
  B -- "metadata sync" --> C["pyproject, server, addon"]
  B -- "docs update" --> D["README, skill, rules"]
  B -- "install docs" --> E["PyPI stable install"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Update server package version constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-0ee260f94eefb5341ba2f880808d78577c1e28ab8efa6209e2b12753496409d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin.cfg</strong><dd><code>Update Godot addon plugin version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-505361f53d50c88c282a85d8bff795aed2e43e41ce9cfe2d4b7d332bfa8c14f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Bump project version and stability classifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>publish.yml</strong><dd><code>Update publish workflow stable release comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enforcement.md</strong><dd><code>Update enforcement rule current version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-688b42a0fee7d33fb02e12946e7605b1b44f14ecfb129ef4cad7226fd37932e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update stable version and install instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SKILL.md</strong><dd><code>Update getting-started skill version references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/405/files#diff-2e76fc71066ad43d91d7382c6f64f051cfc58f8eba73b4f43c709690e242615f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

