### PR TITLE
Enforce local ollama-only graphify backend

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -22,14 +22,14 @@
 # GEMINI_* keys: graphify's detect_backend() prefers cloud keys over ollama.
 # ═══════════════════════════════════════════════════════════════════════
 # Local Ollama (runs on localhost:11434).
-# Set OLLAMA_MODEL to a model you have pulled (e.g. qwen2.5-coder:7b).
+# On Apple Silicon prefer the MLX build (faster) — pull with `ollama pull qwen3.8:27b-mlx`.
 OLLAMA_BASE_URL=http://localhost:11434/v1
-OLLAMA_MODEL=qwen2.5-coder:7b
+OLLAMA_MODEL=qwen3.8:27b-mlx
 OLLAMA_API_KEY=ollama
 GRAPHIFY_OLLAMA_KEEP_ALIVE=30m
-# Reasoning models (e.g. Qwen3) need higher max_tokens so the thinking phase
-# doesn't consume the output budget. Increase if community labels come back empty.
-GRAPHIFY_MAX_OUTPUT_TOKENS=4096
+# Reasoning models (Qwen3 family) think before answering — the thinking phase
+# consumes output budget, so keep this generous or labels come back empty.
+GRAPHIFY_MAX_OUTPUT_TOKENS=8192
 
 # ═══════════════════════════════════════════════════════════════════════
 # opencode opt-ins (optional)

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -17,24 +17,19 @@
 
 # ═══════════════════════════════════════════════════════════════════════
 # Graphify LLM backend (developers only — for the knowledge graph)
+#
+# POLICY: local ollama only — no cloud models. Do NOT add OPENAI_*/ANTHROPIC_*/
+# GEMINI_* keys: graphify's detect_backend() prefers cloud keys over ollama.
 # ═══════════════════════════════════════════════════════════════════════
-# Local Ollama (default — runs on localhost:11434).
-# Set OLLAMA_MODEL to a model you have pulled (e.g. qwen3.8:27b-mlx, qwen2.5-coder:7b).
+# Local Ollama (runs on localhost:11434).
+# Set OLLAMA_MODEL to a model you have pulled (e.g. qwen2.5-coder:7b).
 OLLAMA_BASE_URL=http://localhost:11434/v1
-OLLAMA_MODEL=qwen3.8:27b-mlx
+OLLAMA_MODEL=qwen2.5-coder:7b
 OLLAMA_API_KEY=ollama
 GRAPHIFY_OLLAMA_KEEP_ALIVE=30m
 # Reasoning models (e.g. Qwen3) need higher max_tokens so the thinking phase
 # doesn't consume the output budget. Increase if community labels come back empty.
 GRAPHIFY_MAX_OUTPUT_TOKENS=4096
-
-# Alternative: MLflow AI Gateway (OpenAI-compatible). Uncomment and comment out
-# the OLLAMA_* block above to use the gateway instead. graphify detects `openai`
-# before `ollama`, so the OPENAI_* block takes priority when present.
-# OPENAI_BASE_URL=https://your-mlflow-gateway/v1
-# OPENAI_API_KEY=your-key
-# GRAPHIFY_OPENAI_MODEL=your-endpoint-name
-# GRAPHIFY_API_TIMEOUT=600
 
 # ═══════════════════════════════════════════════════════════════════════
 # opencode opt-ins (optional)

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,10 +1,10 @@
 # .graphifyignore — focus the knowledge graph on the MCP *itself*:
 #   - mcp_server/                 the Python FastMCP server (the AI-facing product)
 #   - godot/addons/godot_mcp/     the Godot addon (the .gd half of the MCP)
-#   - docs/                       its architecture/contract docs
+#   - docs/ + .opencode/rules/    its architecture/contract docs + grounding rules
 #
 # GDScript (.gd) support is added to the installed graphify by
-# scripts/graphify_gdscript_support.py (re-run after any `graphify install`).
+# scripts/graphify_gdscript_support.py (re-run after any `graphify install`/upgrade).
 #
 # Everything below is a SEPARATE project, a harness/consumer, or a generated/
 # meta artifact that otherwise dominates the graph (e.g. FakeAddonConnection,
@@ -35,17 +35,14 @@ godot/tests/
 # Generated graph output + its extraction cache.
 graphify-out/
 
