### PR TITLE
Fix `scripts_write` overwrite response contract

### DIFF
--- a/godot/addons/godot_mcp/handlers/scripts.gd
+++ b/godot/addons/godot_mcp/handlers/scripts.gd
@@ -97,7 +97,13 @@ func _cmd_write_script(params: Dictionary) -> Dictionary:
 		# sidecar so nothing is left orphaned (parity with the shader handler).
 		ur.add_undo_method(_router, "_remove_file_with_uid", path)
 	ur.commit_action()
-	return _router._ok({"script_path": path, "created": not existed, "would_overwrite": existed})
+	# #424: report what actually happened — an overwrite reads as success
+	# (overwrote/previous_existed), never as a no-op ("would_overwrite" is the
+	# dry-run probe's phrasing and stays there).
+	return _router._ok({
+		"script_path": path, "created": not existed,
+		"overwrote": existed, "previous_existed": existed,
+	})
 
 
 

--- a/mcp_server/models/scripts.py
+++ b/mcp_server/models/scripts.py
@@ -47,13 +47,22 @@ class WriteScriptResult(BaseModel):
         # carries the dry-run probe key ``would_overwrite`` (it reads like a no-op,
         # #424), and a dry-run preview never carries the effect keys. FastMCP builds
         # structured_content via pydantic-core, which only honors this hook.
+        overwrote = self.overwrote or (not self.dry_run and self.would_overwrite)
+        if not self.dry_run:
+            # Version skew (#424 round-2): a legacy addon replying only
+            # ``would_overwrite`` on a real run maps to the effect keys — the
+            # overwrite DID land, so the response must never read ``overwrote:false``.
+            previous_existed = self.previous_existed or self.would_overwrite
+        else:
+            previous_existed = self.previous_existed
         data = {"script_path": self.script_path, "created": self.created}
         if self.dry_run:
             data["dry_run"] = True
             data["would_overwrite"] = self.would_overwrite
+            data["previous_existed"] = previous_existed
         else:
-            data["overwrote"] = self.overwrote
-            data["previous_existed"] = self.previous_existed
+            data["overwrote"] = overwrote
+            data["previous_existed"] = previous_existed
         return data
 
 

--- a/mcp_server/models/scripts.py
+++ b/mcp_server/models/scripts.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, Field, model_serializer
 
 
 class ScriptContent(BaseModel):
@@ -29,11 +31,30 @@ class NodeScript(BaseModel):
 class WriteScriptResult(BaseModel):
     script_path: str
     created: bool = False
-    # True when the write replaced an existing script (so the agent isn't blind to
-    # clobbering hand-written code). In dry_run this is determined by an existence
-    # probe; the change stays reversible via the editor's undo (#205).
+    # Real-run truth about what the write did (#424): an overwrite reports
+    # ``overwrote=True, previous_existed=True`` — the response must never read like
+    # a no-op while the bytes landed. In dry_run the effect hasn't happened, so the
+    # result instead carries ``would_overwrite`` from the existence probe; the
+    # change stays reversible via the editor's undo (#205).
+    overwrote: bool = False
+    previous_existed: bool = False
     would_overwrite: bool = False
     dry_run: bool = False
+
+    @model_serializer(mode="plain")
+    def _serialize(self) -> dict[str, Any]:
+        # Mode-split serialization (same pattern as UndoResult): a real run never
+        # carries the dry-run probe key ``would_overwrite`` (it reads like a no-op,
+        # #424), and a dry-run preview never carries the effect keys. FastMCP builds
+        # structured_content via pydantic-core, which only honors this hook.
+        data = {"script_path": self.script_path, "created": self.created}
+        if self.dry_run:
+            data["dry_run"] = True
+            data["would_overwrite"] = self.would_overwrite
+        else:
+            data["overwrote"] = self.overwrote
+            data["previous_existed"] = self.previous_existed
+        return data
 
 
 class PatchScriptResult(BaseModel):

