### PR TITLE
Fix Object property coercion and null-write reporting

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -58,6 +58,7 @@ The accepted shapes:
 | `Color` | `{"r":…,"g":…,"b":…,"a":…}` or hex string | `"#ff0000"` / `{"r":1,"g":0,"b":0,"a":1}` |
 | `Rect2` / `Rect2i` | `{"position":{x,y},"size":{x,y}}` or `"Rect2(x, y, w, h)"` | `{"position":{"x":0,"y":0},"size":{"x":4,"y":5}}` |
 | `NodePath` / `StringName` | string | `"Player/Sprite2D"` |
+| Object (Resource) | `"res://…"` path (loaded via `ResourceLoader`) or `null` to clear | `"res://materials/stone.tres"` |
 | `int` / `float` / `bool` / `String` | the primitive as-is | `42`, `1.5`, `true`, `"hi"` |
 
 The addon coercion is the fallback: a string like `"Vector2(100, 200)"` or a bare array
@@ -263,7 +264,11 @@ UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
 
  - `godot_scene_edit_set_node_property` coerces JSON to the property's declared Godot type via
    `type_coerce.from_json` (Vector2/3 & Color as `{…}` objects or arrays, NodePath as string,
-   plus string forms like `"Vector2(100, 200)"` and `"#ff0000"` — issue #51).
+   plus string forms like `"Vector2(100, 200)"` and `"#ff0000"` — issue #51). Object-typed
+   properties accept a `res://`/`uid://` path (loaded via `ResourceLoader`) or `null` to clear;
+   a missing resource is a structured `RESOURCE_NOT_FOUND`, and a set that lands as `null`
+   (engine rejected the assignment) is a `VALIDATION_ERROR` — the tool never reports
+   `set:true` for a write that didn't stick (issue #414).
  - `godot_scene_edit_delete_node` (destructive) requires `confirm=True` to delete; `dry_run=True` previews
    without confirming. The addon also honors the `confirm` flag defensively.
  - `godot_scene_edit_create_scene` writes a new `.tscn`/`.scn` and opens it; it is a file creation, not a

--- a/godot/addons/godot_mcp/handlers/mutation.gd
+++ b/godot/addons/godot_mcp/handlers/mutation.gd
@@ -88,17 +88,43 @@ func _cmd_set_node_property(params: Dictionary) -> Dictionary:
 	if prop_type == -1:
 		return _router._fail("VALIDATION_ERROR", "Node has no property '%s'." % property)
 
+	# Object-typed properties accept a res:// path and load it (issue #414) —
+	# the generic from_json falls through to the raw value, which set() then
+	# silently no-ops on a typed Object property while reporting success.
+	var new_value: Variant
+	if prop_type == TYPE_OBJECT:
+		var coerced: Dictionary = Coerce.object_from_json(params.get("value"))
+		if not bool(coerced.get("ok", false)):
+			return _router._fail(
+				str(coerced.get("error", "VALIDATION_ERROR")),
+				"Setting '%s' failed: %s" % [property, str(coerced.get("hint", ""))],
+				"value",
+			)
+		new_value = coerced["value"]
+	else:
+		new_value = Coerce.from_json(params.get("value"), prop_type)
+
 	var old_value: Variant = node.get(property)
-	var new_value: Variant = Coerce.from_json(params.get("value"), prop_type)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set %s.%s" % [String(node.name), property])
 	ur.add_do_property(node, property, new_value)
 	ur.add_undo_property(node, property, old_value)
 	ur.commit_action()
+	var read_back: Variant = node.get(property)
+	# The echo is the agent's only verifier: a null read-back after a non-null
+	# write means the engine rejected the assignment (e.g. a dimension/type
+	# mismatch) — report that, never set:true (issue #414).
+	if read_back == null and new_value != null:
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Setting '%s' did not land (reads back null after the set). The value may be "
+				+ "incompatible with the property's expected type." % property,
+			"value",
+		)
 	return _router._ok({
 		"node_path": str(params.get("node_path")),
 		"property": property,
-		"value": Coerce.to_json(node.get(property)),
+		"value": Coerce.to_json(read_back),
 		"set": true,
 	})
 

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -131,6 +131,44 @@ static func _from_string(value: String, type: int) -> Variant:
 	return null
 
 
