### PR TITLE
Fix `run_commands` bare-name resolution and param mapping

### DIFF
--- a/mcp_server/command_map.py
+++ b/mcp_server/command_map.py
@@ -1,0 +1,331 @@
+"""Bare-name resolution and param translation for ``run_commands`` (#420, #421).
+
+``godot_composite_run_commands`` accepts sub-commands in three forms: the addon
+command (``cmd_set_physics_layers``), the bare action name of an *untrimmed*
+tool (``set_node_property``), and — the gap this module closes — the bare
+exposed name of a tool whose action the ``godot_`` transform trimmed or
+reordered (``set_layers`` → ``cmd_set_physics_layers``, ``add_bus`` →
+``cmd_add_audio_bus``).
+
+The table below is static and mirrors the tool registry: ``BARE_TO_COMMAND``
+is derived from the same ``godot_tool_name``/handler data the tool surface is
+registered with (see tests/unit/test_command_map.py, which cross-checks it
+against the live registry so it cannot drift). Params are passed through
+verbatim except where a tool's Python signature renames the addon's key —
+currently only ``node_name`` → ``name`` (create/compose).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Exposed bare name (exposed tool name minus the ``godot_`` prefix) -> the addon
+# command the tool actually routes to. Single-bridge-command tools only:
+# multi-step orchestrators (run_test_scenario, run_stress_test, run_tests,
+# export_project, debug_workflow) run several commands with interleaved logic
+# and cannot be expressed as one batch entry.
+BARE_TO_COMMAND: dict[str, str] = {
+    "animation_add_state_machine_state": "cmd_add_state_machine_state",
+    "animation_add_track": "cmd_add_animation_track",
+    "animation_create": "cmd_create_animation",
+    "animation_create_tree": "cmd_create_animation_tree",
+    "animation_get": "cmd_get_animation",
+    "animation_insert_keyframe": "cmd_insert_keyframe",
+    "animation_list_animations": "cmd_list_animations",
+    "animation_set_blend_tree_node": "cmd_set_blend_tree_node",
+    "asset_import_asset": "cmd_import_asset",
+    "asset_import_create_material_from_textures": "cmd_create_material_from_textures",
+    "asset_import_get_status": "cmd_get_import_status",
+    "audio_add_bus": "cmd_add_audio_bus",
+    "audio_add_bus_effect": "cmd_add_audio_bus_effect",
+    "audio_add_player": "cmd_add_audio_player",
+    "audio_get_bus_layout": "cmd_get_audio_bus_layout",
+    "audio_remove_bus": "cmd_remove_audio_bus",
+    "audio_remove_bus_effect": "cmd_remove_audio_bus_effect",
+    "batch_cross_scene_set_property": "cmd_cross_scene_set_property",
+    "batch_find_nodes_by_type": "cmd_find_nodes_by_type",
+    "batch_get_dependencies": "cmd_get_dependencies",
+    "batch_set_property": "cmd_batch_set_property",
+    "composite_apply_node_edits": "cmd_apply_node_edits",
+    "composite_batch_create_nodes": "cmd_batch_create_nodes",
+    "composite_compose_node": "cmd_compose_node",
+    "composite_run_commands": "cmd_run_commands",
+    "debugger_clear_breakpoints": "cmd_clear_breakpoints",
+    "debugger_continue_execution": "cmd_continue_execution",
+    "debugger_evaluate_expression": "cmd_evaluate_expression",
+    "debugger_force_break": "cmd_force_break",
+    "debugger_get_frame_variables": "cmd_get_frame_variables",
+    "debugger_get_stack_frames": "cmd_get_stack_frames",
+    "debugger_remove_breakpoint": "cmd_remove_breakpoint",
+    "debugger_set_breakpoint": "cmd_set_breakpoint",
+    "debugger_step_into": "cmd_step_into",
+    "debugger_step_out": "cmd_step_out",
+    "debugger_step_over": "cmd_step_over",
+    "editor_capture_screenshot": "cmd_capture_editor_screenshot",
+    "export_get_info": "cmd_get_export_info",
+    "export_list_presets": "cmd_list_export_presets",
+    "input_get_stats": "cmd_get_input_stats",
+    "input_map_add_action": "cmd_add_input_action",
+    "input_map_add_event": "cmd_add_input_event",
+    "input_map_clear_action_events": "cmd_clear_input_action_events",
+    "input_map_get_action_events": "cmd_get_input_action_events",
+    "input_map_remove_action": "cmd_remove_input_action",
+    "input_play_sequence": "cmd_play_input_sequence",
+    "input_record": "cmd_record_input",
+    "input_simulate_action": "cmd_simulate_action",
+    "input_simulate_key": "cmd_simulate_key",
+    "input_simulate_mouse": "cmd_simulate_mouse",
+    "input_stop_recording": "cmd_stop_recording",
+    "inspection_get_active_scene": "cmd_get_active_scene",
+    "inspection_get_node_groups": "cmd_get_node_groups",
+    "inspection_get_node_properties": "cmd_get_node_properties",
+    "inspection_get_node_property": "cmd_get_node_property",
+    "inspection_get_node_property_list": "cmd_get_node_property_list",
+    "inspection_get_project_info": "cmd_get_project_info",
+    "inspection_get_scene_tree": "cmd_get_scene_tree",
+    "inspection_get_selected_node": "cmd_get_selected_node",
+    "inspection_list_scenes": "cmd_list_scenes",
+    "navigation_bake_mesh": "cmd_bake_navigation_mesh",
+    "navigation_get_region": "cmd_get_navigation_region",
+    "navigation_set_layers": "cmd_set_navigation_layers",
+    "navigation_setup_agent": "cmd_setup_navigation_agent",
+    "navigation_setup_region": "cmd_setup_navigation_region",
+    "particles_apply_preset": "cmd_apply_particle_preset",
+    "particles_create": "cmd_create_particles",
+    "particles_get_material": "cmd_get_particle_material",
+    "particles_set_color_gradient": "cmd_set_particle_color_gradient",
+    "particles_set_material": "cmd_set_particle_material",
+    "physics_add_raycast": "cmd_add_raycast",
+    "physics_set_layers": "cmd_set_physics_layers",
+    "physics_setup_body": "cmd_setup_physics_body",
+    "physics_setup_collision": "cmd_setup_collision",
+    "profiling_get_editor_performance": "cmd_get_editor_performance",
+    "profiling_get_performance_monitors": "cmd_get_performance_monitors",
+    "project_delete_resource_file": "cmd_delete_resource_file",
+    "project_get_filesystem_tree": "cmd_get_filesystem_tree",
+    "project_get_setting": "cmd_get_setting",
+    "project_resolve_uid": "cmd_uid_to_path",
+    "project_scaffold": "cmd_scaffold_project",
+    "project_search_files": "cmd_search_files",
+    "project_set_setting": "cmd_set_setting",
+    "resources_edit_create_resource": "cmd_create_resource",
+    "resources_edit_read_resource_file": "cmd_read_resource",
+    "resources_edit_register_autoload": "cmd_register_autoload",
+    "resources_edit_set_resource_property": "cmd_set_resource_property",
+    "resources_edit_unregister_autoload": "cmd_unregister_autoload",
+    "runtime_find_ui_elements": "cmd_find_ui_elements",
+    "runtime_get_game_scene_tree": "cmd_get_game_scene_tree",
+    "runtime_get_property_samples": "cmd_get_property_samples",
+    "runtime_is_playing": "cmd_is_playing",
+    "runtime_monitor_property": "cmd_monitor_property",
+    "runtime_play_scene": "cmd_play_scene",
+    "runtime_stop_scene": "cmd_stop_scene",
+    "scene_3d_add_mesh_instance": "cmd_add_mesh_instance",
+    "scene_3d_add_mesh_library_item": "cmd_add_mesh_library_item",
+    "scene_3d_create_mesh_library": "cmd_create_mesh_library",
+    "scene_3d_gridmap_get_cell": "cmd_gridmap_get_cell",
+    "scene_3d_gridmap_set_cell": "cmd_gridmap_set_cell",
+    "scene_3d_setup_camera": "cmd_setup_camera",
+    "scene_3d_setup_environment": "cmd_setup_environment",
+    "scene_3d_setup_lighting": "cmd_setup_lighting",
+    "scene_edit_add_to_group": "cmd_add_to_group",
+    "scene_edit_attach_script": "cmd_attach_script",
+    "scene_edit_close_scene": "cmd_close_scene",
+    "scene_edit_connect_signal": "cmd_connect_signal",
+    "scene_edit_create_node": "cmd_create_node",
+    "scene_edit_create_scene": "cmd_create_scene",
+    "scene_edit_delete_node": "cmd_delete_node",
+    "scene_edit_disconnect_signal": "cmd_disconnect_signal",
+    "scene_edit_duplicate_node": "cmd_duplicate_node",
+    "scene_edit_instance_scene": "cmd_instance_scene",
+    "scene_edit_list_open_scenes": "cmd_list_open_scenes",
+    "scene_edit_list_signal_connections": "cmd_list_signal_connections",
+    "scene_edit_move_node": "cmd_move_node",
+    "scene_edit_open_scene": "cmd_open_scene",
+    "scene_edit_reload_scene": "cmd_reload_scene",
+    "scene_edit_remove_from_group": "cmd_remove_from_group",
+    "scene_edit_rename_node": "cmd_rename_node",
+    "scene_edit_save_all_scenes": "cmd_save_all_scenes",
+    "scene_edit_save_scene": "cmd_save_scene",
+    "scene_edit_select_nodes": "cmd_select_nodes",
+    "scene_edit_set_node_property": "cmd_set_node_property",
+    "scripts_get_for_node": "cmd_get_script_for_node",
+    "scripts_list": "cmd_list_scripts",
+    "scripts_patch": "cmd_patch_script",
+    "scripts_read": "cmd_read_script",
+    "scripts_write": "cmd_write_script",
+    "shader_assign_material": "cmd_assign_shader_material",
+    "shader_create": "cmd_create_shader",
+    "shader_get_param": "cmd_get_shader_param",
+    "shader_read": "cmd_read_shader",
+    "shader_set_param": "cmd_set_shader_param",
+    "theme_ui_create": "cmd_create_theme",
+    "theme_ui_get_node_overrides": "cmd_get_node_theme_overrides",
+    "theme_ui_set_color": "cmd_set_theme_color",
+    "theme_ui_set_font_size": "cmd_set_theme_font_size",
+    "theme_ui_set_stylebox": "cmd_set_theme_stylebox",
+    "tilemap_add_tileset_atlas_source": "cmd_add_tileset_atlas_source",
+    "tilemap_clear": "cmd_tilemap_clear",
+    "tilemap_create_tile": "cmd_create_tile",
+    "tilemap_create_tileset": "cmd_create_tileset",
+    "tilemap_fill_rect": "cmd_tilemap_fill_rect",
+    "tilemap_get_cell": "cmd_tilemap_get_cell",
+    "tilemap_get_used_cells": "cmd_tilemap_get_used_cells",
+    "tilemap_layers": "cmd_tilemap_layers",
+    "tilemap_set_cell": "cmd_tilemap_set_cell",
+    "undo": "cmd_undo",
+    "visual_shader_add_node": "cmd_add_shader_node",
+    "visual_shader_connect_nodes": "cmd_connect_shader_nodes",
+    "visual_shader_create": "cmd_create_visual_shader",
+    "visual_shader_list_node_types": "cmd_list_shader_node_types",
+    "visual_shader_read": "cmd_read_visual_shader",
+    "visual_shader_set_node_param": "cmd_set_shader_node_param",
+}
+
+# Param keys the tool layer renames before sending to the addon, per bare
+# handler name (the resolved cmd_* minus its ``cmd_`` prefix). The tool
+# signatures use agent-friendly keys; the addon expects the canonical envelope
+# keys (create/compose: ``node_name`` -> ``name``).
+PARAM_ALIASES: dict[str, dict[str, str]] = {
+    "create_node": {"node_name": "name"},
+    "compose_node": {"node_name": "name"},
+}
+
+# Multi-step orchestrators: names an agent might try that can NOT be one batch
+# entry. Reported with a targeted hint instead of a generic unknown-name error.
+ORCHESTRATORS: dict[str, str] = {
+    "run_test_scenario": (
+        "plays a scene, injects inputs and evaluates assertions in one tool;"
+        " call it directly instead"
+    ),
+    "testing_run_test_scenario": (
+        "plays a scene, injects inputs and evaluates assertions in one tool;"
+        " call it directly instead"
+    ),
+    "run_stress_test": "a play + repeated-input workflow; call it directly instead",
+    "testing_run_stress_test": "a play + repeated-input workflow; call it directly instead",
+    "run_tests": (
+        "a headless GUT run via the Godot binary, not a bridge command;"
+        " call it directly instead"
+    ),
+    "testing_run_tests": (
+        "a headless GUT run via the Godot binary, not a bridge command;"
+        " call it directly instead"
+    ),
+    "export_project": (
+        "a headless export via the Godot binary, not a bridge command;"
+        " call it directly instead"
+    ),
+    "debug_workflow": "an aggregator over several read-only checks; call it directly instead",
+    "assert_node_state": "polls the runtime probe (monitor + samples); call it directly instead",
+    "testing_assert_node_state": (
+        "polls the runtime probe (monitor + samples); call it directly instead"
+    ),
+    "run_and_capture": (
+        "runs the project headless via the Godot binary, not a bridge command;"
+        " call it directly instead"
+    ),
+    "runtime_run_and_capture": (
+        "runs the project headless via the Godot binary, not a bridge command;"
+        " call it directly instead"
+    ),
+}
+
+
+def _suggest(miss: str) -> str | None:
+    """Closest known bare name for a failed lookup, or None.
+
+    Similarity = longest common substring (not just prefix), so
+    ``set_layerz`` finds ``physics_set_layers``. Ties break toward the
+    shorter name (closer to the plain handler form).
+    """
+    best: tuple[int, str] | None = None
+    for known in BARE_TO_COMMAND:
+        # Longest common substring between the miss and the known name.
+        common = 0
+        for i in range(len(miss)):
+            for j in range(len(known)):
+                k = 0
+                while i + k < len(miss) and j + k < len(known) and miss[i + k] == known[j + k]:
+                    k += 1
+                if k > common:
+                    common = k
+        if common == 0:
+            continue
+        if best is None or common > best[0] or (common == best[0] and len(known) < len(best[1])):
+            best = (common, known)
+    return best[1] if best else None
+
+
+def resolve_command(command: str) -> str:
+    """Resolve a sub-command to the addon ``cmd_*`` form.
+
+    Accepts (in order): the ``cmd_*`` form verbatim; a bare name from the
+    registry table (trimmed/reordered exposed names, with or without the
+    toolset prefix); a plain handler name (``create_node`` →
+    ``cmd_create_node``). Raises ``ToolError`` with a targeted hint on a miss.
+    """
+    from fastmcp.exceptions import ToolError
+
+    if command.startswith("cmd_"):
+        return command
+    if command in BARE_TO_COMMAND:
+        return BARE_TO_COMMAND[command]
+    # Registry-table names carry their toolset prefix; accept the same name
+    # with a known prefix stripped. Ambiguity resolves by preferring the entry
+    # whose REMAINDER (after dropping the prefix) is longest-equal — in
+    # practice "set_layers" matches "physics_set_layers" and
+    # "navigation_set_layers" identically, so prefer the alphabetically first
+    # deterministic choice only when the full bare name is unambiguous.
+    hits = [known for known in BARE_TO_COMMAND if known.endswith(f"_{command}")]
+    if len(hits) == 1:
+        return BARE_TO_COMMAND[hits[0]]
+    if len(hits) > 1:
+        # Multiple toolsets expose the same action. Disambiguate the way the
+        # addon does: the bare form is genuinely ambiguous, so ask the caller
+        # to use the prefixed form rather than silently picking one.
+        raise ToolError(
+            f"VALIDATION_ERROR: '{command}' is ambiguous — matches {', '.join(sorted(hits))}. "
+            f"Use the prefixed bare form (e.g. '{sorted(hits)[0]}') or the cmd_* form."
+        )
+    # Last resort: treat the input as a plain handler name.
+    if f"cmd_{command}" in set(BARE_TO_COMMAND.values()):
+        return f"cmd_{command}"
+    # Known orchestrator? Point at the real tool instead of "unknown".
+    if command in ORCHESTRATORS:
+        raise ToolError(
+            f"VALIDATION_ERROR: '{command}' is a multi-step orchestrator, not a single "
+            f"bridge command — it {ORCHESTRATORS[command]}."
+        )
+    suggestion = _suggest(command)
+    hint = f"Unknown command '{command}'."
+    if suggestion:
+        hint += f" Did you mean '{suggestion}'?"
+    else:
+        hint += (
+            " Use the exposed tool name without the 'godot_' prefix"
+            " (e.g. 'scene_edit_create_node') or the addon cmd_* form."
+        )
+    raise ToolError(f"VALIDATION_ERROR: {hint}")
+
+
+def map_params(bare_name: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Translate a batch entry's params to the addon's envelope keys.
+
+    Applies the per-name alias table (``node_name`` -> ``name``); unknown keys
+    pass through untouched so the addon's own validation reports them.
+    """
+    aliases = PARAM_ALIASES.get(bare_name)
+    if not aliases:
+        return params
+    mapped = dict(params)
+    for source, target in aliases.items():
+        if target in mapped:
+            # Explicit target wins; drop the alias so the addon sees one key.
+            mapped.pop(source, None)
+        elif source in mapped:
+            mapped[target] = mapped.pop(source)
+    return mapped
+
+
+__all__ = ["BARE_TO_COMMAND", "ORCHESTRATORS", "PARAM_ALIASES", "map_params", "resolve_command"]