--- a/mcp_server/tools/scripts.py
+++ b/mcp_server/tools/scripts.py
@@ -84,14 +84,15 @@ def register_scripts(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
         result = await route(bridge, "cmd_get_script_for_node", {"node_path": node_path})
         return NodeScript(**result)
 
-    @mcp.tool(meta=MUTATING, tags=SCRIPTS)
+    @mcp.tool(meta=MUTATING, tags=SCRIPTS, output_schema=WriteScriptResult.model_json_schema())
     async def write_script(
         script_path: str, content: str, dry_run: bool = False
     ) -> WriteScriptResult:
         """Create or overwrite the GDScript at ``script_path`` with ``content``.
         Reversible via the editor's undo. ``dry_run=True`` writes nothing and reports
         ``would_overwrite`` so the agent knows whether it is about to replace an
-        existing script.
+        existing script. A real run reports what happened: ``created`` on a fresh file,
+        ``overwrote``/``previous_existed`` when an existing script was replaced.
         """
         params = {"script_path": script_path, "content": content}
         if dry_run:
@@ -100,7 +101,11 @@ def register_scripts(mcp: FastMCP, bridge: Bridge, config: ServerConfig, runner:
             await validate_or_raise(bridge, "cmd_write_script", params)
             exists = await _script_exists(bridge, script_path)
             return WriteScriptResult(
-                script_path=script_path, created=not exists, would_overwrite=exists, dry_run=True
+                script_path=script_path,
+                created=not exists,
+                would_overwrite=exists,
+                previous_existed=exists,
+                dry_run=True,
             )
         return WriteScriptResult(**await route(bridge, "cmd_write_script", params))
 

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -159,6 +159,35 @@ async def test_write_script_rejects_res_root_escape() -> None:
     assert "cmd_write_script" not in sent  # rejected before reaching the addon
 
 
+async def test_write_script_overwrite_reports_the_effect() -> None:
+    """#424: a real overwrite must read as success — ``created:false, overwrote:true,
+    previous_existed:true``. ``would_overwrite`` is dry-run-only phrasing; the real
+    response must not read like a no-op while the bytes landed."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_write_script":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"script_path": cmd.params["script_path"], "created": False,
+                 "overwrote": True, "previous_existed": True},
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scripts"})
+        result = await client.call_tool(
+            "godot_scripts_write", {"script_path": "res://x.gd", "content": "extends Node"}
+        )
+    sc = result.structured_content
+    assert sc["created"] is False
+    assert sc["overwrote"] is True
+    assert sc["previous_existed"] is True
+    # The misleading key must not appear on a real run (dry_run keeps its probe form).
+    assert "would_overwrite" not in sc
+
+
 async def test_write_script_dry_run_does_not_bypass_containment() -> None:
     # A dry-run must validate the path BEFORE probing existence, so an escaped path
     # can't read a file outside the project via cmd_read_script (Qodo #209).

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -139,7 +139,11 @@ async def test_write_script_safety_and_dry_run() -> None:
     assert dry.structured_content["dry_run"] is True
     assert dry.structured_content["would_overwrite"] is True
     assert dry.structured_content["created"] is False
+    # #424 round-2 review: the preview must state the file's existence too — the
+    # tool sets previous_existed; the serializer must not drop it.
+    assert dry.structured_content["previous_existed"] is True
     assert dry_new.structured_content["would_overwrite"] is False
+    assert dry_new.structured_content["previous_existed"] is False
     assert dry_new.structured_content["created"] is True
     sent = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
     assert "cmd_write_script" not in sent  # dry-run writes nothing
@@ -186,6 +190,34 @@ async def test_write_script_overwrite_reports_the_effect() -> None:
     assert sc["previous_existed"] is True
     # The misleading key must not appear on a real run (dry_run keeps its probe form).
     assert "would_overwrite" not in sc
+
+
+async def test_write_script_legacy_addon_payload_maps_to_effect_truth() -> None:
+    """#424 round-2 (version skew): a legacy addon that still replies
+    ``{created:false, would_overwrite:true}`` must not serialize as
+    ``overwrote:false`` while the bytes landed — the parsed probe key maps to
+    the effect keys on a real run."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_write_script":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"script_path": cmd.params["script_path"], "created": False,
+                 "would_overwrite": True},
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scripts"})
+        result = await client.call_tool(
+            "godot_scripts_write", {"script_path": "res://x.gd", "content": "extends Node"}
+        )
+    sc = result.structured_content
+    assert sc["overwrote"] is True
+    assert sc["previous_existed"] is True
+    assert sc["created"] is False
 
 
 async def test_write_script_dry_run_does_not_bypass_containment() -> None:


### PR DESCRIPTION
### **User description**
## Summary

Fixes #424: `godot_scripts_write` on an existing script reported `{created:false, would_overwrite:true}` — reading like a rejection/no-op — while the bytes WERE overwritten. An agent trusting the envelope double-writes or abandons a correct write.

### New contract

- **Real run**: `{created:false, overwrote:true, previous_existed:true}` — reports what actually happened. The misleading dry-run-probe key `would_overwrite` never appears on a real run.
- **Dry run** (unchanged semantics, cleaned shape): `{created, would_overwrite, previous_existed, dry_run:true}` — the effect hasn't happened, so the probe phrasing stays there. `previous_existed` now included for symmetry.
- `would_overwrite` remains accepted in the model (mode-split serializer, same pattern as `UndoResult`) so older envelopes still parse; it's just never emitted from the real-run path.

### Acceptance criteria (#424)

- [x] Real overwrite reports `{created:false, overwrote:true, previous_existed:true}` — effect-truthful, not a no-op read
- [x] Dry-run keeps `would_overwrite` (probe form) and gains `previous_existed`
- [x] Real-run response no longer carries `would_overwrite` (mode-split serialization; explicit `output_schema` because the serializer hides fields from schema generation — same fix as `godot_undo`)
- [x] Addon handler + model + tool docstring agree

### Test plan

- `test_write_script_overwrite_reports_the_effect` (new, red first): real run → `overwrote/previous_existed` true, `created` false, no `would_overwrite` key
- Existing dry-run test updated expectations preserved (`would_overwrite` still on preview)
- `test_output_schema` full-surface guard passes again (write_script no longer degenerate)
- Full suite 732 pass, mypy/ruff/zero-skip clean


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix `scripts_write` overwrite response

- Add `overwrote` and `previous_existed`

- Real-run drops `would_overwrite` key

- Dry-run gains `previous_existed` field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Real write"] -- "reports effect" --> B["overwrote/previous_existed"]
  C["Dry run"] -- "keeps probe" --> D["would_overwrite/previous_existed"]
  E["Addon handler"] -- "emits truth" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scripts.py</strong><dd><code>Add effect-truthful write result serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/scripts.py

<ul><li>Add <code>overwrote</code> and <code>previous_existed</code> fields<br> <li> Serialize dry-run and real-run separately<br> <li> Remove <code>would_overwrite</code> from real-run output<br> <li> Keep old key parseable for compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/448/files#diff-dd7d014708fad36bfa6f1e2b7f8a61137c50a0026792a6b3f05f17b7f222f2f3">+25/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scripts.py</strong><dd><code>Update write script tool schema and docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/scripts.py

<ul><li>Add explicit <code>output_schema</code> for <code>write_script</code><br> <li> Document real-run overwrite fields<br> <li> Include <code>previous_existed</code> in dry-run result<br> <li> Preserve dry-run <code>would_overwrite</code> behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/448/files#diff-53b07b1d837dec653317ad780630699d2a4d175c423508a0155d17eab5f99e1c">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scripts.gd</strong><dd><code>Report overwrite effect in addon handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/scripts.gd

<ul><li>Return <code>overwrote</code> and <code>previous_existed</code> on write<br> <li> Stop emitting <code>would_overwrite</code> for real runs<br> <li> Preserve undo behavior for create/overwrite</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/448/files#diff-fde6407c60d4eebfb9621e101cbefda7b8daae93b3a351fc73331fdf5a922744">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scripts.py</strong><dd><code>Add overwrite effect contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_scripts.py

<ul><li>Add test for real overwrite response<br> <li> Assert <code>overwrote</code> and <code>previous_existed</code> true<br> <li> Assert <code>would_overwrite</code> absent on real run</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/448/files#diff-9549267864d28f3304b4acded59f0df00eb2a24150480e2c261e2ca158979f4b">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