+## Coerce a JSON string into an Object-typed property value (issue #414).
+## A "res://" path loads the resource (so set_node_property can assign
+## materials/shaders/scripts); a null/missing value stays null (the honest
+## "clear this property" case); anything else for TYPE_OBJECT is left for the
+## caller to reject. Returns {ok, value} — ok=false means "not coercible".
+static func object_from_json(value: Variant) -> Dictionary:
+	if value == null:
+		return {"ok": true, "value": null}
+	if value is String:
+		var path := str(value)
+		if path.begins_with("res://") or path.begins_with("uid://"):
+			if not ResourceLoader.exists(path):
+				return {"ok": false, "error": "RESOURCE_NOT_FOUND", "hint": "No resource at '%s'." % path}
+			var loaded: Resource = load(path)
+			if loaded == null:
+				return {"ok": false, "error": "RESOURCE_NOT_FOUND", "hint": "Could not load '%s'." % path}
+			return {"ok": true, "value": loaded}
+	return {"ok": false, "error": "VALIDATION_ERROR", "hint": "Object properties accept a res:// path or null; got %s." % _json_type_name(value)}
+
+
+static func _json_type_name(value: Variant) -> String:
+	match typeof(value):
+		TYPE_STRING:
+			return "a string"
+		TYPE_INT:
+			return "an int"
+		TYPE_FLOAT:
+			return "a float"
+		TYPE_BOOL:
+			return "a bool"
+		TYPE_DICTIONARY:
+			return "an object"
+		TYPE_ARRAY:
+			return "an array"
+		_:
+			return str(typeof(value))
+
+
 static func _has_rect_keys(value: Variant) -> bool:
 	return value is Dictionary and value.has("position") and value.has("size")
 

--- a/tests/integration/test_mutation_e2e.py
+++ b/tests/integration/test_mutation_e2e.py
@@ -95,6 +95,87 @@ async def _run_roundtrip() -> None:
         await bridge.close()
 
 