--- a/mcp_server/command_map.py
+++ b/mcp_server/command_map.py
@@ -272,11 +272,10 @@ def resolve_command(command: str) -> str:
     if command in BARE_TO_COMMAND:
         return BARE_TO_COMMAND[command]
     # Registry-table names carry their toolset prefix; accept the same name
-    # with a known prefix stripped. Ambiguity resolves by preferring the entry
-    # whose REMAINDER (after dropping the prefix) is longest-equal — in
-    # practice "set_layers" matches "physics_set_layers" and
-    # "navigation_set_layers" identically, so prefer the alphabetically first
-    # deterministic choice only when the full bare name is unambiguous.
+    # with a known prefix stripped ("create_node" == the bare of
+    # "scene_edit_create_node"). Exactly one match resolves; more than one
+    # (e.g. "set_layers" matching both physics and navigation) is ambiguous —
+    # fail naming the matches rather than silently picking one.
     hits = [known for known in BARE_TO_COMMAND if known.endswith(f"_{command}")]
     if len(hits) == 1:
         return BARE_TO_COMMAND[hits[0]]

--- a/mcp_server/tools/composite.py
+++ b/mcp_server/tools/composite.py
@@ -37,9 +37,33 @@ COMPOSITE = {COMPOSITE_TAG}
 
 
 def _normalize_command(command: str) -> str:
