### PR TITLE
Fix silent 2D/3D collision shape mismatch

### DIFF
--- a/godot/addons/godot_mcp/handlers/physics.gd
+++ b/godot/addons/godot_mcp/handlers/physics.gd
@@ -85,6 +85,20 @@ func _cmd_setup_collision(params: Dictionary) -> Dictionary:
 	if not (collision is CollisionShape2D or collision is CollisionShape3D):
 		collision.free()
 		return _router._fail("VALIDATION_ERROR", "'%s' is not a CollisionShape2D/3D." % collision_node_type)
+	# Cross-check dimensions (#410): a Shape3D on a CollisionShape2D silently no-ops
+	# at the engine level (shape reads back null), shipping collisionless levels
+	# behind ok:true. Reject the mismatch with a dimension-naming hint instead.
+	if (collision is CollisionShape2D) != (shape is Shape2D):
+		var shape_dim := "2D" if shape is Shape2D else "3D"
+		var node_dim := "2D" if collision is CollisionShape2D else "3D"
+		collision.free()
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Dimension mismatch: shape '%s' is a %s shape but collision_node_type '%s' is %s. "
+				% [shape_type, shape_dim, collision_node_type, node_dim]
+				+ "Pass a matching collision_node_type (e.g. CollisionShape%s)." % shape_dim,
+			"collision_node_type",
+		)
 	collision.name = str(params.get("name", collision_node_type))
 	collision.set("shape", shape)
 	var ur := EditorInterface.get_editor_undo_redo()

--- a/godot/addons/godot_mcp/handlers/physics.gd
+++ b/godot/addons/godot_mcp/handlers/physics.gd
@@ -99,6 +99,20 @@ func _cmd_setup_collision(params: Dictionary) -> Dictionary:
 				+ "Pass a matching collision_node_type (e.g. CollisionShape%s)." % shape_dim,
 			"collision_node_type",
 		)
+	# Also reject a shape-vs-body mismatch (Qodo follow-up on #410): a 2D shape
+	# under a 3D body (or vice versa) can never collide in that physics world —
+	# reject up front instead of adding a useless child.
+	if (parent is CollisionObject2D) != (shape is Shape2D):
+		var body_dim := "2D" if parent is CollisionObject2D else "3D"
+		var body_shape_dim := "2D" if shape is Shape2D else "3D"
+		collision.free()
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Dimension mismatch: body '%s' is a %s physics body but shape '%s' is %s. "
+				% [str(params.get("node_path")), body_dim, shape_type, body_shape_dim]
+				+ "Use a %s shape on a %s body." % [body_dim, body_dim],
+			"shape_type",
+		)
 	collision.name = str(params.get("name", collision_node_type))
 	collision.set("shape", shape)
 	var ur := EditorInterface.get_editor_undo_redo()

--- a/mcp_server/tools/physics.py
+++ b/mcp_server/tools/physics.py
@@ -66,8 +66,17 @@ def register_physics(mcp: FastMCP, bridge: Bridge) -> None:
         ``collision_node_type`` (CollisionShape2D/3D) holding a ``shape_type`` shape
         (e.g. RectangleShape2D) with ``properties`` (size/radius/…).
 
+        The shape and the collision node must be the SAME dimension: a 3D shape
+        (BoxShape3D) with the default CollisionShape2D fails with a
+        VALIDATION_ERROR naming the mismatch — pass ``collision_node_type``
+        matching the shape's dimension (a 2D shape on a 3D body fails the same
+        way). For 3D bodies pass ``collision_node_type="CollisionShape3D"``.
+
         IF THIS FAILS with "Node not found":
           -> The node_path is wrong. Use get_scene_tree() to verify the path.
