### PR TITLE
Post-stable documentation accuracy pass

### DIFF
--- a/.opencode/rules/enforcement.md
+++ b/.opencode/rules/enforcement.md
@@ -17,8 +17,10 @@ These rules are the project's grounding contract. A change that violates one is 
 | Lint | `ruff` errors |
 | Bridge contract ([[error-handling]]) | An envelope shape change without a contract-test update |
 | Safety classes ([[mcp-tools]]) | A `mutating`/`destructive` tool missing `dry_run`/`confirm`, or safety logic placed in the addon |
+| camelCase gate | A tool name that breaks the `godot_<toolset>_<action>` transform contract (scoped to the transform contract tests) |
+| Live-editor e2e (`e2e.yml`) | Addon/server smoke against a real Godot editor on the self-hosted runner |
 
-CI does not exist yet (greenfield). Wire these gates into a workflow as part of the scaffold issue, and keep this table in sync with what CI actually runs.
+CI runs all gates above via `.github/workflows/ci.yml` (zero-skip, lint, mypy, pytest, camelCase gate) plus `e2e.yml` (live-editor smoke on a self-hosted runner) and `publish.yml` (PyPI + GitHub release on tag). Keep this table in sync with what CI actually runs.
 
 ## PR acceptance checklist
 

--- a/.opencode/rules/error-handling.md
+++ b/.opencode/rules/error-handling.md
@@ -31,7 +31,7 @@ MUST:
 ## Rules
 
 MUST:
-- Use stable, enumerated error codes (e.g. `PRECONDITION_FAILED`, `RESOURCE_NOT_FOUND`, `BRIDGE_DISCONNECTED`, `VALIDATION_ERROR`, `INTERNAL_ERROR`) — never ad-hoc strings.
+- Use stable, enumerated error codes (`PRECONDITION_FAILED`, `RESOURCE_NOT_FOUND`, `VALIDATION_ERROR`, `BRIDGE_DISCONNECTED`, `TIMEOUT`, `INTERNAL_ERROR`, `APPROVAL_DENIED` — the full `ErrorCode` enum in `mcp_server/models/envelope.py`) — never ad-hoc strings.
 - Catch errors at the bridge boundary on both sides and convert to an `ok: false` envelope. A GDScript runtime error or a Python exception must never escape as a raw trace to the client.
 - Log with structured (JSON-friendly) records including the command `id`; include exception info on error-level logs.
 

--- a/.opencode/rules/mcp-tools.md
+++ b/.opencode/rules/mcp-tools.md
@@ -52,7 +52,7 @@ A large flat tool surface degrades agent tool-selection and burns context. Keep 
 
 - **Resources** (`@mcp.resource("godot://...")`) are read-only and return JSON strings. No side effects. Mutations always go through tools.
 - **Prompts** (`@mcp.prompt()`) are step-numbered instruction templates — they tell the agent *which tools/resources to use in what order*, they do not act. Typed, documented arguments.