-    """Accept either the addon command (``cmd_set_node_property``) or the bare
-    tool name (``set_node_property``); the addon dispatches on the ``cmd_`` form."""
-    return command if command.startswith("cmd_") else f"cmd_{command}"
+    """Resolve a sub-command to the addon ``cmd_*`` form (#420).
+
+    Accepts the addon command (``cmd_set_physics_layers``), the bare handler
+    name (``create_node``), or the bare *exposed* tool name including trimmed /
+    reordered actions (``physics_set_layers`` -> ``cmd_set_physics_layers``,
+    ``add_bus`` -> ``cmd_add_audio_bus``) via the registry-mirrored table in
+    ``command_map``. Raises a structured error with a suggestion on a miss.
+    """
+    from mcp_server.command_map import resolve_command
+
+    return resolve_command(command)
+
+
+def _map_batch_params(command: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Translate a batch entry's param keys to the addon envelope keys (#421).
+
+    Batch entries carry agent-facing tool params; the addon expects the
+    canonical keys the tool layer normally maps (``node_name`` -> ``name``).
+    The command string (either form) maps via the same alias table.
+    """
+    from mcp_server.command_map import map_params, resolve_command
+
+    try:
+        resolved = resolve_command(command)
+    except Exception:
+        return params  # unresolvable commands error in _normalize_command anyway
+    return map_params(resolved.removeprefix("cmd_"), params)
 
 
 def _child_to_addon(child: dict[str, Any]) -> dict[str, Any]:
@@ -173,7 +197,7 @@ def register_composite(mcp: FastMCP, bridge: Bridge) -> None:
         normalized = [
             {
                 "command": _normalize_command(str(c.get("command", ""))),
-                "params": c.get("params", {}),
+                "params": _map_batch_params(str(c.get("command", "")), c.get("params", {})),
             }
             for c in commands
         ]

--- a/tests/contract/test_run_commands.py
+++ b/tests/contract/test_run_commands.py
@@ -167,3 +167,139 @@ async def test_run_commands_rejects_nesting() -> None:
     assert result.is_error
     assert "nested" in str(result.content).lower()
     assert "cmd_run_commands" not in _commands(conn)  # nothing sent
+
+
+async def test_run_commands_resolves_trimmed_tool_names() -> None:
+    # #420: exposed names whose action is trimmed by the godot_ transform
+    # (e.g. godot_physics_set_layers -> "physics_set_layers") must resolve to
+    # the real addon handler (cmd_set_physics_layers), not the nonexistent
+    # cmd_set_layers. The documented bare form is the exposed name minus "godot_".
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "godot_composite_run_commands",
+            {
+                "commands": [
+                    {"command": "physics_set_layers", "params": {"node_path": "Body"}},
+                    {
+                        "command": "particles_apply_preset",
+                        "params": {"node_path": "P", "preset": "smoke"},
+                    },
+                    {"command": "write_script", "params": {"script_path": "res://a.gd"}},
+                    {"command": "capture_screenshot", "params": {}},
+                ]
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is True
+    assert [r["command"] for r in data["results"]] == [
+        "cmd_set_physics_layers",
+        "cmd_apply_particle_preset",
+        "cmd_write_script",
+        "cmd_capture_editor_screenshot",
+    ]
+
+
+async def test_run_commands_ambiguous_bare_name_lists_matches() -> None:
+    # #420: "set_layers" is genuinely ambiguous (navigation_set_layers vs
+    # physics_set_layers) — fail up front naming both, instead of leaking a
+    # bogus cmd_set_layers to the addon.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "godot_composite_run_commands",
+            {"commands": [{"command": "set_layers", "params": {}}]},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "navigation_set_layers" in text and "physics_set_layers" in text
+    assert "cmd_set_layers" not in _commands(conn)  # nothing sent
+
+
+async def test_run_commands_resolves_reordered_read_names() -> None:
+    # #420 (read half): tools whose bare name reorders words vs the handler
+    # (audio_add_bus -> add_audio_bus, get_bus_layout -> get_audio_bus_layout,
+    #  read_shader -> read_shader, get_shader_param -> get_shader_param).
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "godot_composite_run_commands",
+            {
+                "commands": [
+                    {"command": "add_bus", "params": {"name": "SFX"}},
+                    {"command": "get_bus_layout", "params": {}},
+                    {"command": "read_shader", "params": {"shader_path": "res://a.gdshader"}},
+                    {"command": "get_shader_param", "params": {"node_path": "X", "name": "y"}},
+                ]
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is True
+    assert [r["command"] for r in data["results"]] == [
+        "cmd_add_audio_bus",
+        "cmd_get_audio_bus_layout",
+        "cmd_read_shader",
+        "cmd_get_shader_param",
+    ]
+
+
+async def test_run_commands_maps_create_node_node_name() -> None:
+    # #421: the create_node tool maps node_name -> addon's "name" key. run_commands
+    # must apply the same translation, or the addon silently falls back to the
+    # type name (the reported "create_node ignores node_name" symptom).
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "godot_composite_run_commands",
+            {
+                "commands": [
+                    {
+                        "command": "create_node",
+                        "params": {
+                            "parent_path": ".",
+                            "node_type": "Area3D",
+                            "node_name": "DetectionArea",
+                        },
+                    },
+                    {
+                        "command": "cmd_create_node",
+                        "params": {
+                            "parent_path": ".",
+                            "node_type": "Area3D",
+                            "node_name": "AlsoMapped",
+                        },
+                    },
+                ]
+            },
+        )
+    data = result.structured_content
+    assert data["ok_all"] is True
+    sent = CommandEnvelope.model_validate_json(conn.sent[-1])
+    batch = sent.params["commands"]
+    assert batch[0]["params"] == {
+        "parent_path": ".",
+        "node_type": "Area3D",
+        "name": "DetectionArea",
+    }
+    assert batch[1]["params"]["name"] == "AlsoMapped"
+
+
+async def test_run_commands_unknown_bare_name_fails_with_suggestion() -> None:
+    # #420: a bare name that matches no tool must fail the batch up front with the
+    # closest real name in the hint — not leak into the addon as cmd_<garbage>.
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "composite"})
+        result = await client.call_tool(
+            "godot_composite_run_commands",
+            {"commands": [{"command": "set_layerz", "params": {}}]},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "set_layers" in str(result.content)  # suggests the real bare name
+    assert "cmd_set_layerz" not in _commands(conn)  # nothing sent to the addon

--- a/tests/unit/test_command_map.py
+++ b/tests/unit/test_command_map.py
@@ -1,0 +1,181 @@
+"""Unit tests for the run_commands bare-name table (mcp_server/command_map.py).
+
+The table is static by design (no registry dependency at request time), so a
+drift test pins it against the live registry: every bridge-routed tool must be
+resolvable, and every table entry must map to a command some tool actually
+routes. This is the guard that keeps #420/#421 fixed as the surface grows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from mcp_server.command_map import (
+    BARE_TO_COMMAND,
+    ORCHESTRATORS,
+    map_params,
+    resolve_command,
+)
+
+# ---------------------------------------------------------------- unit basics
+
+
+def test_resolve_accepts_cmd_form_verbatim() -> None:
+    assert resolve_command("cmd_set_node_property") == "cmd_set_node_property"
+
+
+def test_resolve_trimmed_and_reordered_names() -> None:
+    assert resolve_command("physics_set_layers") == "cmd_set_physics_layers"
+    assert resolve_command("particles_apply_preset") == "cmd_apply_particle_preset"
+    assert resolve_command("write_script") == "cmd_write_script"
+    assert resolve_command("add_bus") == "cmd_add_audio_bus"
+    assert resolve_command("get_bus_layout") == "cmd_get_audio_bus_layout"
+    assert resolve_command("read_shader") == "cmd_read_shader"
+    assert resolve_command("get_shader_param") == "cmd_get_shader_param"
+
+
+def test_resolve_plain_handler_name() -> None:
+    assert resolve_command("create_node") == "cmd_create_node"
+    assert resolve_command("set_node_property") == "cmd_set_node_property"
+
+
+def test_resolve_unknown_suggests_closest() -> None:
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError) as exc:
+        resolve_command("set_layerz")
+    assert "set_layers" in str(exc.value)
+
+
+def test_resolve_ambiguous_names_both_toolsets() -> None:
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError) as exc:
+        resolve_command("set_layers")
+    assert "navigation_set_layers" in str(exc.value)
+    assert "physics_set_layers" in str(exc.value)
+
+
+def test_resolve_orchestrator_gets_targeted_hint() -> None:
+    from fastmcp.exceptions import ToolError
+
+    for name in ("run_tests", "run_test_scenario", "export_project"):
+        with pytest.raises(ToolError) as exc:
+            resolve_command(name)
+        assert "directly" in str(exc.value)
+
+
+def test_table_has_no_orchestrator_overlap() -> None:
+    assert not (set(BARE_TO_COMMAND) & set(ORCHESTRATORS))
+
+
+def test_map_params_translates_node_name() -> None:
+    mapped = map_params(
+        "create_node", {"parent_path": ".", "node_type": "Area3D", "node_name": "X"}
+    )
+    assert mapped == {"parent_path": ".", "node_type": "Area3D", "name": "X"}
+    # explicit "name" wins; node_name is dropped
+    mapped = map_params("create_node", {"name": "Y", "node_name": "X"})
+    assert mapped == {"name": "Y"}
+    # unknown names pass through untouched
+    assert map_params("nope", {"node_name": "Z"}) == {"node_name": "Z"}
+
+
+# ---------------------------------------------------------------- drift guard
+
+
+def _scrape_fn_cmds() -> dict[str, list[str]]:
+    """fn name -> every cmd_ literal it routes (module + delegate helpers)."""
+    fn_cmds: dict[str, list[str]] = {}
+    tool_re = re.compile(r"async def ([a-z_]+)\(")
+    route_re = re.compile(r'"(cmd_[a-z_]+)"')
+    for path in Path("mcp_server/tools").glob("*.py"):
+        current: str | None = None
+        for line in path.read_text().splitlines():
+            m = tool_re.search(line)
+            if m:
+                current = m.group(1)
+            for r in route_re.finditer(line):
+                if current:
+                    fn_cmds.setdefault(current, [])
+                    if r.group(1) not in fn_cmds[current]:
+                        fn_cmds[current].append(r.group(1))
+    return fn_cmds
+
+
+def _live_registry() -> list[tuple[str, str]]:
+    """(exposed name, handler fn name) for every registered tool."""
+    os.environ.setdefault("GODOT_MCP_DEFAULT_TOOLSETS", "all")
+    from mcp_server.bridge import Bridge
+    from mcp_server.config import ServerConfig
+    from mcp_server.server import create_server
+    from mcp_server.transforms import _original_handler_name, godot_tool_name
+    from tests.fakes import FakeAddonConnection, connector_for
+
+    async def collect() -> list[tuple[str, str]]:
+        conn = FakeAddonConnection()
+        bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+        server = create_server(ServerConfig(), bridge=bridge)
+        tools = await server.local_provider.list_tools()
+        return [
+            (godot_tool_name(_original_handler_name(t), t.tags), _original_handler_name(t))
+            for t in tools
+        ]
+
+    return asyncio.run(collect())
+
+
+def test_every_bridge_tool_bare_name_resolves_or_is_exempted() -> None:
+    """Drift guard: every registered tool's bare name either resolves to the
+    command its fn routes, or is in a documented exemption bucket."""
+    fn_cmds = _scrape_fn_cmds()
+    # multi-step orchestrators and no-bridge-command tools must NOT be in the table
+    exempt_no_cmd = {
+        # pure-python: analysis service, toolset mgmt, health, server info
+        "analyze_dependencies", "analyze_signal_flow", "cross_scene_find_refs",
+        "detect_circular_dependencies", "find_orphaned_resources",
+        "find_unused_resources", "project_stats", "project_structure",
+        "validate_scene_integrity", "enable_toolset", "disable_toolset",
+        "get_server_info", "health_check", "list_toolsets",
+        "list_tools_by_safety_class", "read_resource",
+        # shells out to the Godot binary
+        "get_parse_errors",
+        # multi-step orchestrators (run several commands / binary runs)
+        "debug_workflow", "run_tests", "run_test_scenario", "run_stress_test",
+        "run_and_capture", "export_project", "assert_node_state",
+        "compare_screenshots",
+    }
+    # delegated fns: the literal lives in a module-level helper, not the tool fn
+    delegated: dict[str, str] = {
+        "set_node_property": "cmd_set_node_property",  # _try_set_with_suggestions
+    }
+    problems: list[str] = []
+    for exposed, fn in _live_registry():
+        bare = exposed.removeprefix("godot_")
+        if bare in BARE_TO_COMMAND:
+            cmds = fn_cmds.get(fn) or ([delegated[fn]] if fn in delegated else [])
+            if cmds and BARE_TO_COMMAND[bare] not in cmds:
+                problems.append(f"{bare}: table says {BARE_TO_COMMAND[bare]}, fn routes {cmds}")
+            continue
+        if bare in ORCHESTRATORS or fn in exempt_no_cmd or fn in delegated:
+            continue
+        if fn.startswith("_"):
+            continue
+        if not fn_cmds.get(fn):
+            continue  # genuinely no bridge command
+        problems.append(f"{bare} (fn {fn}) routes {fn_cmds[fn]} but has no table entry")
+    assert not problems, "command_map drift:\n" + "\n".join(problems)
+
+
+def test_every_table_target_is_a_real_routed_command() -> None:
+    """Reverse guard: each table value must be a cmd_ literal routed by some fn
+    (no typos into nonexistent handlers)."""
+    fn_cmds = _scrape_fn_cmds()
+    routed = {c for cmds in fn_cmds.values() for c in cmds}
+    missing = {bare: cmd for bare, cmd in BARE_TO_COMMAND.items() if cmd not in routed}
+    assert not missing, f"table entries routing nowhere: {missing}"


