### PR TITLE
Refuse zero-polygon navigation bakes

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -512,7 +512,7 @@ Author navigation — generic over 2D/3D, pass the node type names. All `mutatin
 |------|--------|---------|
 | `godot_navigation_setup_region` | `parent_path, region_type="NavigationRegion2D", name?, properties?` | `NavigationRegionResult { node_path, region_type, created }` |
 | `godot_navigation_setup_agent` | `parent_path, agent_type="NavigationAgent2D", name?, properties?` | `NavigationAgentResult { node_path, agent_type, created }` |
-| `godot_navigation_bake_mesh` | `node_path` | `BakeNavigationResult { node_path, baked }` |
+| `godot_navigation_bake_mesh` | `node_path` | `BakeNavigationResult { node_path, baked, polygon_count, vertex_count }` |
 | `godot_navigation_get_region` | `node_path` | `NavigationRegionInfo { node_path, has_polygon, outline_count, vertex_count, polygon_count }` (`read_only`) |
 | `godot_navigation_set_layers` | `node_path, layers[]` (1-based bit indices) | `NavigationLayersResult { node_path, navigation_layers }` |
 
@@ -521,7 +521,10 @@ assigned (NavigationPolygon for 2D, NavigationMesh for 3D) so it is ready to bak
 `godot_navigation_setup_agent` adds a NavigationAgent2D/3D configured with `properties`
 (radius, path_desired_distance, target_desired_distance, max_speed, …). `godot_navigation_bake_mesh`
 bakes the region's navmesh/navpoly synchronously (undo restores the pre-bake resource;
-a region with no navmesh returns a structured precondition). `godot_navigation_set_layers`
+a region with no navmesh returns a structured precondition). A bake that yields zero
+polygons (no source geometry parsed) is refused with a VALIDATION_ERROR naming the fix —
+`baked:true` is never reported for an empty navmesh (#413); a successful bake echoes
+`polygon_count`/`vertex_count` for verification. `godot_navigation_set_layers`
 turns `[1,3]` into the bitmask `5` on any node with a `navigation_layers` property.
 
 #### Audio (issue #44) — category: `audio` (gated off by default)

--- a/godot/addons/godot_mcp/handlers/navigation.gd
+++ b/godot/addons/godot_mcp/handlers/navigation.gd
@@ -77,6 +77,8 @@ func _cmd_bake_navigation_mesh(params: Dictionary) -> Dictionary:
 	# Baking mutates the assigned navmesh resource in place. To stay undoable we bake a
 	# fresh duplicate (the do/redo target) and keep the original pristine as the undo
 	# value, so the snapshot is never the bake target and repeated undo/redo is stable.
+	var polygon_count := -1
+	var vertex_count := -1
 	if region is NavigationRegion2D:
 		if region.navigation_polygon == null:
 			return _router._fail("VALIDATION_ERROR", "Region has no navigation_polygon; assign one first.", "navigation_polygon")
@@ -89,6 +91,8 @@ func _cmd_bake_navigation_mesh(params: Dictionary) -> Dictionary:
 		ur.add_undo_property(region, "navigation_polygon", original)
 		ur.add_undo_reference(original)
 		ur.commit_action()
+		polygon_count = working.get_polygon_count()
+		vertex_count = working.get_vertex_count()
 	elif region is NavigationRegion3D:
 		if region.navigation_mesh == null:
 			return _router._fail("VALIDATION_ERROR", "Region has no navigation_mesh; assign one first.", "navigation_mesh")
@@ -101,9 +105,29 @@ func _cmd_bake_navigation_mesh(params: Dictionary) -> Dictionary:
 		ur.add_undo_property(region, "navigation_mesh", original)
 		ur.add_undo_reference(original)
 		ur.commit_action()
+		polygon_count = working.get_polygon_count()
+		if working.has_method("get_vertices"):
+			var verts: PackedVector3Array = working.get_vertices()
+			vertex_count = verts.size()
 	else:
 		return _router._fail("VALIDATION_ERROR", "Node is not a NavigationRegion2D/NavigationRegion3D.")
-	return _router._ok({"node_path": str(params.get("node_path")), "baked": true})
+	# A bake that produced zero polygons is a failed bake (no source geometry was
+	# parsed, or every agent/geometry filter excluded it) — never report baked:true
+	# for an empty navmesh, an agent trusting that ships AI that can't pathfind (#413).
+	if polygon_count <= 0:
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Bake produced no polygons (%d vertices) — no source geometry was parsed. Add "
+				+ "MeshInstance3D/GridMap/StaticBody colliders under the region (or under "
+				+ "the root_node_type the mesh parses) and retry." % vertex_count,
+			"polygon_count",
+		)
+	return _router._ok({
+		"node_path": str(params.get("node_path")),
+		"baked": true,
+		"polygon_count": polygon_count,
+		"vertex_count": vertex_count,
+	})
 
 
 

--- a/mcp_server/models/navigation.py
+++ b/mcp_server/models/navigation.py
@@ -22,6 +22,10 @@ class NavigationAgentResult(BaseModel):
 class BakeNavigationResult(BaseModel):
     node_path: str
     baked: bool = False
+    # Only present on a real (non-dry-run) bake: the produced polygon/vertex
+    # counts — a bake yielding 0 polygons is refused by the addon (#413).
+    polygon_count: int | None = None
+    vertex_count: int | None = None
     dry_run: bool = False
 
 

--- a/tests/contract/test_navigation.py
+++ b/tests/contract/test_navigation.py
@@ -38,7 +38,10 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 },
             )
         case "cmd_bake_navigation_mesh":
-            return ResponseEnvelope.success(cmd.id, {"node_path": p["node_path"], "baked": True})
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"node_path": p["node_path"], "baked": True, "polygon_count": 3, "vertex_count": 9},
+            )
         case "cmd_get_navigation_region":
             if p["node_path"] == "EmptyRegion":
                 return ResponseEnvelope.success(
@@ -120,6 +123,9 @@ async def test_region_agent_and_bake() -> None:
     assert region.structured_content["node_path"] == "./NavigationRegion3D"
     assert agent.structured_content["agent_type"] == "NavigationAgent2D"
     assert baked.structured_content["baked"] is True
+    # #413: the bake echoes the produced geometry so an agent can verify it.
+    assert baked.structured_content["polygon_count"] == 3
+    assert baked.structured_content["vertex_count"] == 9
 
 
 async def test_set_navigation_layers_bitmask() -> None:

--- a/tests/integration/test_navigation_e2e.py
+++ b/tests/integration/test_navigation_e2e.py
@@ -75,9 +75,14 @@ async def _run() -> None:
         assert by_name["Nav"] == "NavigationRegion3D"
         assert by_name["Agent"] == "NavigationAgent3D"
 
-        # bake the (empty) navmesh — completes synchronously without error
-        baked = await _ok(bridge, "cmd_bake_navigation_mesh", {"node_path": "Nav"})
-        assert baked["baked"] is True
+        # #413: baking a navmesh with no source geometry must NOT claim baked:true.
+        # setup_region assigns a fresh empty NavigationMesh; with no parsed geometry
+        # the bake yields 0 polygons — the addon must report the honest result.
+        baked_empty = await bridge.send("cmd_bake_navigation_mesh", {"node_path": "Nav"})
+        assert baked_empty.ok is False and baked_empty.error == "VALIDATION_ERROR", (
+            f"empty navmesh bake reported ok: {baked_empty.error} {baked_empty.hint}"
+        )
+        assert "polygon" in str(baked_empty.hint or "").lower(), str(baked_empty.hint)
 
         # navigation layers from 1-based bit indices
         layers = await _ok(


### PR DESCRIPTION
### **User description**
## Summary

`godot_navigation_bake_mesh` completed silently and returned `baked:true` on a region whose source geometry parsed to nothing; `get_region` then showed `vertex_count:0, polygon_count:0` — no error anywhere (#413). An agent trusting the flag ships AI that can't pathfind (enemies idled in the stress-test).

**Fix**
- The handler reads the produced geometry off the bake target (the undoable working duplicate) after `commit_action()`.
- `polygon_count == 0` → `VALIDATION_ERROR` naming the likely cause and the fix (add MeshInstance3D/GridMap/collider source geometry) — never `baked:true`.
- A real bake echoes `polygon_count`/`vertex_count`; `BakeNavigationResult` gains both fields so callers verify without a second round-trip.
- `docs/tool-contracts.md` documents the honest-bake contract.

## Acceptance criteria (from #413)

- [x] Report honestly: zero polygons → `baked:false`-shaped failure with a clear reason
- [x] Include `polygon_count`/`vertex_count` in the bake result so an agent can detect a failed bake

## Test plan

- Live-editor e2e `test_live_navigation` (red before the fix — reproduced the exact `baked:true` on an empty navmesh): empty bake → `VALIDATION_ERROR` with 'polygon' in the hint.
- Contract test pins the echoed counts (`polygon_count=3, vertex_count=9`).
- Preflight: `pytest` 709 passed · `ruff` clean · `mypy` clean · zero-skip scan clean.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Zero-polygon bakes now fail

- Bake result gains counts

- Documented and regression-tested

- Existing empty-bake callers may break


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Navigation bake handler"] -- "reads produced geometry" --> B["Zero polygons?"]
  B -- "yes" --> C["VALIDATION_ERROR"]
  B -- "no" --> D["BakeNavigationResult with counts"]
  E["Contract and integration tests"] -- "pin behavior" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation.py</strong><dd><code>Extend bake result model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/navigation.py

<ul><li>Adds optional <code>polygon_count</code> and <code>vertex_count</code> to <code>BakeNavigationResult</code>.<br> <li> Notes counts are present only on real, non-dry-run bakes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/439/files#diff-adb51357162c3b6d6072f0cb21e20fe6cc43a2028b9aa35439635709f5d9a46a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_navigation.py</strong><dd><code>Pin bake result counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_navigation.py

<ul><li>Updates the fake <code>cmd_bake_navigation_mesh</code> response to include counts.<br> <li> Asserts a successful bake returns <code>polygon_count=3</code> and <code>vertex_count=9</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/439/files#diff-b5c60317400f94fbdf9304eccc9ac8820bc2391fae31632522ea4f4bcc4c6a20">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_navigation_e2e.py</strong><dd><code>Test empty bake rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_navigation_e2e.py

<ul><li>Changes the empty-navmesh bake expectation from success to <br><code>VALIDATION_ERROR</code>.<br> <li> Asserts the failure hint mentions <code>polygon</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/439/files#diff-07022463428a3213e0648ea7050a0594a3317aac775860db46d599c23cd2f78f">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation.gd</strong><dd><code>Fail empty navmesh bakes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/navigation.gd

<ul><li>Captures polygon and vertex counts from the undoable bake duplicate <br>after commit.<br> <li> Returns <code>VALIDATION_ERROR</code> when <code>polygon_count <= 0</code> instead of <br><code>baked:true</code>.<br> <li> Includes <code>polygon_count</code> and <code>vertex_count</code> in successful bake results.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/439/files#diff-91aaab3aeb4da2213c44ffb334975a672c18e34006a8022a36edb7ae768c2a5b">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document honest bake contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Updates <code>godot_navigation_bake_mesh</code> to document <code>polygon_count</code> and <br><code>vertex_count</code>.<br> <li> Documents zero-polygon bakes as <code>VALIDATION_ERROR</code> and successful bakes <br>echoing counts.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/439/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

