### PR TITLE
Fix project scaffold confirm forwarding

### DIFF
--- a/mcp_server/tools/project_scaffold.py
+++ b/mcp_server/tools/project_scaffold.py
@@ -66,10 +66,13 @@ def register_project_scaffold(
             )
         if not dry_run:
             require_confirmation(confirm, "scaffold_project")
-        params: dict[str, str] = {
+        params: dict[str, str | bool] = {
             "type": type,
             "project_name": project_name or type,
             "main_scene": main_scene or "main",
+            # Forward the destructive gate to the addon: it re-checks confirm
+            # defensively (#409) and would reject the call without it.
+            "confirm": confirm,
         }
         preview = {
             "created": False,

--- a/tests/contract/test_project_scaffold.py
+++ b/tests/contract/test_project_scaffold.py
@@ -76,6 +76,21 @@ async def test_scaffold_project_success() -> None:
     assert "cmd_scaffold_project" in _commands(conn)
 
 
+async def test_scaffold_forwards_confirm_to_addon() -> None:
+    # #409: the addon re-gates destructively on params.confirm; the tool must
+    # forward the caller's confirm flag in the bridge envelope, or the addon
+    # rejects the very call the server-side gate already approved.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "project_scaffold"})
+        await client.call_tool(
+            "godot_project_scaffold",
+            {"type": "3d_fps", "project_name": "Shooter", "confirm": True},
+        )
+    last = CommandEnvelope.model_validate_json(conn.sent[-1])
+    assert last.params.get("confirm") is True
+
+
 async def test_scaffold_project_requires_confirm() -> None:
     server, conn = _build()
     async with Client(server) as client:


### PR DESCRIPTION
### **User description**
## Summary

`godot_project_scaffold` was 100% dead: the server-side `require_confirmation` gate passed on `confirm=true`, but the tool built bridge params containing only `type`/`project_name`/`main_scene` — `confirm` was never forwarded. The addon then re-gated defensively on `params.confirm` (handlers/project_scaffold.gd:62) and rejected every call with the exact `PRECONDITION_FAILED` from the issue report.

Fix: include `"confirm": confirm` in the params dict (mcp_server/tools/project_scaffold.py).

## Acceptance criteria (from #409)

- [x] With `confirm=true`, the call reaches the addon with the confirmation the gate demanded
- [x] Server-side gate unchanged (still blocks falsy confirm before any bridge call)
- [x] Addon untouched — its defensive re-check now finally sees the flag it asked for

## Test plan

- New contract test `test_scaffold_forwards_confirm_to_addon` asserts `confirm` reaches the envelope — **verified red before the fix** (failed on `params.get("confirm") is True`)
- Full suite: 690 passed, 0 skipped (zero-skip gate clean)
- `ruff check` + `mypy` clean
- Note: one flaky run of `test_addon_bridge_reconnect_backoff` during full-suite runs (port contention with the live-editor suites); passes in isolation on main and on this branch, and the re-run of the full suite was clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes scaffold tool confirm forwarding

- No MCP schema change; confirm forwarded

- Addon gate now receives confirm flag

- Adds test; confirmed scaffold can proceed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCP tool"]
  B["Bridge envelope"]
  C["Addon gate"]
  D["Project scaffold"]
  A -- "adds confirm param" --> B
  B -- "forwards confirm" --> C
  C -- "allows mutation" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project_scaffold.py</strong><dd><code>Forward confirm to addon gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/project_scaffold.py

<ul><li>Adds confirm to bridge params<br> <li> Widens params type to include bool<br> <li> Documents addon re-check requirement<br> <li> Allows confirmed destructive scaffold to proceed</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/433/files#diff-8660d5903f7d4910de781db7dcd47a1af4328e5f64d438127e9a95f065d19d2e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_project_scaffold.py</strong><dd><code>Add confirm forwarding contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_project_scaffold.py

<ul><li>Adds contract test for confirm forwarding<br> <li> Asserts envelope params include confirm true<br> <li> Covers destructive gate behavior<br> <li> Validates toolset is no longer dead</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/433/files#diff-06dd859c8a3223526a255e9e1b987f69d570361263d9845a0a03d89183ef8af7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