### PR DESCRIPTION
### **User description**
## Summary

`godot_composite_run_commands` forwarded sub-commands **raw** to the addon, with two consequences (verified in triage on both issues):

1. **#420 — name resolution.** Bare names were blind `cmd_`-prefixed (`set_layers` → `cmd_set_layers`, which doesn't exist — the real handler is `cmd_set_physics_layers`; likewise `apply_preset` → `cmd_apply_preset` vs `cmd_apply_particle_preset`), while other names (`compose_node`, `setup_collision`) resolved fine. The tool name ↔ handler name divergence (from the `godot_` transform's trimming) was invisible to the batch path.
2. **#421 — param translation.** The direct `create_node` tool maps `node_name` → the addon's `name` key (mcp_server/tools/mutation.py:116), but batch entries bypassed the tool layer entirely, so `{node_name: "DetectionArea"}` reached the addon untranslated and the addon silently fell back to the type name.

**One fix closes both.**

- New `mcp_server/command_map.py`: a registry-mirrored `BARE_TO_COMMAND` table (154 entries covering every single-command bridge tool — trimmed and reordered exposed names included), `PARAM_ALIASES` (`node_name` → `name` for create/compose), targeted hints for multi-step orchestrators (`run_tests`, `export_project`, … are not expressible as one batch entry), suggestion-on-miss, and an **explicit ambiguity error** when a bare name matches multiple toolsets (`set_layers` matches `navigation_set_layers` *and* `physics_set_layers` — no silent pick).
- `composite.py`: `_normalize_command` delegates to the table; batch params are alias-mapped before send.
- Drift guards (`tests/unit/test_command_map.py`): every registered bridge tool must resolve or be in a documented exemption bucket; every table value must be a real routed `cmd_` — the table cannot silently rot as the surface grows.