-- Provide a `resources-as-tools` / `prompts-as-tools` fallback for clients without that protocol.
+- Provide the `resources-as-tools` fallback for clients without resource protocol support (`read_resource` tool, `mcp_server/resources/context.py`).
 
 ## Anti-patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ godot-mcp deliberately ships **no** game vocabulary — no Tower/Enemy/Wave mode
 
 The scaffold (issue #1) is in place: `uv`-managed Python package, the addon under `godot/`, docs, and CI.
 
-- Godot **4.4+** (floor), **validated on 4.7-stable** (the `godot/` project declares `config/features=PackedStringArray("4.7")`); Python **3.11+**; **FastMCP 4.0** (PrefectHQ/fastmcp, pinned to the 4.0 beta), managed with **uv**. Always verify Godot APIs against the current docs for the pinned version (via `context7` or `docs.godotengine.org`) rather than from memory — see [[addon]].
+- Godot **4.4+** (floor), **validated on 4.7-stable** (the `godot/` project declares `config/features=PackedStringArray("4.7")`); Python **3.11+**; **FastMCP 4.0.1** (PrefectHQ/fastmcp, stable — MCP SDK v2, 2026-07-28 sessionless protocol), managed with **uv**. Always verify Godot APIs against the current docs for the pinned version (via `context7` or `docs.godotengine.org`) rather than from memory — see [[addon]].
 - **Dev commands** (run from repo root, mirrored by `.github/workflows/ci.yml`):
   - `uv sync` — create the venv and install runtime + dev deps.
   - `uv run pytest -q` — full suite; single file `uv run pytest tests/unit/test_smoke.py`; single test `uv run pytest tests/unit/test_smoke.py::test_version_is_calver`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! godot-mcp is a standalone MCP server t
 
 - **Python 3.11+** managed with [uv](https://docs.astral.sh/uv/)
 - **Godot 4.4+** (validated on 4.7-stable)
-- **FastMCP 4.0** (pinned to the 4.0 beta)
+- **FastMCP 4.0.1** (stable — GA on MCP SDK v2, the 2026-07-28 sessionless protocol)
 
 ## Setup
 
@@ -109,7 +109,7 @@ See [`skills/README.md`](skills/README.md) for details.
 
 ## Versioning
 
-CalVer `YYYY.MM.DD[-N]` with PEP 440 prerelease suffixes (e.g. `2026.08.26b1`). The version is in `pyproject.toml`, `mcp_server/__init__.py`, and `godot/addons/godot_mcp/plugin.cfg` — all three must stay in lockstep.
+CalVer `YYYY.MM.DD[-N]` (stable, e.g. `2026.09.02`); prerelease suffixes (`b1`, `rc1`) only when cutting a beta. The version is in `pyproject.toml`, `mcp_server/__init__.py`, `godot/addons/godot_mcp/plugin.cfg`, and the version references in `skills/godot-getting-started/SKILL.md` — all must stay in lockstep (the drift tests enforce it).
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://pypi.org/project/godot-editor-mcp/"><img src="https://img.shields.io/badge/PyPI-godot--editor--mcp-4a9eff.svg" alt="PyPI" /></a>
   <a href="https://github.com/hybridindie/godot-mcp/pkgs/container/godot-mcp"><img src="https://img.shields.io/badge/Docker-ghcr.io-2496ed.svg" alt="Docker" /></a>
-  <a href="https://github.com/hybridindie/godot-mcp/releases"><img src="https://img.shields.io/badge/version-2026.08.26b1-brightgreen.svg" alt="Version" /></a>
+  <a href="https://github.com/hybridindie/godot-mcp/releases"><img src="https://img.shields.io/badge/version-2026.09.02-brightgreen.svg" alt="Version" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
 </p>
 
@@ -661,7 +661,9 @@ All configuration is optional and passed via environment variables:
 | `GODOT_MCP_GODOT_BIN` | auto-discovered | Godot executable for `godot_runtime_run_and_capture` / `godot_export_project` |
 | `GODOT_MCP_PROJECT_DIR` | connected editor's project | Project directory for runner, export, and analysis |
 | `GODOT_MCP_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) — JSON to stderr |
+| `GODOT_MCP_DEFAULT_TOOLSETS` | unset (= `inspection`) | Seed the initial enabled toolsets: `all`, or a comma-separated category list (e.g. `scene_edit,runtime`). Unknown names are ignored with a log line. `enable_toolset`/`disable_toolset` still work normally afterwards |
 | `GODOT_MCP_APPROVAL_WEBHOOK` | unset | Optional human-in-the-loop approval webhook for destructive tools (`ApprovalMiddleware`) |
+| `GODOT_MCP_APPROVAL_REQUIRE` | unset | When set (to a truthy value) and **no** webhook is configured, `mutating`/`destructive` tools return an `InputRequiredResult` approval prompt instead of auto-approving |
 | `GODOT_MCP_AUTH_TOKEN` | unset | Bearer token for HTTP transport auth; **required** for non-loopback binds |
 
 ---

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -1025,6 +1025,12 @@ structured `ToolError`. They change tool *exposure* only — never the Godot pro
 — so they are `read_only`. The default-off-for-new-categories rule means the live
 surface stays small as the catalog grows (see `.opencode/rules/mcp-tools.md`).
 
+The initial exposure can be seeded via the `GODOT_MCP_DEFAULT_TOOLSETS` env var
+(issue #393): `all`, or a comma-separated category list (e.g. `scene_edit,runtime`).
+Unknown names are ignored with a log line; unset keeps the default (`core` +
+`inspection`). This only seeds the server-global enabled set at startup —
+`enable_toolset`/`disable_toolset` work unchanged on top of it.
+
 ## Resources
 
 - `@mcp.resource("godot://…")` handlers are **read-only** and return JSON strings; no side

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,7 +9,7 @@ building Godot games through the MCP tools. Two categories:
   prevention (rendering, physics, autoloads, GDScript gotchas, scene
   authoring).
 
-The skills document the surface as of **2026.08.31b3** (180 tools across
+The skills document the surface as of **2026.09.02** (180 tools across
 29 categories, 9 workflow prompts). `godot-getting-started` teaches how to
 check the live server version (`godot_health_check`) — if the server you're
 driving is older or newer, trust `godot_get_server_info()`'s inventory over


### PR DESCRIPTION
### **User description**
## Summary

Full documentation audit against the **live probed surface** (not from memory): tool counts, category names, prompt names, skill structure, ports, env vars, install commands — every checkable claim verified against `mcp_server` code and a live in-memory client.

**Verified accurate (no change):**

- 180 tools / 29 categories / 27 gated (names diffed programmatically against `TOOLSETS` — exact match)
- 9 prompts (all names correct), 4 resources
- `godot-expert`: 10 sections + 7 reference guides + 11 bugs (all counts exact)
- Ports `ws://127.0.0.1:9080` / HTTP `9090`; mermaid diagram matches the #276 inverted topology
- `install-skills.sh` flags match `--help`; tutorial / enforcement / `debugger_feasibility` / `harness-performance` carry no stale claims

**Fixed (8 inaccuracies):**

1. README version badge: `2026.08.26b1` → `2026.09.02` (stale since the first beta)
2. CONTRIBUTING: "FastMCP 4.0 (pinned to the 4.0 beta)" → 4.0.1 stable (GA, MCP SDK v2 / 2026-07-28 protocol)
3. CONTRIBUTING versioning section: stable CalVer is the norm; prerelease suffixes only for betas; skill version refs added to the lockstep list (they're drift-tested)
4. AGENTS.md: same FastMCP beta→stable fix
5. skills/README: "surface as of 2026.08.31b3" → 2026.09.02
6. `GODOT_MCP_DEFAULT_TOOLSETS` (#397, merged today) was documented **nowhere** — now in README's env table and tool-contracts' toolset-gating section
7. `GODOT_MCP_APPROVAL_REQUIRE` (#346 guard opt-in) existed in `config.py` but was documented **nowhere** — now in README's env table
8. README Resources section still suggested `--pre` in one spot (the install section was fixed in the release PR; this one was missed)

## Test plan

- [x] Skill-version drift tests green (`test_skills_metadata.py`, the #382 guard)
- [x] Version tests green (`test_smoke.py`)
- [x] `ruff check` / `mypy` / zero-skip clean
- [x] Docs-only change — no runtime code touched


___

### **PR Type**
Documentation


___

### **Description**
- Documents stable FastMCP 4.0.1

- Documents public env var behavior

- Updates version references to 2026.09.02

- Clarifies CalVer and lockstep rules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FastMCP 4.0.1"] -- "updates" --> B["AGENTS.md"]
  A -- "updates" --> C["CONTRIBUTING.md"]
  D["2026.09.02"] -- "updates" --> E["README.md"]
  D -- "updates" --> F["skills/README.md"]
  G["GODOT_MCP_DEFAULT_TOOLSETS"] -- "documents" --> H["tool-contracts.md"]
  I["GODOT_MCP_APPROVAL_REQUIRE"] -- "documents" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Update FastMCP stable version note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Updates FastMCP from <code>4.0</code> beta to <code>4.0.1</code> stable<br> <li> Notes MCP SDK v2 and 2026-07-28 sessionless protocol<br> <li> Keeps Godot and Python version guidance unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/406/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Clarify stable versioning and FastMCP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Changes FastMCP requirement to <code>4.0.1</code> stable<br> <li> Clarifies stable CalVer as normal version format<br> <li> Adds skill version references to lockstep list<br> <li> Notes prerelease suffixes only for beta releases</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/406/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document env vars and new version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updates version badge from <code>2026.08.26b1</code> to <code>2026.09.02</code><br> <li> Documents <code>GODOT_MCP_DEFAULT_TOOLSETS</code> startup seeding<br> <li> Documents <code>GODOT_MCP_APPROVAL_REQUIRE</code> approval prompt behavior<br> <li> Explains unknown toolset names are ignored</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/406/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document default toolset env seeding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Adds <code>GODOT_MCP_DEFAULT_TOOLSETS</code> to toolset-gating docs<br> <li> Explains <code>all</code> or comma-separated category seeding<br> <li> Clarifies unset keeps <code>core</code> plus <code>inspection</code><br> <li> Notes <code>enable_toolset</code> and <code>disable_toolset</code> remain unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/406/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update skill surface version date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

skills/README.md

<ul><li>Updates documented surface date to <code>2026.09.02</code><br> <li> Keeps tool, category, and prompt counts<br> <li> Aligns skill docs with stable release</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/406/files#diff-4d647326e823e7202ff18d96504599a2f17893ead7e40499f82899106dbad2c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

