### PR TITLE
Fix script write response contract

### DIFF
--- a/mcp_server/models/scripts.py
+++ b/mcp_server/models/scripts.py
@@ -47,14 +47,22 @@ class WriteScriptResult(BaseModel):
         # carries the dry-run probe key ``would_overwrite`` (it reads like a no-op,
         # #424), and a dry-run preview never carries the effect keys. FastMCP builds
         # structured_content via pydantic-core, which only honors this hook.
+        overwrote = self.overwrote or (not self.dry_run and self.would_overwrite)
+        if not self.dry_run:
+            # Version skew (#424 round-2): a legacy addon replying only
+            # ``would_overwrite`` on a real run maps to the effect keys — the
+            # overwrite DID land, so the response must never read ``overwrote:false``.
+            previous_existed = self.previous_existed or self.would_overwrite
+        else:
+            previous_existed = self.previous_existed
         data = {"script_path": self.script_path, "created": self.created}
         if self.dry_run:
             data["dry_run"] = True
             data["would_overwrite"] = self.would_overwrite
-            data["previous_existed"] = self.previous_existed
+            data["previous_existed"] = previous_existed
         else:
-            data["overwrote"] = self.overwrote
-            data["previous_existed"] = self.previous_existed
+            data["overwrote"] = overwrote
+            data["previous_existed"] = previous_existed
         return data
 
 

--- a/mcp_server/models/scripts.py
+++ b/mcp_server/models/scripts.py
@@ -51,6 +51,7 @@ class WriteScriptResult(BaseModel):
         if self.dry_run:
             data["dry_run"] = True
             data["would_overwrite"] = self.would_overwrite
+            data["previous_existed"] = self.previous_existed
         else:
             data["overwrote"] = self.overwrote
             data["previous_existed"] = self.previous_existed

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -192,6 +192,34 @@ async def test_write_script_overwrite_reports_the_effect() -> None:
     assert "would_overwrite" not in sc
 
 
+async def test_write_script_legacy_addon_payload_maps_to_effect_truth() -> None:
+    """#424 round-2 (version skew): a legacy addon that still replies
+    ``{created:false, would_overwrite:true}`` must not serialize as
+    ``overwrote:false`` while the bytes landed — the parsed probe key maps to
+    the effect keys on a real run."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_write_script":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"script_path": cmd.params["script_path"], "created": False,
+                 "would_overwrite": True},
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "scripts"})
+        result = await client.call_tool(
+            "godot_scripts_write", {"script_path": "res://x.gd", "content": "extends Node"}
+        )
+    sc = result.structured_content
+    assert sc["overwrote"] is True
+    assert sc["previous_existed"] is True
+    assert sc["created"] is False
+
+
 async def test_write_script_dry_run_does_not_bypass_containment() -> None:
     # A dry-run must validate the path BEFORE probing existence, so an escaped path
     # can't read a file outside the project via cmd_read_script (Qodo #209).

--- a/tests/contract/test_scripts.py
+++ b/tests/contract/test_scripts.py
@@ -139,7 +139,11 @@ async def test_write_script_safety_and_dry_run() -> None:
     assert dry.structured_content["dry_run"] is True
     assert dry.structured_content["would_overwrite"] is True
     assert dry.structured_content["created"] is False
+    # #424 round-2 review: the preview must state the file's existence too — the
+    # tool sets previous_existed; the serializer must not drop it.
+    assert dry.structured_content["previous_existed"] is True
     assert dry_new.structured_content["would_overwrite"] is False
+    assert dry_new.structured_content["previous_existed"] is False
     assert dry_new.structured_content["created"] is True
     sent = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
     assert "cmd_write_script" not in sent  # dry-run writes nothing


### PR DESCRIPTION
### **User description**
Follow-up to #448 (closes #424): Qodo caught that the dry-run branch of the mode-split serializer dropped `previous_existed` while the tool sets it — a dead assignment and a doc/behavior mismatch. Now the preview emits it (test-pinned), so the agent sees the file's existence in both modes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Real run reports overwrite effect

- Dry-run preview includes `previous_existed`

- Real run omits `would_overwrite` key

- Older envelopes still parse safely


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scripts_write"]
  B["dry-run: would_overwrite, previous_existed"]
  C["real: overwrote, previous_existed"]
  D["WriteScriptResult serializer"]
  A -->|"dry run"| B
  A -->|"real run"| C
  D -->|"mode split"| B
  D -->|"mode split"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scripts.py</strong><dd><code>Add mode-split serializer to script write result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/scripts.py

<ul><li>Adds <code>overwrote</code> and <code>previous_existed</code> fields<br> <li> Adds mode-split <code>model_serializer</code> for <code>WriteScriptResult</code><br> <li> Keeps <code>would_overwrite</code> for dry-run previews only<br> <li> Updates comments for #424</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/450/files#diff-dd7d014708fad36bfa6f1e2b7f8a61137c50a0026792a6b3f05f17b7f222f2f3">+26/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scripts.py</strong><dd><code>Update script write tool schema and dry-run</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/scripts.py

<ul><li>Updates <code>write_script</code> tool with explicit <code>output_schema</code><br> <li> Dry-run result now sets <code>previous_existed</code><br> <li> Docstring documents real-run overwrite reporting<br> <li> Keeps dry-run validation before existence probe</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/450/files#diff-53b07b1d837dec653317ad780630699d2a4d175c423508a0155d17eab5f99e1c">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scripts.gd</strong><dd><code>Report actual script write effect in addon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/scripts.gd

<ul><li><code>_cmd_write_script</code> returns <code>overwrote</code> and <code>previous_existed</code><br> <li> Removes <code>would_overwrite</code> from real-run response<br> <li> Keeps undo behavior for create and overwrite<br> <li> Adds comment explaining #424 effect reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/450/files#diff-fde6407c60d4eebfb9621e101cbefda7b8daae93b3a351fc73331fdf5a922744">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scripts.py</strong><dd><code>Add contract tests for script write reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_scripts.py

<ul><li>Adds <code>previous_existed</code> assertions for dry-run previews<br> <li> Adds test for real overwrite reporting effect<br> <li> Pins absence of <code>would_overwrite</code> on real runs<br> <li> Preserves existing dry-run and containment tests</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/450/files#diff-9549267864d28f3304b4acded59f0df00eb2a24150480e2c261e2ca158979f4b">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

