### PR TITLE
Fix debugger silent no-op by exposing break state

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -744,7 +744,7 @@ answers `godot_mcp:` debugger queries. Play control is `runtime`; reads are `rea
 |------|--------|---------|
 | `godot_runtime_play_scene` | `scene_path?` | `PlayResult { playing, scene }` |
 | `godot_runtime_stop_scene` | — | `PlayResult { playing }` |
-| `godot_runtime_is_playing` | — | `PlayResult { playing, scene }` |
+| `godot_runtime_is_playing` | — | `PlayResult { playing, scene, paused }` |
 | `godot_runtime_get_game_scene_tree` | — | `GameSceneTreeResult { playing, connected, tree?, hint }` (read_only) |
 
 `godot_runtime_play_scene` runs `scene_path` (a `res://*.tscn`) or the main scene when omitted.
@@ -878,9 +878,9 @@ Control breakpoints, step execution, and inspect the paused call stack in a runn
 | `godot_debugger_set_breakpoint` | `path (res:// script), line` | `BreakpointResult { breakpoint_set, path, line }` |
 | `godot_debugger_remove_breakpoint` | `path, line` | `BreakpointResult { breakpoint_removed, path, line }` |
 | `godot_debugger_clear_breakpoints` | — | `ClearBreakpointsResult { breakpoints_cleared }` |
-| `godot_debugger_force_break` | — | `ForceBreakResult { force_break_sent }` |
+| `godot_debugger_force_break` | — | `ForceBreakResult { force_break_sent, breaked }` |
 