+        IF THIS FAILS with "Dimension mismatch":
+          -> shape_type and collision_node_type disagree (2D vs 3D). Pass a
+             collision_node_type of the same dimension as shape_type.
         """
         await require_node_exists(bridge, node_path)
         params = {

--- a/mcp_server/tools/physics.py
+++ b/mcp_server/tools/physics.py
@@ -66,17 +66,19 @@ def register_physics(mcp: FastMCP, bridge: Bridge) -> None:
         ``collision_node_type`` (CollisionShape2D/3D) holding a ``shape_type`` shape
         (e.g. RectangleShape2D) with ``properties`` (size/radius/…).
 
-        The shape and the collision node must be the SAME dimension: a 3D shape
-        (BoxShape3D) with the default CollisionShape2D fails with a
-        VALIDATION_ERROR naming the mismatch — pass ``collision_node_type``
-        matching the shape's dimension (a 2D shape on a 3D body fails the same
-        way). For 3D bodies pass ``collision_node_type="CollisionShape3D"``.
+        The shape must match the dimension of BOTH the collision node and the
+        target body: a 3D shape (BoxShape3D) with the default CollisionShape2D
+        fails, and a 2D shape (RectangleShape2D) on a StaticBody3D fails too —
+        a 2D shape can never collide in a 3D physics world. A VALIDATION_ERROR
+        naming the mismatch is returned in both cases. For 3D bodies pass
+        ``shape_type`` like ``BoxShape3D`` and ``collision_node_type="CollisionShape3D"``.
 
         IF THIS FAILS with "Node not found":
           -> The node_path is wrong. Use get_scene_tree() to verify the path.
         IF THIS FAILS with "Dimension mismatch":
-          -> shape_type and collision_node_type disagree (2D vs 3D). Pass a
-             collision_node_type of the same dimension as shape_type.
+          -> shape_type and collision_node_type (or the target body) disagree
+             (2D vs 3D). Pass a collision_node_type of the same dimension as
+             shape_type AND a shape of the same dimension as the target body.
         """
         await require_node_exists(bridge, node_path)
         params = {

--- a/tests/integration/test_physics_e2e.py
+++ b/tests/integration/test_physics_e2e.py
@@ -134,3 +134,75 @@ def test_live_physics() -> None:
         except subprocess.TimeoutExpired:
             editor.kill()
         SCRATCH_FILE.unlink(missing_ok=True)
+
+
+async def _run_3d_dimension() -> None:
+    # #410: setup_collision must not silently ship a collisionless 3D level.
+    # (a) a BoxShape3D with the default (2D) collision node is a dimension
+    #     mismatch -> structured VALIDATION_ERROR, nothing created;
+    # (b) an explicit CollisionShape3D + BoxShape3D actually collides
+    #     (shape lands on the node, ok:true is truthful).
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    if not await serve_and_await_editor(bridge):
+        raise AssertionError("the addon never connected to the bridge")
+    scene = "res://e2e_physics3d_scratch.tscn"
+    try:
+        await _ok(bridge, "cmd_create_scene", {"root_type": "Node3D", "scene_path": scene})
+        await _wait_scene_open(bridge)
+        await _create(bridge, "FloorBody", "StaticBody3D")
+
+        # (a) 3D shape + default 2D node -> dimension mismatch, rejected
+        mismatch = await bridge.send(
+            "cmd_setup_collision",
+            {
+                "node_path": "FloorBody",
+                "shape_type": "BoxShape3D",
+                "properties": {"size": [30, 1, 30]},
+            },
+        )
+        assert mismatch.ok is False and mismatch.error == "VALIDATION_ERROR"
+        assert mismatch.hint and "dimension" in mismatch.hint.lower()
+        tree = await _ok(bridge, "cmd_get_scene_tree", {})
+        floor_body = next(c for c in tree["tree"]["children"] if c["name"] == "FloorBody")
+        assert not floor_body.get("children"), "no node may be created on a mismatch"
+
+        # (b) explicit 3D node + 3D shape -> shape really attached
+        col = await _ok(
+            bridge,
+            "cmd_setup_collision",
+            {
+                "node_path": "FloorBody",
+                "shape_type": "BoxShape3D",
+                "collision_node_type": "CollisionShape3D",
+                "properties": {"size": [30, 1, 30]},
+            },
+        )
+        assert col["created"] is True
+        col_path = str(col["node_path"])  # the addon echoes the real path
+        shape_read = await _ok(
+            bridge, "cmd_get_node_property", {"node_path": col_path, "property": "shape"}
+        )
+        assert shape_read["exists"] is True and shape_read["value"] is not None, (
+            "shape silently dropped (the #410 symptom)"
+        )
+    finally:
+        await bridge.close()
+
+
+def test_live_physics_3d_dimension_mismatch() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GODOT_MCP_BRIDGE_URL": BRIDGE_URL},
+    )
+    try:
+        asyncio.run(_run_3d_dimension())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        (GODOT_PROJECT / "e2e_physics3d_scratch.tscn").unlink(missing_ok=True)

--- a/tests/integration/test_physics_e2e.py
+++ b/tests/integration/test_physics_e2e.py
@@ -166,6 +166,25 @@ async def _run_3d_dimension() -> None:
         floor_body = next(c for c in tree["tree"]["children"] if c["name"] == "FloorBody")
         assert not floor_body.get("children"), "no node may be created on a mismatch"
 