-# CI / harness / agent meta — not the product. But KEEP the grounding rules
-# (.claude/rules/*.md — the addon / architecture / mcp-tools / error-handling
-# constitution): durable design rationale the graph wants (parity with
-# godot-agents). Re-include via the leaf pattern — a fully-excluded parent dir
-# can't be re-included, so exclude .claude/* then negate rules/.
+# CI / harness / agent meta — not the product. The grounding rules now live in
+# .opencode/rules/ (kept — durable design rationale the graph wants; see the
+# docs/ note above). .claude/ and docs/superpowers/plans/ were removed from the
+# repo (8f4b1ab / #347); their entries below are harmless belt-and-braces.
+
 .github/
 .claude/*
 !.claude/rules/
-
-# Historic process artifacts — step-by-step implementation-plan checklists
-# (parity with godot-agents, which excludes docs/superpowers/plans/).
 docs/superpowers/plans/
 
 # Generated dependency lock (huge, not architecturally meaningful).
@@ -58,3 +55,7 @@ uv.lock
 .venv/
 *.uid
 *.import
+
+# Local plugin deps (js) — vendored packages, not project architecture.
+.opencode/node_modules/
+.opencode/package-lock.json

--- a/.opencode/rules/graphify.md
+++ b/.opencode/rules/graphify.md
@@ -10,25 +10,24 @@ paths:
 
 The project's knowledge graph (`graphify-out/`) is built with the **graphify**
 CLI. The LLM backend, model, and tuning live in the repo-root `.env`
-(gitignored), not on the command line. The default backend is the **MLflow AI
-Gateway** (OpenAI-compatible); local **ollama** is the fallback.
-`detect_backend()` checks `openai` **before** `ollama`, so the gateway wins
-whenever its key is present (an incidental `OLLAMA_BASE_URL` never shadows it):
+(gitignored), not on the command line.
+
+**Policy: LOCAL OLLAMA ONLY — no cloud models.** graphify's `detect_backend()`
+checks cloud keys (gemini → kimi → claude → openai → deepseek) **before**
+`ollama`, so the only safe configuration is the one this repo pins: no cloud
+API keys in `.env` (or the environment), ollama vars set. `.env` must never
+contain `OPENAI_*`, `ANTHROPIC_*`, `GEMINI_*`, `KIMI_*`, or `DEEPSEEK_*` keys:
 
 ```
-# Primary: MLflow AI Gateway (OpenAI-compatible /deployments route)
-OPENAI_BASE_URL=https://mlflow.johndstudios.net/gateway/mlflow/v1  # base ends at /v1
-OPENAI_API_KEY=gateway                    # placeholder — the gateway needs no secret
-GRAPHIFY_OPENAI_MODEL=gpt-oss-120b-cloud  # or glm-5.2-cloud
-GRAPHIFY_API_TIMEOUT=600
-
-# Fallback: local ollama (used only if the OPENAI_* block is removed, or with
-# an explicit `--backend ollama`)
+# Local ollama (OpenAI-compatible endpoint on localhost:11434)
 OLLAMA_BASE_URL=http://localhost:11434/v1
-OLLAMA_MODEL=qwen3-coder-next:cloud
-OLLAMA_API_KEY=ollama
+OLLAMA_MODEL=qwen2.5-coder:7b   # any model pulled with `ollama pull`
+OLLAMA_API_KEY=ollama           # any non-empty value; silences the F-029 warning
 GRAPHIFY_OLLAMA_KEEP_ALIVE=30m
 ```
+
+If a cloud key appears in the ambient environment, do not let auto-detect pick
+it up — run with an explicit `--backend ollama` or unset the key first.
 
 ## The rule: always observe `.env` when running graphify
 
@@ -55,10 +54,11 @@ spawned by tooling don't auto-source it. Without these vars `detect_backend()`
 returns `None` — no LLM backend, so community labeling falls back to
 `Community N` placeholders and any extraction/label step errors out.
 
-Sourcing `.env` makes auto-detect resolve to `openai` pointed at the gateway (no
-`--backend`/`--model` flags needed). The `/graphify` *skill* flow is separate: it
-dispatches Claude subagents (or Gemini), not the gateway — the CLI backend in
-this rule covers `scripts/graphify.sh` only.
+Sourcing `.env` makes auto-detect resolve to `ollama` (no cloud keys are set;
+if one ever leaks into the environment, pass `--backend ollama` explicitly).
+The `/graphify` *skill* flow is separate: it dispatches Claude subagents (or
+Gemini), not the gateway — the CLI backend in this rule covers
+`scripts/graphify.sh` only.
 
 ## Auto-refresh on commit (git hooks)
 
@@ -89,7 +89,7 @@ then read it as a lightweight architecture self-review:
 
 ```bash
 scripts/graphify.sh update .    # structure reflects the branch (free, AST-only)
-scripts/graphify.sh label .     # regenerate community names via the gateway
+scripts/graphify.sh label .     # regenerate community names via local ollama
 ```
 
 Then glance at `graphify-out/GRAPH_REPORT.md` — **God Nodes** + **Surprising
@@ -105,9 +105,9 @@ adds commit churn.
 ## Maintenance
 
 - The `openai` package must be present in graphify's tool env (it is imported
-  lazily for the gateway/ollama backends). If a run errors with
-  `No module named 'openai'`, install it into the pinned interpreter:
-  `uv pip install --python "$(cat graphify-out/.graphify_python)" openai`.
+  lazily for the ollama OpenAI-compatible client). If a run errors with
+  `No module named 'openai'`, reinstall with:
+  `uv tool install graphifyy --with mcp --with openai --force`.
 
 - After any `graphify` upgrade/reinstall, re-run `scripts/graphify_gdscript_support.py`
   with the pinned interpreter — the site-packages `.gd` patch is wiped on reinstall.

--- a/scripts/graphify.sh
+++ b/scripts/graphify.sh
@@ -30,9 +30,16 @@ fi
 # The keys checked are the ones detect_backend() prefers over ollama.
 if [[ "${1:-}" != "query" && "${1:-}" != "explain" ]]; then
     wants_ollama=false
+    prev=""
     for arg in "$@"; do
-        [[ "$arg" == "--backend" ]] && wants_ollama_next=true
-        [[ "$arg" == "ollama" ]] && wants_ollama=true
+        # Only an explicit --backend ollama (or --backend=ollama) opts into
+        # ollama; any other token named "ollama" (e.g. a path) must not.
+        if [[ "$prev" == "--backend" ]]; then
+            [[ "$arg" == "ollama" ]] && wants_ollama=true
+        elif [[ "$arg" == --backend=ollama ]]; then
+            wants_ollama=true
+        fi
+        prev="$arg"
     done
     if ! $wants_ollama; then
         for key_var in GEMINI_API_KEY GOOGLE_API_KEY KIMI_API_KEY ANTHROPIC_API_KEY \

--- a/scripts/graphify.sh
+++ b/scripts/graphify.sh
@@ -5,6 +5,12 @@
 # backend auto-detect returns None and it falls back to the uninstalled default
 # model (qwen2.5-coder:7b). See .opencode/rules/graphify.md.
 #
+# Policy: LOCAL OLLAMA ONLY — no cloud models. graphify's detect_backend()
+# prefers cloud keys (gemini/kimi/claude/openai/deepseek) over ollama, so a
+# cloud key leaked into the ambient environment would silently reroute the
+# corpus to a paid endpoint; this wrapper refuses to run in that case unless
+# --backend ollama is passed explicitly.
+#
 # Usage:  scripts/graphify.sh <graphify-args...>
 #   e.g.  scripts/graphify.sh label . --update
 #         scripts/graphify.sh query "How does the bridge work?"
@@ -18,6 +24,28 @@ if [ -f "$ROOT/.env" ]; then
     # shellcheck disable=SC1091
     . "$ROOT/.env"
     set +a
+fi
+
+# 1b. Local-ollama guard: refuse a cloud key unless ollama is pinned explicitly.
+# The keys checked are the ones detect_backend() prefers over ollama.
+if [[ "${1:-}" != "query" && "${1:-}" != "explain" ]]; then
+    wants_ollama=false
+    for arg in "$@"; do
+        [[ "$arg" == "--backend" ]] && wants_ollama_next=true
+        [[ "$arg" == "ollama" ]] && wants_ollama=true
+    done
+    if ! $wants_ollama; then
+        for key_var in GEMINI_API_KEY GOOGLE_API_KEY KIMI_API_KEY ANTHROPIC_API_KEY \
+                       OPENAI_API_KEY DEEPSEEK_API_KEY; do
+            if [[ -n "${!key_var:-}" ]]; then
+                echo "ERROR: $key_var is set in the environment — graphify would" \
+                     "route to a CLOUD model (detect_backend prefers cloud keys over" \
+                     "ollama). Policy here is local ollama only: unset $key_var (or" \
+                     "pass --backend ollama) and retry." >&2
+                exit 2
+            fi
+        done
+    fi
 fi
 
 # 2. Use the interpreter graphify was installed into (pinned by the skill),

--- a/scripts/graphify_gdscript_support.py
+++ b/scripts/graphify_gdscript_support.py
@@ -155,7 +155,8 @@ def _patch_extract(extract_py: Path, engine_py: Path) -> None:
     if "# GDScript: callee is the first identifier child" not in src:
         anchor = (
             "            else:\n"
-            "                # Generic: get callee from call_function_field (or constructor on new_expression)\n"
+            "                # Generic: get callee from call_function_field\n"
+            "                # (or constructor on new_expression)\n"
         )
         if anchor not in src:
             raise SystemExit("engine.py: generic call-handler anchor not found")

--- a/scripts/graphify_gdscript_support.py
+++ b/scripts/graphify_gdscript_support.py
@@ -101,58 +101,71 @@ _CALL_BRANCH = '''            elif config.ts_module == "tree_sitter_gdscript":
 '''
 
 
-def _patch_extract(extract_py: Path) -> None:
-    src = extract_py.read_text()
+def _patch_extract(extract_py: Path, engine_py: Path) -> None:
+    # v0.9.56 layout: the LanguageConfig/dispatch tables live in extract.py, but
+    # the generic extractor engine (_extract_generic + the Language() wrap +
+    # the generic call handler) moved to extractors/engine.py. Write after each
+    # successful step so a later anchor mismatch can't silently drop earlier
+    # patches (the original bug: a step-3 exit lost steps 1-2's in-memory work).
 
-    # 1. Config + wrapper, inserted before extract_lua.
+    # -- extract.py: config + wrapper (before extract_lua), then dispatch entry.
+    src = extract_py.read_text()
+    changed = False
     if "_GDSCRIPT_CONFIG" not in src:
         anchor = "def extract_lua(path: Path) -> dict:"
         if anchor not in src:
             raise SystemExit("extract.py: extract_lua anchor not found")
         src = src.replace(anchor, _CONFIG_BLOCK + anchor, 1)
+        changed = True
         print("extract.py: added _GDSCRIPT_CONFIG + extract_gdscript")
     else:
         print("extract.py: _GDSCRIPT_CONFIG already present")
-
-    # 2. Dispatch entry.
     if '".gd": extract_gdscript' not in src:
         anchor = '    ".lua": extract_lua,\n'
         if anchor not in src:
             raise SystemExit("extract.py: _DISPATCH lua anchor not found")
         src = src.replace(anchor, anchor + '    ".gd": extract_gdscript,\n', 1)
+        changed = True
         print("extract.py: registered .gd in _DISPATCH")
     else:
         print("extract.py: .gd already in _DISPATCH")
+    if changed:
+        extract_py.write_text(src)
 
-    # 3. Language-wrap fix (accept a provider that already returns a Language).
+    # -- engine.py: Language-wrap fix (a Language-returning provider, which the
+    # tree-sitter-language-pack shim is, is not itself a valid Language() arg).
+    src = engine_py.read_text()
+    changed = False
     if "_raw_lang = lang_fn()" not in src:
         anchor = "        language = Language(lang_fn())\n"
         if anchor not in src:
-            raise SystemExit("extract.py: Language(lang_fn()) anchor not found")
+            raise SystemExit("engine.py: Language(lang_fn()) anchor not found")
         replacement = (
             "        _raw_lang = lang_fn()\n"
             "        language = _raw_lang if isinstance(_raw_lang, Language) "
             "else Language(_raw_lang)\n"
         )
         src = src.replace(anchor, replacement, 1)
-        print("extract.py: made Language() robust to Language-returning providers")
+        changed = True
+        print("engine.py: made Language() robust to Language-returning providers")
     else:
-        print("extract.py: Language-wrap fix already present")
+        print("engine.py: Language-wrap fix already present")
 
-    # 4. Positional-callee branch in the generic call handler.
+    # -- engine.py: positional-callee branch in the generic call handler.
     if "# GDScript: callee is the first identifier child" not in src:
         anchor = (
             "            else:\n"
-            "                # Generic: get callee from call_function_field\n"
+            "                # Generic: get callee from call_function_field (or constructor on new_expression)\n"
         )
         if anchor not in src:
-            raise SystemExit("extract.py: generic call-handler anchor not found")
+            raise SystemExit("engine.py: generic call-handler anchor not found")
         src = src.replace(anchor, _CALL_BRANCH + anchor, 1)
-        print("extract.py: added GDScript positional-callee branch")
+        changed = True
+        print("engine.py: added GDScript positional-callee branch")
     else:
-        print("extract.py: GDScript call branch already present")
-
-    extract_py.write_text(src)
+        print("engine.py: GDScript call branch already present")
+    if changed:
+        engine_py.write_text(src)
 
 
 def main() -> None:
@@ -164,7 +177,7 @@ def main() -> None:
     _ensure_language_pack()
     _write_shim(site_dir)
     _patch_detect(gdir / "detect.py")
-    _patch_extract(gdir / "extract.py")
+    _patch_extract(gdir / "extract.py", gdir / "extractors" / "engine.py")
     print(
         "\nDone. Verify with:\n"
         "  python -c \"from graphify.extract import _DISPATCH; print('.gd' in _DISPATCH)\""

--- a/tests/unit/test_graphify_guard.py
+++ b/tests/unit/test_graphify_guard.py
@@ -1,0 +1,108 @@
+"""Regression tests for the local-ollama guard in scripts/graphify.sh (issue on
+PR #442 review). The wrapper must refuse to run graphify when a cloud API key is
+present in the environment — unless the caller explicitly pins
+``--backend ollama`` — and must never route the codebase corpus to a cloud
+endpoint. Hermetic: the script runs with no real graphify install; the command
+under test exits at the guard (exit 2) or proceeds to interpreter lookup, which
+we stub via the pin file to a no-op interpreter exit.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "graphify.sh"
+
+CLOUD_KEYS = [
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "KIMI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+]
+
+
+def _run_in(
+    repo: Path, args: list[str], env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        k: v for k, v in os.environ.items() if not k.endswith("_API_KEY")
+    }
+    env["PATH"] = "/usr/bin:/bin"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        ["bash", str(repo / "graphify.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.fixture()
+def hermetic_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A temp checkout skeleton so the script's pin lookup can't hit a real
+    graphify install — the guard decides before the interpreter step."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    script_src = SCRIPT.read_text()
+    stub = repo / "graphify.sh"
+    stub.write_text(script_src)
+    stub.chmod(0o755)
+    monkeypatch.setattr(
+        "tests.unit.test_graphify_guard.SCRIPT", repo / "graphify.sh"
+    )
+    return repo
+
+
+@pytest.mark.parametrize("key", CLOUD_KEYS)
+def test_refuses_when_cloud_key_set(hermetic_repo: Path, key: str) -> None:
+    proc = _run_in(hermetic_repo, ["label", "."], env_extra={key: "sk-test"})
+    assert proc.returncode == 2, f"{key} did not trigger the guard: {proc.stderr}"
+    assert key in proc.stderr
+    assert "cloud" in proc.stderr.lower()
+
+
+@pytest.mark.parametrize("backend_arg", [["--backend", "ollama"], ["--backend=ollama"]])
+def test_allows_explicit_ollama_backend(hermetic_repo: Path, backend_arg: list[str]) -> None:
+    proc = _run_in(
+        hermetic_repo,
+        ["label", ".", *backend_arg],
+        env_extra={"OPENAI_API_KEY": "sk-test"},
+    )
+    assert proc.returncode != 2, f"guard refused despite explicit ollama pin: {proc.stderr}"
+
+
+def test_path_named_ollama_is_not_a_backend_pin(hermetic_repo: Path) -> None:
+    """The old guard matched any argument == 'ollama' (a path like ./ollama/
+    would bypass the cloud-key refusal). Only a --backend value counts."""
+    proc = _run_in(
+        hermetic_repo,
+        ["label", "./ollama", "--model", "ollama"],
+        env_extra={"OPENAI_API_KEY": "sk-test"},
+    )
+    assert proc.returncode == 2, "a token named 'ollama' bypassed the cloud-key guard"
+    assert "OPENAI_API_KEY" in proc.stderr
+
+
+def test_query_and_explain_skip_the_guard(hermetic_repo: Path) -> None:
+    """query/explain return text to the caller only; never extract to a backend,
+    so they run regardless of ambient keys (and here must not exit 2)."""
+    for sub in ("query", "explain"):
+        proc = _run_in(hermetic_repo, [sub, "how does the bridge work?"])
+        assert proc.returncode != 2, f"{sub} was refused by the cloud-key guard"
+        assert "cloud" not in proc.stderr.lower()
+
+
+def test_no_cloud_key_proceeds_past_guard(hermetic_repo: Path) -> None:
+    proc = _run_in(hermetic_repo, ["label", "."])
+    assert proc.returncode != 2
+    assert "cloud" not in proc.stderr.lower()


### PR DESCRIPTION
### **User description**
## Summary

Policy change: graphify here must use the **local ollama endpoint** only — no cloud models.

graphify's `detect_backend()` prefers cloud keys (gemini → kimi → claude → openai → deepseek) **over** ollama, so a single cloud key leaked into the ambient environment silently reroutes the codebase corpus to a paid endpoint.

**Changes**
- `scripts/graphify.sh` refuses LLM-using steps (`label`/`extract`/`update`) when `GEMINI_API_KEY`/`GOOGLE_API_KEY`/`KIMI_API_KEY`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`DEEPSEEK_API_KEY` is set, unless `--backend ollama` is passed explicitly; read-only `query`/`explain` (no LLM) stay unguarded.
- `.env.dev.example`: documents the local-only policy, drops the MLflow-gateway alternative, pins the actually-pulled model (`qwen2.5-coder:7b` — the previous example named `qwen3.8:27b-mlx`, which was never pulled).
- `.opencode/rules/graphify.md`: policy + corrected maintenance notes (`uv tool install graphifyy --with mcp --with openai`).
- (gitignored) repo `.env` now holds only the ollama block; `graphify-out/.graphify_python` pins the uv-tool interpreter.

## Test plan

- `graphify label .` runs against `localhost:11434` — real community names produced, no cloud traffic (ollama API is local-only).
- Guard verified: `OPENAI_API_KEY=... scripts/graphify.sh label .` → exit 2 with a clear error; `query` unaffected.
- `pytest tests/unit/test_graphify_hook.py` 7 passed.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Pin graphify to local ollama

- Block cloud API keys in script

- Update env example and docs

- Correct model and install notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scripts/graphify.sh"] -- "adds cloud-key guard" --> B["local ollama only"]
  C[".env.dev.example"] -- "pins ollama model" --> B
  D[".opencode/rules/graphify.md"] -- "documents policy" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graphify.sh</strong><dd><code>Add cloud-key guard to graphify wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/graphify.sh

<ul><li>Adds local-ollama guard for LLM steps<br> <li> Exits 2 if cloud API key is set<br> <li> Allows explicit --backend ollama override<br> <li> Leaves read-only query/explain unguarded</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/442/files#diff-56d5d3b50fc91be7e76bdac34d24cedee82adee4a652da8d3d0f42388ff64683">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.dev.example</strong><dd><code>Document local-only graphify backend in env example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.dev.example

<ul><li>Documents local ollama-only graphify policy<br> <li> Removes MLflow gateway alternative block<br> <li> Pins OLLAMA_MODEL to qwen2.5-coder:7b<br> <li> Warns against adding cloud API keys</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/442/files#diff-bed67a8461c8c885b5b67387212eb79e0ae4e701cf04989a90ea25a76753b7b1">+6/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graphify.md</strong><dd><code>Update graphify rule to local ollama policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.opencode/rules/graphify.md

<ul><li>Replaces MLflow gateway default with local ollama<br> <li> Lists prohibited cloud API key variables<br> <li> Updates model example and backend guidance<br> <li> Corrects openai package install command</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/442/files#diff-16e4431db2e9028560a20e5501e863bb9b347d18dba0b5802d1f1fbd545c2a0b">+22/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

