### PR TITLE
Fix two defective tests in toolsets and audio e2e

### DIFF
--- a/tests/integration/test_audio_e2e.py
+++ b/tests/integration/test_audio_e2e.py
@@ -121,9 +121,13 @@ async def _run() -> None:
         )
         assert unknown_bus.ok is False and unknown_bus.error == "VALIDATION_ERROR"
         bad_effect = await bridge.send(
-            "cmd_add_audio_bus_effect", {"bus": "Music", "effect_type": "Node"}
+            "cmd_add_audio_bus_effect", {"bus": "Master", "effect_type": "Node"}
         )
+        # Pin the effect-type validation, not the bus-existence check: Master
+        # always exists, so a failure that produces "No audio bus" would indicate
+        # the addon validated in the wrong order (or a wrong-regression).
         assert bad_effect.ok is False and bad_effect.error == "VALIDATION_ERROR"
+        assert bad_effect.hint and "not an AudioEffect" in bad_effect.hint
         bad_stream = await bridge.send(
             "cmd_add_audio_player",
             {

--- a/tests/unit/test_toolsets.py
+++ b/tests/unit/test_toolsets.py
@@ -39,13 +39,28 @@ def test_toolset_min_godot_keys_are_valid_categories() -> None:
         assert category in TOOLSETS, f"Unknown toolset '{category}' in TOOLSET_MIN_GODOT"
 
 
-def test_toolset_min_godot_tuple_ordering() -> None:
-    """Version comparison via tuple < works as expected for Godot versions."""
-    assert (4, 3) < (4, 4)
-    assert (4, 4) < (4, 5)
-    assert (3, 5) < (4, 4)
-    assert (4, 4) == (4, 4)
-    assert not ((4, 4) < (4, 4))
+def test_toolset_min_godot_floors_are_valid_and_comparable() -> None:
+    """Every TOOLSET_MIN_GODOT floor is a well-formed, comparable version tuple.
+
+    This pins the actual configuration rather than reasserting Python's tuple
+    comparison semantics (the previous test could never fail). Each floor must be
+    a (major, minor) pair with a supported major, and the dict itself non-empty.
+    """
+    assert TOOLSET_MIN_GODOT, "TOOLSET_MIN_GODOT must not be empty"
+    for category, floor in TOOLSET_MIN_GODOT.items():
+        assert isinstance(floor, tuple) and len(floor) == 2, (
+            f"Toolset '{category}' floor {floor!r} is not a (major, minor) tuple"
+        )
+        major, minor = floor
+        assert isinstance(major, int) and isinstance(minor, int), (
+            f"Toolset '{category}' floor {floor!r} is not a two-int tuple"
+        )
+        assert major >= 4, (
+            f"Toolset '{category}' floor {floor!r} is below the supported major"
+        )
+        # Sanity: a valid tuple must always order against itself consistently.
+        assert not (floor < floor)
+        assert floor == tuple(floor)
 
 
 # --- GODOT_MCP_DEFAULT_TOOLSETS startup seeding (issue #393) -----------------


### PR DESCRIPTION
### **User description**
## Summary

Two genuine defects surfaced by a normal review of the test suite (dispatched explorer agents over the contract/unit/integration/shared-infra tiers and hand-verified each finding). Test-only changes; no production code touched.

**1. `tests/unit/test_toolsets.py` — a test that could never fail.** `test_toolset_min_godot_tuple_ordering` asserted only Python tuple-comparison semantics (`(4,3) < (4,4)`, …), reading nothing from `TOOLSET_MIN_GODOT` or any product code. It documents the language, not the project. Replaced with `test_toolset_min_godot_floors_are_valid_and_comparable`, which iterates the real `TOOLSET_MIN_GODOT` config and asserts each floor is a valid `(major >= 4, minor)` tuple plus self-consistency. **Verified non-tautological:** it trips on a fabricated `(3, 0)` floor.

**2. `tests/integration/test_audio_e2e.py` — passes for the wrong reason.** The `bad_effect` case sent `{"bus": "Music", "effect_type": "Node"}`, but the `Music` bus is **removed earlier** in the same scenario. The addon validates bus-existence before effect-type (`handlers/audio.gd`), so this hit the "No audio bus" branch, not the "is not an AudioEffect" branch it claimed — meaning a regression that let a bad `effect_type` through would go undetected. Now targets the always-present `Master` bus **and** pins the response hint to `"not an AudioEffect"` so the effect-type branch is genuinely exercised.

Closes #432.

## Checklist

- [x] Test-only change (no production code)
- [x] Verified #1 is genuinely data-driven (fails on a fabricated bad floor)
- [x] Verified #2 now exercises the intended validation branch
- [x] Unit suite: 243 passed
- [x] `ruff check` clean on both files
- [x] `mypy` clean on both files
- [x] zero-skip gate clean
- [x] Audio e2e collects cleanly (skipif-gated on the Godot binary, as intended)

## Test plan

- `uv run pytest tests/unit/test_toolsets.py -q` → 18 passed
- `uv run pytest tests/unit/ -q` → 243 passed
- `uv run pytest tests/integration/test_audio_e2e.py --collect-only -q` → 1 collected (live-editor test, gated on `GODOT_BIN`)
- `uv run ruff check .` and `uv run mypy` + zero-skip gate clean

Note: the live audio e2e runs on the self-hosted Godot runner via `e2e.yml`; it cannot be executed here without a Godot binary, but the change is a target-parameter + assertion-strengthening only.


___

### **PR Type**
Tests


___

### **Description**
- Fix tautological toolset version test

- Make audio effect test target Master

- Pin effect-type validation hint

- Test-only changes, no production code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test suite review"] -- "finds defects" --> B["toolsets unit test"]
  A -- "finds defects" --> C["audio e2e test"]
  B -- "data-driven floor checks" --> D["Validated tests"]
  C -- "Master bus and hint pin" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_e2e.py</strong><dd><code>Target Master bus and pin effect-type hint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_audio_e2e.py

<ul><li>Change bad_effect case from removed Music bus to always-present Master <br>bus<br> <li> Add assertion that hint contains "not an AudioEffect"<br> <li> Ensure effect-type validation branch is exercised, not bus-existence <br>branch<br> <li> Add explanatory comment about validation order</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/408/files#diff-a0399e0a9330a6c0ac398d83a4c05548c647ebf50ed59647bd9830732b4597f5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_toolsets.py</strong><dd><code>Replace tautological toolset floor test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_toolsets.py

<ul><li>Replace tautological tuple-ordering test with data-driven <br>TOOLSET_MIN_GODOT validation<br> <li> Assert dict non-empty and each floor is a two-int tuple<br> <li> Assert major >= 4 and self-comparison consistency<br> <li> Remove assertions that only tested Python tuple semantics</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/408/files#diff-dfab2b1942f5b880dfeb6eae1e5dd1a71a836326e2703af594fe12053f57bed0">+22/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___