+        # (a2) 2D shape under the 3D body is ALSO a mismatch (shape vs parent
+        # body dimensions, the Qodo follow-up finding): even with a matching
+        # 2D collision node, a RectangleShape2D on a StaticBody3D must fail —
+        # a 2D shape can never collide in a 3D physics world.
+        two_d = await bridge.send(
+            "cmd_setup_collision",
+            {
+                "node_path": "FloorBody",
+                "shape_type": "RectangleShape2D",
+                "collision_node_type": "CollisionShape2D",
+                "properties": {"size": [30, 1]},
+            },
+        )
+        assert two_d.ok is False and two_d.error == "VALIDATION_ERROR"
+        assert two_d.hint and "dimension" in two_d.hint.lower()
+        tree2 = await _ok(bridge, "cmd_get_scene_tree", {})
+        floor_body2 = next(c for c in tree2["tree"]["children"] if c["name"] == "FloorBody")
+        assert not floor_body2.get("children"), "no node may be created on a 2D-under-3D mismatch"
+
         # (b) explicit 3D node + 3D shape -> shape really attached
         col = await _ok(
             bridge,


### PR DESCRIPTION
### **User description**
## Summary

`godot_physics_setup_collision` with a 3D shape (e.g. `BoxShape3D`) and the default `collision_node_type` (CollisionShape2D, mcp_server/defaults.py:58) created a `CollisionShape2D` whose `shape` silently read back `null` — Godot no-ops the cross-dimension assignment — while the envelope reported `ok:true`. The issue's live stress-test shipped an entire collisionless 3D level this way.

**Fix (addon-side cross-check, not inference):** `cmd_setup_collision` now compares the shape's dimension against the collision node's and fails with a structured `VALIDATION_ERROR` naming both dimensions, the two types, and the fix — e.g. `Dimension mismatch: shape 'BoxShape3D' is a 3D shape but collision_node_type 'CollisionShape2D' is 2D. Pass a matching collision_node_type (e.g. CollisionShape3D).` (`required=collision_node_type`). The instantiated node is freed; nothing is added to the scene on a mismatch.

Deliberately **not** auto-inferring the collision node from the shape: inference would silently change behavior for 2D-body callers relying on the default, and the issue lists rejection as an acceptable alternative. The tool docstring now documents the dimension rule and the recovery path.

## Acceptance criteria (from #410)

- [x] A dimension-mismatched call hard-fails with a clear error instead of silently dropping the shape
- [x] An explicit matching `collision_node_type` works and the shape verifiably lands (`get_node_property` reads it back non-null)
- [x] No silent `ok:true` on the failure path; no node created on rejection

## Test plan

- New live-editor e2e `test_live_physics_3d_dimension_mismatch` pins both halves — **verified red before the fix** (reproduced the exact `ok:true` + `CollisionShape2D` + dropped-shape symptom from the issue)
- Full suite: 690 passed, 0 skipped; ruff/mypy/zero-skip clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Rejects 2D/3D collision shape mismatches

- Returns structured validation error with hint

- Frees created node on rejection

- Adds tests; mismatched calls now fail


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["setup_collision"] --> B["dimension check"]
  B -- "mismatch" --> C["VALIDATION_ERROR"]
  B -- "match" --> D["attach shape"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>physics.py</strong><dd><code>Document collision dimension mismatch rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/physics.py

<ul><li>Documents same-dimension requirement in tool docstring<br> <li> Explains dimension mismatch failure and recovery<br> <li> Notes 3D bodies need CollisionShape3D</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/436/files#diff-520ea6f87016bfb3691c13daa0018bdd7c4fb7599c944605be5d1ffaee8c91be">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_physics_e2e.py</strong><dd><code>Add live 3D dimension mismatch tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_physics_e2e.py

<ul><li>Adds live editor e2e for 3D mismatch<br> <li> Asserts structured error and no node created<br> <li> Verifies explicit 3D shape attaches non-null<br> <li> Cleans up scratch scene after test</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/436/files#diff-727c439f35aaac7e4b87d5b52c83deb1eef303268edd3c941721004cb13a296f">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>physics.gd</strong><dd><code>Reject 2D/3D collision shape mismatches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/physics.gd

<ul><li>Adds dimension cross-check before attaching shape<br> <li> Frees instantiated node on mismatch<br> <li> Returns VALIDATION_ERROR naming both dimensions<br> <li> Includes recovery hint for matching node</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/436/files#diff-28724bb054bad4591811a537ad774e663a867b1aa821647146cfd239aea410b0">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

