### PR TITLE
Add runtime game frame capture tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ The full surface is 180 tools across 29 categories (`core` + 28 toggleable tools
 ### Runtime (gated) — `runtime` / `read_only`
 - `godot_runtime_run_and_capture` — headless subprocess
 - `godot_runtime_play_scene`, `godot_runtime_stop_scene`, `godot_runtime_is_playing`, `godot_runtime_get_game_scene_tree` — editor play session
+- `godot_runtime_capture_game_screenshot` — PNG of the *running game's* viewport (probe in-process grab)
 
 ### Input Simulation (gated) — `runtime` / `read_only`
 - `godot_input_simulate_key`, `godot_input_simulate_mouse`, `godot_input_simulate_action`, `godot_input_play_sequence`

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -746,6 +746,7 @@ answers `godot_mcp:` debugger queries. Play control is `runtime`; reads are `rea
 | `godot_runtime_stop_scene` | — | `PlayResult { playing }` |
 | `godot_runtime_is_playing` | — | `PlayResult { playing, scene }` |
 | `godot_runtime_get_game_scene_tree` | — | `GameSceneTreeResult { playing, connected, tree?, hint }` (read_only) |
+| `godot_runtime_capture_game_screenshot` | `timeout_ms?` | image content (PNG) (read_only) |
 
 `godot_runtime_play_scene` runs `scene_path` (a `res://*.tscn`) or the main scene when omitted.
 `godot_runtime_get_game_scene_tree` returns the *running* game's live tree (`GameNode { name, type,
@@ -754,6 +755,17 @@ path, children }`) from the probe; with no play session it is a `PRECONDITION_FA
 `connected=false` with a `hint` to add the autoload. Replies are cached addon-side
 (poll-and-cache) so the synchronous bridge stays simple. This is the foundation for
 input simulation (#36) and the rest of runtime inspection (#35).
+
+`godot_runtime_capture_game_screenshot` (issue #446) returns the *running game's* rendered
+viewport as an image block — the pixels the player sees, which the editor-viewport capture
+(#33) cannot show (the game is a separate child process). The probe grabs
+`get_viewport().get_texture().get_image()` one rendered frame after the request and replies
+`godot_mcp:game_frame` (base64 PNG); the addon caches it per `request_id` (one grab per
+invocation, mirroring `find_ui_elements`), and the tool polls until ready/`timeout_ms`
+(default 2000). Requires a play session + probe (`PRECONDITION_FAILED` otherwise). Not
+headless-testable (`--headless` does not render; same caveat as #33). Note payload size:
+a 1920×1080 frame is ~1–4 MB base64 over the debugger channel. A frame captured while the
+game is paused at a debugger break shows the frozen viewport.
 
 #### Input simulation (issue #36) — category: `input` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/runtime_session.gd
+++ b/godot/addons/godot_mcp/handlers/runtime_session.gd
@@ -14,6 +14,7 @@ func _init(router: MCPCommandRouter) -> void:
 
 
 func register(handlers: Dictionary) -> void:
+	handlers["cmd_capture_game_screenshot"] = _cmd_capture_game_screenshot
 	handlers["cmd_get_game_scene_tree"] = _cmd_get_game_scene_tree
 	handlers["cmd_get_input_stats"] = _cmd_get_input_stats
 	handlers["cmd_is_playing"] = _cmd_is_playing
@@ -134,4 +135,26 @@ func _cmd_get_input_stats(_params: Dictionary) -> Dictionary:
 	var injected: int = _router._debugger.get_input_acks() if connected else 0
 	return _router._ok({"playing": playing, "connected": connected, "injected": injected})
 
+
+
+func _cmd_capture_game_screenshot(params: Dictionary) -> Dictionary:
+	var guard := _router._require_live_probe()
+	if not guard["ok"]:
+		return guard
+	# Each tool invocation carries a stable request_id (constant across its poll loop).
+	# The probe grab answers asynchronously (one rendered frame later); we dispatch the
+	# capture to the probe exactly once per request_id and match the cached frame by
+	# that id — repeated polls never re-dispatch, and a reused id can't return a prior
+	# request's stale frame (same pattern as find_ui_elements).
+	var request_id := str(params.get("request_id", ""))
+	var payload: Variant = _router._debugger.get_game_frame()
+	if payload is Dictionary and (payload as Dictionary).get("request_id") == request_id:
+		var body: Dictionary = (payload as Dictionary).duplicate()
+		body.erase("request_id")
+		body["ready"] = true
+		return _router._ok(body)
+	if _router._debugger.get_pending_frame_request() != request_id:
+		_router._debugger.begin_frame_request(request_id)
+		_router._debugger.send_to_probe("godot_mcp:capture_frame", [{"request_id": request_id}])
+	return _router._ok({"ready": false})
 

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -21,6 +21,8 @@ var _ui_elements: Variant = null  # last godot_mcp:ui_elements payload (#35)
 var _ui_pending := "__none__"  # request_id of the in-flight find_ui request (#35)
 var _recorded_input: Variant = null  # last godot_mcp:recorded_input payload (#68)
 var _performance: Variant = null  # last godot_mcp:performance payload (#38)
+var _game_frame: Variant = null  # last godot_mcp:game_frame payload (#446)
+var _frame_request_id := ""  # request_id of the in-flight game frame capture (#446)
 var _breakpoints: Array = []  # tracked breakpoints for issue #110
 var _stack_frames: Variant = null  # last stack_dump payload (Tier 2)
 var _evaluation_result: Variant = null  # last evaluation_return payload (Tier 2)
@@ -65,6 +67,9 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			return true
 		"godot_mcp:performance":
 			_performance = data[0] if not data.is_empty() else null
+			return true
+		"godot_mcp:game_frame":
+			_game_frame = data[0] if not data.is_empty() else null
 			return true
 		# Tier 2 debugger: raw Godot debugger protocol replies (issue #110)
 		"stack_dump":
@@ -127,6 +132,8 @@ func _on_stopped() -> void:
 	_ui_pending = "__none__"
 	_recorded_input = null
 	_performance = null
+	_game_frame = null
+	_frame_request_id = ""
 	_stack_frames = null
 	_evaluation_result = null
 	_frame_vars = null
@@ -205,6 +212,22 @@ func clear_recorded_input() -> void:
 
 func get_performance() -> Variant:
 	return _performance
+
+
+## request_id of the in-flight game frame capture (so the router dispatches a
+## grab only once per invocation, mirroring the find_ui request pattern).
+func get_pending_frame_request() -> String:
+	return _frame_request_id
+
+
+## Mark a new game-frame capture as in-flight and drop any prior (stale) frame.
+func begin_frame_request(request_id: String) -> void:
+	_frame_request_id = request_id
+	_game_frame = null
+
+
+func get_game_frame() -> Variant:
+	return _game_frame
 
 
 ## Cache accessors for Tier 2 debugger tools (step, stack, eval).

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -22,7 +22,7 @@ var _ui_pending := "__none__"  # request_id of the in-flight find_ui request (#3
 var _recorded_input: Variant = null  # last godot_mcp:recorded_input payload (#68)
 var _performance: Variant = null  # last godot_mcp:performance payload (#38)
 var _game_frame: Variant = null  # last godot_mcp:game_frame payload (#446)
-var _frame_request_id := ""  # request_id of the in-flight game frame capture (#446)
+var _frame_request_id := "__none__"  # request_id of the in-flight game frame capture (#446)
 var _breakpoints: Array = []  # tracked breakpoints for issue #110
 var _stack_frames: Variant = null  # last stack_dump payload (Tier 2)
 var _evaluation_result: Variant = null  # last evaluation_return payload (Tier 2)
@@ -133,7 +133,7 @@ func _on_stopped() -> void:
 	_recorded_input = null
 	_performance = null
 	_game_frame = null
-	_frame_request_id = ""
+	_frame_request_id = "__none__"
 	_stack_frames = null
 	_evaluation_result = null
 	_frame_vars = null

--- a/godot/addons/godot_mcp/mcp_runtime_probe.gd
+++ b/godot/addons/godot_mcp/mcp_runtime_probe.gd
@@ -70,6 +70,12 @@ func _capture(message: String, data: Array) -> bool:
 		"get_performance":
 			EngineDebugger.send_message("godot_mcp:performance", [_performance_snapshot()])
 			return true
+		"capture_frame":
+			# Deferred one rendered frame: an inline texture read-back can return the
+			# previous frame (or stall); the grab runs in _process and replies when done.
+			_frame_request_id = str(_payload(data).get("request_id", ""))
+			_frame_pending = true
+			return true
 		"clear_breakpoints":
 			EngineDebugger.clear_breakpoints()
 			return true
@@ -113,6 +119,46 @@ func _performance_snapshot() -> Dictionary:
 	for name in _PERF_MONITORS:
 		monitors[name] = Performance.get_monitor(_PERF_MONITORS[name])
 	return monitors
+
+
+# --- game frame capture (issue #446) ----------------------------------------
+
+var _frame_request_id := ""
+var _frame_pending := false
+
+
+## Grab the game's root viewport on the next rendered frame and push it to the
+## editor as base64 PNG. Runs in _process (outside _capture) so the read-back
+## happens after this frame has been drawn.
+func _grab_frame() -> void:
+	var viewport := get_viewport()
+	var err := ""
+	var image: Image = null
+	if viewport == null:
+		err = "Game viewport is unavailable."
+	else:
+		var texture := viewport.get_texture()
+		if texture == null:
+			err = "No viewport texture (no rendered frame)."
+		else:
+			image = texture.get_image()
+			if image == null or image.is_empty():
+				err = "Could not capture the game viewport image."
+	if err.is_empty():
+		EngineDebugger.send_message("godot_mcp:game_frame", [{
+			"request_id": _frame_request_id,
+			"format": "png",
+			"width": image.get_width(),
+			"height": image.get_height(),
+			"base64": Marshalls.raw_to_base64(image.save_png_to_buffer()),
+		}])
+	else:
+		# An error result still closes the request so the poller doesn't spin.
+		EngineDebugger.send_message("godot_mcp:game_frame", [{
+			"request_id": _frame_request_id,
+			"ready": true,
+			"error": err,
+		}])
 
 
 # --- input simulation (issue #36) ------------------------------------------
@@ -234,6 +280,10 @@ var _monitor_error := ""
 ## Also services force_break: an editor-requested break fires here (one ``breakpoint``
 ## inside this frame), so the game needs no cooperation.
 func _process(_delta: float) -> void:
+	if _frame_pending:
+		_frame_pending = false
+		_grab_frame()
+		return  # this frame's read-back replaces the sample pass
 	if check_force_break():
 		return  # resumed after the break; skip this frame's sample so monitors freeze while paused
 	if _monitor_remaining <= 0:

--- a/mcp_server/command_map.py
+++ b/mcp_server/command_map.py
@@ -113,6 +113,7 @@ BARE_TO_COMMAND: dict[str, str] = {
     "resources_edit_register_autoload": "cmd_register_autoload",
     "resources_edit_set_resource_property": "cmd_set_resource_property",
     "resources_edit_unregister_autoload": "cmd_unregister_autoload",
+    "runtime_capture_game_screenshot": "cmd_capture_game_screenshot",
     "runtime_find_ui_elements": "cmd_find_ui_elements",
     "runtime_get_game_scene_tree": "cmd_get_game_scene_tree",
     "runtime_get_property_samples": "cmd_get_property_samples",

--- a/mcp_server/tools/runtime_session.py
+++ b/mcp_server/tools/runtime_session.py
@@ -9,10 +9,19 @@ the ``runtime`` toolset; play control is `runtime`, reads are `read_only`.
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import binascii
+from typing import Any
+
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.utilities.types import Image
 
 from mcp_server.bridge import Bridge
 from mcp_server.categories import RUNTIME_TAG
+from mcp_server.constraints import TimeoutMs
+from mcp_server.defaults import DEFAULT_CAPTURE_TIMEOUT_MS, DEFAULT_POLL_INTERVAL_SECONDS
 from mcp_server.models.runtime_session import GameSceneTreeResult, PlayResult
 from mcp_server.safety import READ_ONLY, RUNTIME
 from mcp_server.tools._route import route
@@ -67,3 +76,45 @@ def register_runtime_session(mcp: FastMCP, bridge: Bridge) -> None:
         get_scene_tree() to read the static scene structure instead.
         """
         return GameSceneTreeResult(**await route(bridge, "cmd_get_game_scene_tree", {}))
+
+    @mcp.tool(meta=READ_ONLY, tags=RUNTIME_SET)
+    async def capture_game_screenshot(
+        timeout_ms: TimeoutMs = DEFAULT_CAPTURE_TIMEOUT_MS,
+    ) -> Image:
+        """Capture the *running game's* rendered viewport as a PNG image, so you can
+        visually verify what the player sees — including shader, lighting, and camera
+        output the editor viewport cannot show (the game is a separate process; the
+        probe grabs the frame in-process). Read-only. Requires an active play session
+        with the runtime probe autoload.
+
+        IF THIS FAILS with "No play session":
+          -> Call play_scene(scene_path) first.
+        IF THIS FAILS with "probe is not connected":
+          -> Register MCPRuntimeProbe as an autoload in the game (get_project_info()
+             to check), then play_scene again.
+        """
+        deadline = asyncio.get_event_loop().time() + timeout_ms / 1000
+        result: dict[str, Any] = {}
+        while True:
+            result = await route(bridge, "cmd_capture_game_screenshot")
+            # Done when the probe's frame arrived; ``{"ready": false}`` means the
+            # grab is still pending (the addon dispatches one request per poll).
+            if result.get("base64") or (result.get("ready") and result.get("error")):
+                break
+            if asyncio.get_event_loop().time() >= deadline:
+                raise ToolError(
+                    f"Game frame capture did not complete within {timeout_ms}ms — "
+                    "is the game window rendering (not fully hidden/minimized)?"
+                )
+            await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
+        if not result.get("base64"):
+            reason = str(result.get("error", "")).strip()
+            detail = f" ({reason})" if reason else ""
+            raise ToolError(f"Game frame capture returned no image data.{detail}")
+        try:
+            data = base64.b64decode(result["base64"], validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ToolError(f"Game frame data was not valid base64: {exc}") from exc
+        # Normalize e.g. "image/png" → "png".
+        fmt = str(result.get("format", "png")).removeprefix("image/")
+        return Image(data=data, format=fmt)

--- a/mcp_server/tools/runtime_session.py
+++ b/mcp_server/tools/runtime_session.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import uuid
 from typing import Any
 
 from fastmcp import FastMCP
@@ -94,9 +95,13 @@ def register_runtime_session(mcp: FastMCP, bridge: Bridge) -> None:
              to check), then play_scene again.
         """
         deadline = asyncio.get_event_loop().time() + timeout_ms / 1000
+        # Stable per-invocation id (constant across the poll loop): the addon dispatches
+        # one probe grab per request_id and matches the cached frame by it (mirrors
+        # find_ui_elements) — polls without it would never trigger the dispatch.
+        params = {"request_id": uuid.uuid4().hex}
         result: dict[str, Any] = {}
         while True:
-            result = await route(bridge, "cmd_capture_game_screenshot")
+            result = await route(bridge, "cmd_capture_game_screenshot", params)
             # Done when the probe's frame arrived; ``{"ready": false}`` means the
             # grab is still pending (the addon dispatches one request per poll).
             if result.get("base64") or (result.get("ready") and result.get("error")):

--- a/tests/contract/test_game_capture.py
+++ b/tests/contract/test_game_capture.py
@@ -96,6 +96,33 @@ async def test_frame_grab_polls_until_ready() -> None:
     assert image_blocks, f"expected an image content block, got {result.content}"
 
 
+async def test_polls_send_a_stable_request_id() -> None:
+    """The tool must carry a per-invocation request_id on every poll (Qodo #447 review):
+
+    the addon dispatches one probe grab per request_id and matches the cached frame by
+    it — polls without the key default to "" and never trigger the dispatch.
+    """
+    seen: list[str] = []
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        if cmd.command == "cmd_capture_game_screenshot":
+            seen.append(str(cmd.params.get("request_id", "")))
+            if len(seen) == 1:
+                return ResponseEnvelope.success(cmd.id, {"ready": False})
+            return ResponseEnvelope.success(cmd.id, {"ready": True, **_FRAME})
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        await client.call_tool("godot_runtime_capture_game_screenshot", {"timeout_ms": 2000})
+    assert seen, "capture command never sent"
+    assert all(r for r in seen), f"empty request_id in polls: {seen}"
+    assert len(set(seen)) == 1, f"request_id must be stable across polls: {seen}"
+
+
 async def test_capture_never_ready_times_out_with_actionable_error() -> None:
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
         return ResponseEnvelope.success(cmd.id, {"ready": False})

--- a/tests/contract/test_game_capture.py
+++ b/tests/contract/test_game_capture.py
@@ -1,0 +1,153 @@
+"""Contract tests for the game frame capture tool (issue #446).
+
+The game runs as a separate child process, so its viewport is reachable only via
+the #66 runtime probe (in-process). Contract shape mirrors the editor screenshot
+tool (issue #33): the addon dispatches one capture request per invocation, the
+server polls the poll-and-cache command until a frame arrives, and the tool
+decodes the base64 PNG into a FastMCP ``Image``.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import ServerConfig
+from mcp_server.models.envelope import CommandEnvelope, ResponseEnvelope
+from mcp_server.server import create_server
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+# 1x1 red PNG.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8"
+    "BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+_FRAME = {"format": "png", "width": 1, "height": 1, "base64": _PNG_B64}
+
+
+def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+    if cmd.command == "cmd_capture_game_screenshot":
+        return ResponseEnvelope.success(cmd.id, {"ready": True, **_FRAME})
+    return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+
+def _server() -> FastMCP:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge)
+
+
+async def test_gated_in_runtime_toolset() -> None:
+    server, _ = _build_simple()
+    async with Client(server, mode="legacy") as client:
+        assert "godot_runtime_capture_game_screenshot" not in {
+            t.name for t in await client.list_tools()
+        }
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        tools = {t.name: t for t in await client.list_tools()}
+    assert "godot_runtime_capture_game_screenshot" in tools
+    assert tools["godot_runtime_capture_game_screenshot"].meta["safety_class"] == "read_only"
+
+
+def _build_simple() -> tuple[FastMCP, FakeAddonConnection]:
+    conn = FakeAddonConnection(responder=_responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    return create_server(ServerConfig(), bridge=bridge), conn
+
+
+async def test_capture_returns_image_content() -> None:
+    server, _ = _build_simple()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool("godot_runtime_capture_game_screenshot", {})
+    image_blocks = [b for b in result.content if type(b).__name__ == "ImageContent"]
+    assert image_blocks, f"expected an image content block, got {result.content}"
+    block = image_blocks[0]
+    assert block.mime_type == "image/png"
+    assert base64.b64decode(block.data).startswith(b"\x89PNG\r\n\x1a\n")
+
+
+async def test_frame_grab_polls_until_ready() -> None:
+    """The probe answers asynchronously; the tool polls the addon's cache."""
+    calls = {"n": 0}
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ResponseEnvelope.success(cmd.id, {"ready": False})
+        return ResponseEnvelope.success(cmd.id, {"ready": True, **_FRAME})
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {"timeout_ms": 2000}
+        )
+    assert calls["n"] >= 2
+    image_blocks = [b for b in result.content if type(b).__name__ == "ImageContent"]
+    assert image_blocks, f"expected an image content block, got {result.content}"
+
+
+async def test_capture_never_ready_times_out_with_actionable_error() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(cmd.id, {"ready": False})
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {"timeout_ms": 250}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "did not complete" in str(result.content)
+
+
+async def test_no_play_session_is_structured_precondition_error() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        if cmd.command == "cmd_capture_game_screenshot":
+            return ResponseEnvelope.failure(
+                cmd.id, "PRECONDITION_FAILED", "No play session. Run play_scene first.",
+                required="play_session",
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {}, raise_on_error=False
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "PRECONDITION_FAILED" in text
+    assert "play_session" in text
+
+
+async def test_malformed_base64_is_structured_error() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(
+            cmd.id, {"ready": True, "format": "png", "base64": "not!!valid!!"}
+        )
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "base64" in str(result.content)

--- a/tests/contract/test_game_capture.py
+++ b/tests/contract/test_game_capture.py
@@ -178,3 +178,29 @@ async def test_malformed_base64_is_structured_error() -> None:
         )
     assert result.is_error
     assert "base64" in str(result.content)
+
+
+async def test_error_frame_surfaces_probe_reason() -> None:
+    """The probe closes a failed grab with ``{ready: true, error}`` (e.g. no viewport
+    texture); the tool must surface that reason as a structured error immediately, not
+    spin until timeout (Qodo #447 round-2 review)."""
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        if cmd.command == "cmd_capture_game_screenshot":
+            return ResponseEnvelope.success(
+                cmd.id, {"ready": True, "error": "No viewport texture (no rendered frame)."}
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {}, raise_on_error=False
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "no image data" in text
+    assert "No viewport texture" in text

--- a/tests/contract/test_output_schema.py
+++ b/tests/contract/test_output_schema.py
@@ -43,12 +43,12 @@ from tests.fakes import FakeAddonConnection, connector_for
 
 pytestmark = pytest.mark.asyncio
 
-# The one tool whose content is an image, not JSON: the spec says structured
-# content applies to JSON results, so this tool correctly declares no schema.
+# The tools whose content is an image, not JSON: the spec says structured
+# content applies to JSON results, so these tools correctly declare no schema.
 # Keyed by the original handler name — Provider.list_tools (all tools, gated
-# included) yields pre-transform names; the public client name is
-# godot_editor_capture_screenshot.
-IMAGE_TOOLS = {"capture_editor_screenshot"}
+# included) yields pre-transform names; the public client names are
+# godot_editor_capture_screenshot / godot_runtime_capture_game_screenshot.
+IMAGE_TOOLS = {"capture_editor_screenshot", "capture_game_screenshot"}
 
 
 def image_responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -409,6 +409,16 @@ def test_router_registers_profiling_commands() -> None:
     assert "_performance_snapshot" in probe  # the probe answers get_performance
 
 
+def test_router_registers_game_capture_commands() -> None:
+    source = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
+    assert '"cmd_capture_game_screenshot"' in source
+    # The probe must grab the game's own viewport (issue #446) — the game runs
+    # as a separate child process, so its viewport exists only in-process.
+    probe = (ADDON_DIR / "mcp_runtime_probe.gd").read_text()
+    assert "capture_frame" in probe and "godot_mcp:game_frame" in probe
+    assert "get_viewport" in probe and "save_png_to_buffer" in probe
+
+
 def test_router_registers_batch_commands() -> None:
     source = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
     for command in (


### PR DESCRIPTION
### **User description**
## Summary

Adds `godot_runtime_capture_game_screenshot` (#446): a vision-capable agent can now SEE the *running game's* rendered viewport — the pixels the player sees. The editor-viewport capture (#33) cannot show this: when playing, the game is a separate child process.

Closes #446.

### How it works (the #66 poll-and-cache rails)

- **Probe** (`mcp_runtime_probe.gd`, in the game process): handles `godot_mcp:capture_frame` — defers the grab one rendered frame (deferred in `_process`), reads `get_viewport().get_texture().get_image()`, replies `godot_mcp:game_frame` with base64 PNG (`save_png_to_buffer` + `raw_to_base64`). Error results also reply (with `error`) so the poller never spins.
- **Addon** (`mcp_debugger.gd` + `handlers/runtime_session.gd`): caches the frame keyed by per-invocation `request_id` (same one-dispatch-per-request pattern as `find_ui_elements` — no re-dispatch on polls, no stale frames); new `cmd_capture_game_screenshot` guards via `_require_live_probe`.
- **MCP** (`tools/runtime_session.py`): `godot_runtime_capture_game_screenshot(timeout_ms=2000)` polls `ready` until the frame arrives or timeout, decodes into a FastMCP `Image`. `read_only`, `runtime` toolset (gated off by default).

### Acceptance criteria (issue #446)

- [x] Probe grabs the game's own root viewport in-process and replies `godot_mcp:game_frame` (base64 PNG)
- [x] Editor addon caches the frame + dispatches one grab per invocation (`request_id` correlation); clears on session stop
- [x] `cmd_capture_game_screenshot` returns `PRECONDITION_FAILED` (`required=play_session`) with no play session / no probe
- [x] MCP tool `godot_runtime_capture_game_screenshot` polls until ready, returns image content, times out with an actionable error
- [x] `runtime` toolset gating + `read_only` safety class
- [x] Not headless-testable (same caveat as #33) — contract tests cover poll/precondition/decode against a fake peer; live capture verified manually

### Test plan

- `tests/contract/test_game_capture.py` (new, 6 tests): gating + safety class, image content round-trip, deferred poll-until-ready, timeout error text, structured precondition, malformed base64
- `tests/contract/test_output_schema.py`: `capture_game_screenshot` added to `IMAGE_TOOLS` (image tools declare no output schema)
- `tests/unit/test_addon_manifest.py`: probe must grab the game viewport (`get_viewport` + `save_png_to_buffer`)
- `tests/unit/test_command_map.py` table: `runtime_capture_game_screenshot` → `cmd_capture_game_screenshot`
- Full preflight: 714 tests pass, mypy clean, ruff clean, zero-skip clean
- Manual (live editor): play a scene with the probe autoload → `godot_runtime_capture_game_screenshot` returns the game's rendered frame


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds runtime game frame capture tool

- Probe captures game viewport as PNG

- Server polls cached frame until ready

- Large frame payloads may time out


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tool["MCP tool"] -- "polls" --> handler["Addon handler"]
  handler -- "dispatches once" --> probe["Runtime probe"]
  probe -- "base64 PNG" --> cache["Debugger cache"]
  cache -- "cached frame" --> handler
  handler -- "Image" --> tool
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>command_map.py</strong><dd><code>Add game capture command mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-28f3a45adf0ec35600a84fdda883682dcbd4e0103947bbe434b97622c7ea3ed1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_session.py</strong><dd><code>Add polling game screenshot MCP tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-d5e162c1addd596209d385e90e8f17a8ed51b5eeb3b872258e3878bb055c9970">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime_session.gd</strong><dd><code>Add game screenshot addon command handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-97d2675a84c1fba2465f143dd6ba64ae45158da6434f45afaf458af983c0e947">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp_debugger.gd</strong><dd><code>Cache game frame debugger payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-c16d1a89bdde3198440746408f5db9412459963442fcca62abedf274114ed7c6">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp_runtime_probe.gd</strong><dd><code>Capture game viewport frame in probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-dd86be34488c1080a1ad6f9d9507d415ba22dff012358b5933fef8ef840439ea">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_game_capture.py</strong><dd><code>Add contract tests for game capture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-4190dbc232289d106651240096b3d7b990a9fd8762227da054b5228c38c038f8">+153/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_output_schema.py</strong><dd><code>Update image tool schema expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-5d4a2f0168e0b9392a53dd6c0be634a7f1d7af79cc4f86ff270f316a7f535105">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_addon_manifest.py</strong><dd><code>Add addon manifest game capture test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-7b97e94c7bcb49783c2153046c691734b56f1f1b47497ab3d9e41aa815e6e135">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document new game capture tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document game capture tool contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/447/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