Note: the documented bare form (docs/tool-contracts.md:712) is the exposed name minus `godot_` — e.g. `physics_set_layers`, not the shorter `set_layers`; the ambiguous short forms now fail loudly naming their matches.

## Acceptance criteria (from #420 + #421)

- [x] `physics_set_layers`, `particles_apply_preset`, `write_script`, `capture_screenshot`, `add_bus`, `get_bus_layout`, … all resolve to real handlers
- [x] `create_node` batch entries honor `node_name` (→ `name`) in both bare and cmd_ forms
- [x] Unknown names fail the batch **up front** with a suggestion; nothing leaks to the addon
- [x] Ambiguous bare names list their matches instead of silently picking

## Test plan

- 5 new contract tests in `tests/contract/test_run_commands.py` (trimmed names, reordered read names, node_name mapping incl. cmd_ form, ambiguity, unknown-with-suggestion) — **all verified red before the fix**
- 10 unit tests in `tests/unit/test_command_map.py` including two drift guards against the live registry
- Full suite: 704 passed, 0 skipped; ruff/mypy/zero-skip clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes `run_commands` bare-name resolution

- Maps batch params to addon keys

- Adds ambiguity and suggestion errors

- Adds drift-guard tests for mapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run_commands batch"] --> B["resolve_command"]
  B --> C["BARE_TO_COMMAND table"]
  B --> D["ambiguity/suggestion errors"]
  A --> E["map_params"]
  E --> F["addon envelope keys"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command_map.py</strong><dd><code>Adds command mapping and resolution helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/command_map.py

<ul><li>Adds <code>BARE_TO_COMMAND</code> mapping exposed bare names to addon <code>cmd_*</code> <br>handlers.<br> <li> Adds <code>PARAM_ALIASES</code> translating <code>node_name</code> to <code>name</code> for create/compose.<br> <li> Adds <code>resolve_command</code> with ambiguity errors and closest-name <br>suggestions.<br> <li> Adds <code>ORCHESTRATORS</code> hints for multi-step tools not expressible in <br>batches.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/435/files#diff-28f3a45adf0ec35600a84fdda883682dcbd4e0103947bbe434b97622c7ea3ed1">+331/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composite.py</strong><dd><code>Updates run_commands normalization and param mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/composite.py

<ul><li>Replaces naive <code>cmd_</code> prefixing with <code>resolve_command</code> in <br><code>_normalize_command</code>.<br> <li> Adds <code>_map_batch_params</code> to translate batch param keys before sending.<br> <li> Applies param mapping in <code>run_commands</code> normalization loop.<br> <li> Preserves existing nesting rejection and bridge precondition behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/435/files#diff-3134dd429903ee6dbd7fc4c698fb4befeace957e783fb15bb65326863aaa6e08">+28/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_run_commands.py</strong><dd><code>Adds run_commands contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_run_commands.py

<ul><li>Adds contract tests for trimmed/reordered bare-name resolution.<br> <li> Adds tests for ambiguous <code>set_layers</code> and unknown-name suggestions.<br> <li> Adds tests verifying <code>node_name</code> maps to <code>name</code> in batches.<br> <li> Ensures invalid commands are rejected before addon dispatch.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/435/files#diff-b86dcc948fa92d8e41be01eaaf90e905dc5fc4e09a4c564b9ae2ee9ca2a52139">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_command_map.py</strong><dd><code>Adds command map drift-guard tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_command_map.py

<ul><li>Adds unit tests for <code>resolve_command</code> and <code>map_params</code>.<br> <li> Adds drift guard checking every bridge tool resolves or is exempt.<br> <li> Adds reverse guard ensuring table targets are real routed commands.<br> <li> Covers orchestrator hints and ambiguity behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/435/files#diff-98ec5a2886550813e9eb018d3872797e567e8e87a99c4eceb5cc2d3e90ae52d4">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