-`godot_debugger_set_breakpoint` uses `EditorDebuggerSession.set_breakpoint(path, line, true)`; `godot_debugger_remove_breakpoint` uses `set_breakpoint(path, line, false)`. `godot_debugger_clear_breakpoints` clears on the game side via the probe (when connected) and removes any individually tracked breakpoints on the editor side. `godot_debugger_force_break` sets `force_break_pending = true` in the probe; the probe services the flag itself from its own `_process` (calling the `breakpoint` keyword there), so games need no cooperation. `MCPRuntimeProbe.check_force_break()` remains public for games that want the break at a chosen point in their own loop instead (see `docs/debugger_feasibility.md` § Limitations). Note the ordering: as an autoload the probe's `_process` usually runs before game code in the same frame, so a cooperative game check will typically find the flag already cleared and the break will land in the probe instead — treat chosen-point timing as best-effort.
+`godot_debugger_set_breakpoint` uses `EditorDebuggerSession.set_breakpoint(path, line, true)`; `godot_debugger_remove_breakpoint` uses `set_breakpoint(path, line, false)`. `godot_debugger_clear_breakpoints` clears on the game side via the probe (when connected) and removes any individually tracked breakpoints on the editor side. `godot_debugger_force_break` sets `force_break_pending = true` in the probe; the probe services the flag itself from its own `_process` (calling the `breakpoint` keyword there), so games need no cooperation. The tool then polls a read-only `cmd_get_debug_break_state` for up to ~2s and reports `breaked` — whether the game actually entered the break loop (#411). `force_break_sent=true` with `breaked=false` means the break did NOT land: verify the probe autoload or restart the play session before trusting stack tools. `godot_runtime_is_playing` exposes `paused` so a game frozen at a break is distinguishable from running logic (#411). `MCPRuntimeProbe.check_force_break()` remains public for games that want the break at a chosen point in their own loop instead (see `docs/debugger_feasibility.md` § Limitations). Note the ordering: as an autoload the probe's `_process` usually runs before game code in the same frame, so a cooperative game check will typically find the flag already cleared and the break will land in the probe instead — treat chosen-point timing as best-effort.
 
 **Tier 2 — step control & stack inspection (issue #110 follow-up):**
 
@@ -890,11 +890,11 @@ Control breakpoints, step execution, and inspect the paused call stack in a runn
 | `godot_debugger_step_over` | — | `StepResult { stepped }` |
 | `godot_debugger_step_out` | — | `StepResult { stepped }` |
 | `godot_debugger_continue_execution` | — | `ContinueResult { running }` |
-| `godot_debugger_get_stack_frames` | — | `StackFramesResult { frames[] }` |
-| `godot_debugger_evaluate_expression` | `expression, frame=0` | `EvaluationResult { expression, value }` |
+| `godot_debugger_get_stack_frames` | — | `StackFramesResult { frames[], hint }` |
+| `godot_debugger_evaluate_expression` | `expression, frame=0` | `EvaluationResult { expression, value, evaluated }` |
 | `godot_debugger_get_frame_variables` | `frame=0` | `FrameVarsResult { frame, locals[], members[], globals[] }` |
 
-Step tools send `step`/`next`/`out`/ `continue` via `EditorDebuggerSession.send_message` and require the game to be paused (`session.is_breaked()`). `godot_debugger_get_stack_frames` returns the current call stack from the debugger protocol (`get_stack_dump` → `stack_dump`); `godot_debugger_evaluate_expression` evaluates a GDScript expression at the given frame (`evaluate` → `evaluation_return`); `godot_debugger_get_frame_variables` fetches locals, members, and globals (`get_stack_frame_vars` → `stack_frame_vars`). All three are captured via the poll-and-cache pattern on `MCPDebugger`, so the first call after a break may return empty data until the async reply arrives.
+Step tools send `step`/`next`/`out`/ `continue` via `EditorDebuggerSession.send_message` and require the game to be paused (`session.is_breaked()`). `godot_debugger_get_stack_frames` returns the current call stack from the debugger protocol (`get_stack_dump` → `stack_dump`); an empty `frames:[]` carries a `hint` — the poll-and-cache reply is async, so empty means "not yet received", not "empty call stack" (#411). `godot_debugger_evaluate_expression` evaluates a GDScript expression at the given frame (`evaluate` → `evaluation_return`) and echoes `evaluated` so a null `value` is distinguishable from "no reply yet" (#411). `godot_debugger_get_frame_variables` fetches locals, members, and globals (`get_stack_frame_vars` → `stack_frame_vars`). All three are captured via the poll-and-cache pattern on `MCPDebugger`, so the first call after a break may return empty data until the async reply arrives.
 
 #### Profiling (issue #38) — category: `profiling` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/debugger.gd
+++ b/godot/addons/godot_mcp/handlers/debugger.gd
@@ -18,6 +18,9 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_remove_breakpoint"] = _cmd_remove_breakpoint
 	handlers["cmd_clear_breakpoints"] = _cmd_clear_breakpoints
 	handlers["cmd_force_break"] = _cmd_force_break
+	# Read-only break-state check the server polls after force_break (#411) —
+	# the break lands a frame or two after the probe services the flag.
+	handlers["cmd_get_debug_break_state"] = _cmd_get_debug_break_state
 	# Tier 2: step control via EditorDebuggerSession.send_message
 	handlers["cmd_step_into"] = _cmd_step
 	handlers["cmd_step_over"] = _cmd_step
@@ -85,12 +88,37 @@ func _cmd_clear_breakpoints(_params: Dictionary) -> Dictionary:
 	return _router._ok({"breakpoints_cleared": true})
 
 
+## Read-only: is the debug session currently in the break loop? Polled by the
+## server after force_break so the tool can report whether the game actually
+## paused (#411).
+func _cmd_get_debug_break_state(_params: Dictionary) -> Dictionary:
+	var guard := _router._require_debug_session()
+	if not guard["ok"]:
+		return guard
+	var debugger := _router._debugger as MCPDebugger
+	var session := debugger.get_session(debugger.get_session_id())
+	var breaked: bool = session.is_breaked()
+	return _router._ok({"breaked": breaked})
+
+
+
 func _cmd_force_break(_params: Dictionary) -> Dictionary:
 	var guard := _router._require_live_probe()
 	if not guard["ok"]:
 		return guard
 	_router._debugger.send_to_probe("godot_mcp:force_break", [])
-	return _router._ok({"force_break_sent": true})
+	# Non-blocking (the editor thread must not sleep): the probe services the
+	# force_break flag on its next frame, so the server polls
+	# cmd_get_debug_break_state for the break state (#411). Report the current
+	# state so the tool result is meaningful even without polling.
+	var breaked := false
+	var session = _router._debugger.get_session(_router._debugger.get_session_id())
+	if session != null and session.is_breaked():
+		breaked = true
+	return _router._ok({
+		"force_break_sent": true,
+		"breaked": breaked,
+	})
 
 # Tier 2: step control via EditorDebuggerSession.send_message ----------------
 
@@ -162,7 +190,13 @@ func _cmd_get_stack_frames(_params: Dictionary) -> Dictionary:
 	var frames: Variant = debugger.get_cached_stack_frames()
 	debugger.request_stack_frames()  # refresh cache for next call
 	if frames == null:
-		return _router._ok({"frames": []})
+		# The reply is async (poll-and-cache): an empty list right after a break
+		# usually means the stack_dump hasn't arrived yet, NOT a live game. Warn
+		# so an agent doesn't read [] as "the stack is empty" (#411).
+		return _router._ok({
+			"frames": [],
+			"hint": "No stack dump cached yet; the game may still be delivering it. Retry after a beat — frames:[] while the game is frozen at a break means 'not yet received', not 'empty call stack'.",
+		})
 	return _router._ok({"frames": frames})
 
 
@@ -190,7 +224,10 @@ func _cmd_evaluate_expression(params: Dictionary) -> Dictionary:
 	var value: Variant = null
 	if cached is Dictionary:
 		value = (cached as Dictionary).get("value", null)
-	return _router._ok({"expression": expression, "value": value})
+	# value:null alone is ambiguous (evaluated-to-null vs. no reply yet vs.
+	# unevaluable frame) — echo whether an evaluation was actually received
+	# so an agent can tell the difference (#411).
+	return _router._ok({"expression": expression, "value": value, "evaluated": cached != null})
 
 
 func _cmd_get_frame_variables(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/handlers/runtime_session.gd
+++ b/godot/addons/godot_mcp/handlers/runtime_session.gd
@@ -52,9 +52,18 @@ func _cmd_stop_scene(_params: Dictionary) -> Dictionary:
 
 
 func _cmd_is_playing(_params: Dictionary) -> Dictionary:
+	# "paused" distinguishes a game frozen in the debugger break loop from one
+	# whose logic is actually running — after force_break this is the tell an
+	# agent needs before trusting input/probe results (#411).
+	var paused := false
+	if _router._debugger != null and _router._debugger.get_session_id() >= 0:
+		var session = _router._debugger.get_session(_router._debugger.get_session_id())
+		if session != null:
+			paused = session.is_breaked()
 	return _router._ok({
 		"playing": EditorInterface.is_playing_scene(),
 		"scene": EditorInterface.get_playing_scene(),
+		"paused": paused,
 	})
 
 

--- a/mcp_server/models/debugger.py
+++ b/mcp_server/models/debugger.py
@@ -26,6 +26,10 @@ class ForceBreakResult(BaseModel):
     """Outcome of requesting a forced break in the running game."""
 
     force_break_sent: bool = False
+    # Whether the debugger session is (now) in a break state. False means the
+    # break was requested but the game has not entered the debug loop (issue
+    # #411) — e.g. no probe cooperation; treat stack tools as unreliable.
+    breaked: bool = False
 
 
 class StepResult(BaseModel):
@@ -44,6 +48,9 @@ class StackFramesResult(BaseModel):
     """Outcome of requesting the current call stack."""
 
     frames: list[dict[str, Any]] = Field(default_factory=list)
+    # Present when frames:[] means "no reply cached yet" rather than "empty
+    # stack" — the poll-and-cache reply is async (issue #411).
+    hint: str = ""
 
 
 class EvaluationResult(BaseModel):
@@ -51,6 +58,9 @@ class EvaluationResult(BaseModel):
 
     expression: str = ""
     value: Any = None
+    # True when an evaluation reply was actually received; value:null with
+    # evaluated=False means "no result yet", not "expression is null" (#411).
+    evaluated: bool = False
 
 
 class FrameVarsResult(BaseModel):

--- a/mcp_server/models/runtime_session.py
+++ b/mcp_server/models/runtime_session.py
@@ -8,6 +8,9 @@ from pydantic import BaseModel, Field
 class PlayResult(BaseModel):
     playing: bool
     scene: str = ""
+    # True when the play session is paused at a debugger breakpoint (issue
+    # #411) — distinguishes "frozen in the debug loop" from "game logic running".
+    paused: bool = False
 
 
 class GameNode(BaseModel):

--- a/mcp_server/tools/debugger.py
+++ b/mcp_server/tools/debugger.py
@@ -12,6 +12,8 @@ Gated in the ``debugger`` toolset.
 
 from __future__ import annotations
 
+import asyncio
+
 from fastmcp import FastMCP
 
 from mcp_server.bridge import Bridge
@@ -30,6 +32,11 @@ from mcp_server.safety import RUNTIME
 from mcp_server.tools._route import route
 
 DEBUGGER = {DEBUGGER_TAG}
+
+# force_break lands a frame or two after the probe services the flag; poll the
+# break-state read before answering (import_asset-style, no editor-side sleep).
+_BREAK_POLL_INTERVAL_S = 0.1
+_BREAK_POLL_TIMEOUT_S = 2.0
 
 
 def register_debugger(mcp: FastMCP, bridge: Bridge) -> None:
@@ -70,8 +77,27 @@ def register_debugger(mcp: FastMCP, bridge: Bridge) -> None:
         WHEN NOT TO USE: You want the game to pause later when a specific line
         runs — use set_breakpoint(path, line) instead. force_break pauses
         immediately, which may land in an unrelated function.
+
+        Returns ``breaked``: whether the game actually entered the break loop
+        (polled for up to ~2s). ``force_break_sent`` with ``breaked=False``
+        means the break did NOT land — do not trust stack/input tools until
+        ``godot_runtime_is_playing`` shows ``paused=true``.
         """
-        return ForceBreakResult(**await route(bridge, "cmd_force_break", {}))
+        await route(bridge, "cmd_force_break", {})
+        # The probe services the break flag on its next frame — poll the
+        # break-state read (import_asset-style) so the result is honest (#411).
+        breaked = False
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _BREAK_POLL_TIMEOUT_S
+        while True:
+            state = await bridge.send("cmd_get_debug_break_state", {})
+            if state.ok and (state.result or {}).get("breaked"):
+                breaked = True
+                break
+            if loop.time() >= deadline:
+                break
+            await asyncio.sleep(_BREAK_POLL_INTERVAL_S)
+        return ForceBreakResult(force_break_sent=True, breaked=breaked)
 
     # Tier 2: step control --------------------------------------------------
 

--- a/tests/contract/test_debugger.py
+++ b/tests/contract/test_debugger.py
@@ -9,6 +9,7 @@ from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
 from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
 from mcp_server.server import create_server
+from mcp_server.tools import debugger as debugger_module
 from tests.fakes import FakeAddonConnection, connector_for
 
 pytestmark = pytest.mark.asyncio
@@ -104,3 +105,34 @@ async def test_force_break() -> None:
     # #411: the result must report whether the game actually reached a break
     # state — force_break_sent alone was a silent no-op trap.
     assert result.structured_content["breaked"] is True
+
+
+async def test_force_break_poll_timeout_reports_breaked_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Honest-failure path: the flag is sent but the game never reports a break
+    state before the poll deadline — the result must say ``breaked=false`` so an
+    agent knows the break did NOT land (#411: force_break_sent alone was the
+    silent no-op trap; a regression hardcoding breaked=true must fail here).
+    Poll constants are patched short so the loop runs without real waiting."""
+    monkeypatch.setattr(debugger_module, "_BREAK_POLL_INTERVAL_S", 0.0)
+    monkeypatch.setattr(debugger_module, "_BREAK_POLL_TIMEOUT_S", 0.0)
+    polled = {"n": 0}
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_force_break":
+            return ResponseEnvelope.success(cmd.id, {"force_break_sent": True})
+        if cmd.command == "cmd_get_debug_break_state":
+            polled["n"] += 1
+            return ResponseEnvelope.success(cmd.id, {"breaked": False})
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("godot_debugger_force_break", {})
+    assert result.structured_content["force_break_sent"] is True
+    assert result.structured_content["breaked"] is False
+    assert polled["n"] >= 1  # the poll actually ran (not short-circuited)

--- a/tests/contract/test_debugger.py
+++ b/tests/contract/test_debugger.py
@@ -31,7 +31,11 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_clear_breakpoints":
             return ResponseEnvelope.success(cmd.id, {"breakpoints_cleared": True})
         case "cmd_force_break":
-            return ResponseEnvelope.success(cmd.id, {"force_break_sent": True})
+            return ResponseEnvelope.success(
+                cmd.id, {"force_break_sent": True, "breaked": True}
+            )
+        case "cmd_get_debug_break_state":  # #411: server polls for the break state
+            return ResponseEnvelope.success(cmd.id, {"breaked": True})
     return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
 
 
@@ -97,3 +101,6 @@ async def test_force_break() -> None:
         await client.call_tool("godot_enable_toolset", {"category": "debugger"})
         result = await client.call_tool("godot_debugger_force_break", {})
     assert result.structured_content["force_break_sent"] is True
+    # #411: the result must report whether the game actually reached a break
+    # state — force_break_sent alone was a silent no-op trap.
+    assert result.structured_content["breaked"] is True

--- a/tests/contract/test_debugger_stack_eval.py
+++ b/tests/contract/test_debugger_stack_eval.py
@@ -44,7 +44,7 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
             p = cmd.params
             return ResponseEnvelope.success(
                 cmd.id,
-                {"expression": p.get("expression"), "value": 42},
+                {"expression": p.get("expression"), "value": 42, "evaluated": True},
             )
         case "cmd_get_frame_variables":
             p = cmd.params
@@ -121,7 +121,33 @@ async def test_evaluate_expression() -> None:
     sc = result.structured_content
     assert sc["expression"] == "player.health * 2"
     assert sc["value"] == 42
+    # #411: evaluated distinguishes "expression is null" from "no reply yet".
+    assert sc["evaluated"] is True
     assert "cmd_evaluate_expression" in _commands(conn)
+
+
+async def test_empty_frames_carry_not_yet_hint() -> None:
+    # #411: frames:[] while breaked is "no reply cached yet" — the addon says so.
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_get_stack_frames":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "frames": [],
+                    "hint": "No stack dump cached yet; retry.",
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "debugger"})
+        result = await client.call_tool("godot_debugger_get_stack_frames", {})
+    sc = result.structured_content
+    assert sc["frames"] == []
+    assert "cached" in sc["hint"]
 
 
 async def test_get_frame_variables() -> None:

--- a/tests/contract/test_runtime_session.py
+++ b/tests/contract/test_runtime_session.py
@@ -31,7 +31,9 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         case "cmd_stop_scene":
             return ResponseEnvelope.success(cmd.id, {"playing": False})
         case "cmd_is_playing":
-            return ResponseEnvelope.success(cmd.id, {"playing": True, "scene": "res://main.tscn"})
+            return ResponseEnvelope.success(
+                cmd.id, {"playing": True, "scene": "res://main.tscn", "paused": False}
+            )
         case "cmd_get_game_scene_tree":
             return ResponseEnvelope.success(
                 cmd.id, {"playing": True, "connected": True, "tree": _TREE}
@@ -75,6 +77,9 @@ async def test_play_stop_and_is_playing() -> None:
     assert played.structured_content["playing"] is True
     assert played.structured_content["scene"] == "res://main.tscn"
     assert playing.structured_content["playing"] is True
+    # #411: is_playing must expose the debug break state so an agent can tell
+    # "frozen at a breakpoint" from "game logic running".
+    assert playing.structured_content["paused"] is False
     assert stopped.structured_content["playing"] is False
 
 

--- a/tests/integration/test_runtime_session_e2e.py
+++ b/tests/integration/test_runtime_session_e2e.py
@@ -96,8 +96,22 @@ async def _run() -> None:
         # force_break must pause WITHOUT the game cooperating: this played scene
         # has no script calling check_force_break(), so only the probe's own
         # _process servicing (issue #392) can bring the debugger to a halt.
+        # #411: the break state is observable — the probe services the flag on
+        # its next frame, so poll cmd_get_debug_break_state (exactly what the
+        # force_break tool does server-side).
         fb = await _ok(bridge, "cmd_force_break", {})
         assert fb["force_break_sent"] is True
+        breaked = False
+        for _ in range(40):
+            state = await _ok(bridge, "cmd_get_debug_break_state", {})
+            if state["breaked"]:
+                breaked = True
+                break
+            await asyncio.sleep(0.2)
+        assert breaked, "force_break did not report the game entering the break loop"
+        # #411: is_playing exposes paused=true while frozen at the break.
+        state = await _ok(bridge, "cmd_is_playing", {})
+        assert state["playing"] is True and state["paused"] is True
         paused = False
         for _ in range(30):
             frames = await bridge.send("cmd_get_stack_frames", {"frame": 0})
@@ -116,6 +130,9 @@ async def _run() -> None:
                 break
             await asyncio.sleep(0.25)
         assert resumed, "debugger still reports paused after continue_execution"
+        # #411: after continue, paused flips back to false.
+        state = await _ok(bridge, "cmd_is_playing", {})
+        assert state["paused"] is False
         await _ok(bridge, "cmd_stop_scene", {})
     finally:
         await bridge.close()


### PR DESCRIPTION
### **User description**
## Summary

The debugger toolset was a silent no-op trap (#411): every mutation acked `sent:true` while the game froze invisibly — `is_playing` stayed true, input acks kept counting, and every stack/eval probe returned empty/null, so a frozen-at-breakpoint game was indistinguishable from a live one.

**Fix**
- `cmd_is_playing` reports `paused` (`EditorDebuggerSession.is_breaked()`); `PlayResult` gains the field — "frozen at a breakpoint" is now visible.
- `force_break` polls a new read-only `cmd_get_debug_break_state` for up to ~2s (non-blocking on the editor thread, import_asset-style server-side poll) and reports `breaked`; `ForceBreakResult` gains the field. `force_break_sent=true` + `breaked=false` = the break did NOT land.
- `get_stack_frames` with no cached dump carries a `hint`: `frames:[]` means "not yet received", not "empty call stack" (`StackFramesResult.hint`).
- `evaluate_expression` echoes `evaluated` so a null `value` is distinguishable from "no reply yet" (`EvaluationResult.evaluated`).
- `docs/tool-contracts.md` updated (both debugger tables + is_playing row).

## Acceptance criteria (from #411)

- [x] force_break → game paused AND break state reported (or a clear `breaked:false` warning)
- [x] `is_playing` exposes a `paused` field
- [x] Empty stack frames while `sent:true` warn "not yet received — retry"
- [x] A null `evaluate` value is distinguishable from "expression evaluated to null"

## Test plan

- Live-editor e2e `test_live_runtime_session` (red before the fix — `breaked`/"paused" absent): force_break → breaked:true + paused:true; continue → paused:false.
- Contract tests pin `breaked` (force_break + break-state poll), `paused` on is_playing, the empty-frames `hint`, and `evaluated:true`.
- Preflight: `pytest` 709 passed · `ruff` clean · `mypy` clean · zero-skip scan clean · addon `--check-only` clean.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Debugger break state now reported

- `is_playing` exposes `paused` field

- `force_break` polls break state

- Empty replies now disambiguated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["force_break"] -- "poll break state" --> B["breaked result"]
  C["is_playing"] -- "add paused" --> D["paused state"]
  E["stack/eval"] -- "add hint/evaluated" --> F["unambiguous replies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>debugger.py</strong><dd><code>Add debugger result fields for break state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-5d4da2bc7238e1c71763d2baf90739b49be9f0a972c0de53e50130869675167e">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_session.py</strong><dd><code>Add paused field to play result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-f6abde3384910dde42b0800beb6c60835d111e8288b04af7dcf7667fe14cee9e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>debugger.py</strong><dd><code>Poll break state after forced break</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-8f98f1d7181af5d2fc172b3bb88dbe231c82b08a2c12585abe69caba7420c29f">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>debugger.gd</strong><dd><code>Expose debugger break state and hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-f2d886a87a83cc375b8499c81e9582d1d117e5eadb302edaea3847fae6cb7c6a">+40/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_session.gd</strong><dd><code>Report paused in is playing handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-97d2675a84c1fba2465f143dd6ba64ae45158da6434f45afaf458af983c0e947">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_debugger.py</strong><dd><code>Update force break contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-9fff5beeb8502593e41971c1a1a5fda44a633236b54934c021f0c0355ed7c8ac">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_debugger_stack_eval.py</strong><dd><code>Add stack eval disambiguation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-fd033f3399019fb78f6fdeeac5363f23f9bab1d46d354902afb9fda01bd8cbb8">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_runtime_session.py</strong><dd><code>Assert paused in runtime session tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-b80973823411e8105a19c4baa74643a985173ee8aa7a8640559fe93cdf57ac77">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_runtime_session_e2e.py</strong><dd><code>Add live break state e2e checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-72c6c83df0df76ab1e00a4b5c680ae199905c56514b9b8ac97eac80733426831">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document new debugger and runtime fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/441/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