+# #414: a res:// path for an Object-typed property must be coerced via load(),
+# and a failed/absent assignment must never report set:true.
+async def _run_object_property_coercion() -> None:
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    if not await serve_and_await_editor(bridge):
+        raise AssertionError("the addon never connected to the bridge")
+    scratch = "res://e2e_obj_prop.tscn"
+    scratch_file = GODOT_PROJECT / "e2e_obj_prop.tscn"
+    mat_path = GODOT_PROJECT / "e2e_obj_prop_mat.tres"
+    mat_code = (
+        "[gd_resource type=\"StandardMaterial3D\" format=3]\n"
+        "[resource]\n"
+        "resource_name = \"e2e_mat\"\n"
+        "albedo_color = Color(1, 0, 0, 1)\n"
+    )
+    try:
+        mat_path.write_text(mat_code, encoding="utf-8")
+        created = await _ok(
+            bridge,
+            "cmd_create_scene",
+            {"root_type": "MeshInstance3D", "scene_path": scratch},
+        )
+        assert created["created"] is True
+        await _wait_scene_open(bridge)
+
+        # Happy path: res:// path coerces via load() for the Object property.
+        was_set = await _ok(
+            bridge,
+            "cmd_set_node_property",
+            {
+                "node_path": ".",
+                "property": "material_override",
+                "value": "res://e2e_obj_prop_mat.tres",
+            },
+        )
+        assert was_set["set"] is True
+        assert was_set["value"] == "res://e2e_obj_prop_mat.tres", (
+            f"material_override did not land (echo={was_set['value']})"
+        )
+
+        # A nonexistent res:// path must fail, not silently set null.
+        bad = await bridge.send(
+            "cmd_set_node_property",
+            {
+                "node_path": ".",
+                "property": "material_override",
+                "value": "res://no_such_material.tres",
+            },
+        )
+        assert bad.ok is False and bad.error == "RESOURCE_NOT_FOUND", (
+            f"missing path silently set: {bad.error} {bad.hint}"
+        )
+        cleared = await _ok(
+            bridge, "cmd_get_node_property", {"node_path": ".", "property": "material_override"}
+        )
+        assert cleared["value"] in (None, "res://e2e_obj_prop_mat.tres")
+    finally:
+        await bridge.close()
+        scratch_file.unlink(missing_ok=True)
+        (GODOT_PROJECT / "e2e_obj_prop_mat.tres").unlink(missing_ok=True)
+        (GODOT_PROJECT / "e2e_obj_prop_mat.tres.uid").unlink(missing_ok=True)
+
+
+def test_live_editor_set_node_property_object_coercion() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GODOT_MCP_BRIDGE_URL": BRIDGE_URL},
+    )
+    try:
+        asyncio.run(_run_object_property_coercion())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+
+
 def test_live_editor_mutation_roundtrip() -> None:
     assert GODOT_BIN is not None
     editor = subprocess.Popen(


### PR DESCRIPTION
### **User description**
## Summary

`godot_scene_edit_set_node_property` on an Object-typed property (`material_override`, script, …) silently no-oped for a `res://` string value: the generic `from_json` fell through to the raw value, the engine's `set()` rejected it behind `ok:true`, and the `value:null` echo was the only tell (\#414).

**Fix**
- `type_coerce.object_from_json()` — the single coercion site per the addon rule — loads `res://`/`uid://` paths via `ResourceLoader`; a missing resource is a structured `RESOURCE_NOT_FOUND`, any other non-null non-string is a `VALIDATION_ERROR`.
- The handler verifies the read-back: a null echo after a non-null write is a `VALIDATION_ERROR` naming the property — `set:true` is never reported for a write that didn't stick.
- `docs/tool-contracts.md` documents the Object value shape and the no-silent-no-op guarantee.

## Acceptance criteria (from #414)

- [x] Coerce `res://` string paths via `load()` for Object-typed properties
- [x] Missing resource → coercion error (structured, actionable)
- [x] NEVER answer `set:true` for a null write (read-back check)

## Test plan

- Live-editor e2e `test_live_editor_set_node_property_object_coercion` (red before the fix — reproduced the exact silent `set:true/null`): res:// material lands on `material_override` (echo == path) and a nonexistent path returns `RESOURCE_NOT_FOUND`.
- Preflight: `pytest` 709 passed · `ruff check` clean · `mypy` clean · zero-skip scan clean · addon scripts `--check-only` clean.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- `set_node_property` loads `res://` Object paths

- Missing resources return `RESOURCE_NOT_FOUND`

- Null read-back returns `VALIDATION_ERROR`

- Adds e2e tests and docs


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["set_node_property"] --> B{"Object property?"}
  B -->|yes| C["object_from_json"]
  B -->|no| F["from_json"]
  C -->|res:// path| D["ResourceLoader.load"]
  C -->|missing| E["RESOURCE_NOT_FOUND"]
  C -->|invalid| G["VALIDATION_ERROR"]
  D --> H["read-back check"]
  F --> H
  H -->|null after non-null| G
  H -->|ok| J["set:true"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mutation_e2e.py</strong><dd><code>Add live-editor Object property coercion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_mutation_e2e.py

<ul><li>Adds live-editor e2e for Object property coercion.<br> <li> Verifies <code>res://</code> material lands on <code>material_override</code>.<br> <li> Asserts missing path returns <code>RESOURCE_NOT_FOUND</code>.<br> <li> Cleans up scratch scene and material files.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/438/files#diff-fca9c42f6b57e4b598712f309783a25e3e5b6eaa4f8b0aaeff5379de54927daa">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mutation.gd</strong><dd><code>Validate Object property writes in mutation handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/mutation.gd

<ul><li>Routes Object-typed writes through <code>Coerce.object_from_json</code>.<br> <li> Returns structured errors for non-coercible Object values.<br> <li> Adds read-back validation after UndoRedo commit.<br> <li> Reports <code>VALIDATION_ERROR</code> when non-null write reads null.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/438/files#diff-7105857301a59754fbe43497aafc9063a2f160070bc3de86ee46991d23d06b8c">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>type_coerce.gd</strong><dd><code>Add Object resource path coercion helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/type_coerce.gd

<ul><li>Adds <code>object_from_json</code> for Object-typed JSON values.<br> <li> Loads <code>res://</code> and <code>uid://</code> paths via <code>ResourceLoader</code>.<br> <li> Returns <code>RESOURCE_NOT_FOUND</code> for missing or unloadable paths.<br> <li> Returns <code>VALIDATION_ERROR</code> for non-string non-null values.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/438/files#diff-28c7345bea182a56e26f4ab210915106f814f6395a5f414af2913e1b299ada05">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document Object property coercion contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Documents Object value shape as <code>res://</code> path or null.<br> <li> Explains <code>ResourceLoader</code> loading for Object properties.<br> <li> States missing resource and null read-back error behavior.<br> <li> Adds no-silent-no-op guarantee for <code>set_node_property</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/438/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

