### PR TITLE
Fix `project_scaffold` dry-run to return real plan

### DIFF
--- a/mcp_server/tools/project_scaffold.py
+++ b/mcp_server/tools/project_scaffold.py
@@ -21,7 +21,7 @@ from mcp_server.safety import (
     enforce_preconditions,
     require_confirmation,
 )
-from mcp_server.tools._route import run_or_preview
+from mcp_server.tools._route import route
 
 PROJECT_SCAFFOLD = {PROJECT_SCAFFOLD_TAG}
 
@@ -66,24 +66,35 @@ def register_project_scaffold(
             )
         if not dry_run:
             require_confirmation(confirm, "scaffold_project")
+        project_name = project_name or type
+        main_scene = main_scene or "main"
         params: dict[str, str | bool] = {
             "type": type,
-            "project_name": project_name or type,
-            "main_scene": main_scene or "main",
+            "project_name": project_name,
+            "main_scene": main_scene,
             # Forward the destructive gate to the addon: it re-checks confirm
             # defensively (#409) and would reject the call without it.
             "confirm": confirm,
         }
-        preview = {
-            "created": False,
-            "paths_created": [],
-            "autoloads_registered": [],
-        }
-        return await run_or_preview(
-            dry_run,
-            ScaffoldProjectResult,
-            preview,
-            bridge,
-            "cmd_scaffold_project",
-            params,
-        )
+        if dry_run:
+            # #426: the preview must be the actual plan the real run executes —
+            # directories, settings artifact, autoload script, and root scene —
+            # mirroring the addon handler's steps (project_scaffold.gd), not a
+            # vacuous empty result indistinguishable from a no-op.
+            scene_path = f"res://scenes/{main_scene}.tscn"
+            plan = [
+                "res://scenes/",
+                "res://scripts/",
+                "res://assets/",
+                "res://shaders/",
+                "res://project.godot",
+                "res://scripts/game_state.gd",
+                scene_path,
+            ]
+            return ScaffoldProjectResult(
+                created=False,
+                paths_created=plan,
+                autoloads_registered=["GameState"],
+                dry_run=True,
+            )
+        return ScaffoldProjectResult(**await route(bridge, "cmd_scaffold_project", params))

--- a/tests/contract/test_project_scaffold.py
+++ b/tests/contract/test_project_scaffold.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -120,6 +121,42 @@ async def test_scaffold_project_dry_run() -> None:
     assert dry.structured_content["dry_run"] is True
     assert dry.structured_content["created"] is False
     assert "cmd_scaffold_project" not in _commands(conn)
+
+
+async def test_scaffold_project_dry_run_returns_the_real_plan() -> None:
+    """#426: dry_run must return the same plan the real run would execute — the
+    directories, settings, autoloads, and root scene — not a vacuous empty result
+    indistinguishable from a no-op."""
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "project_scaffold"})
+        dry = await client.call_tool(
+            "godot_project_scaffold",
+            {"type": "2d_platformer", "project_name": "Jump", "dry_run": True},
+        )
+    sc = dry.structured_content
+    assert sc["dry_run"] is True
+    assert sc["created"] is False  # nothing was created
+    plan: list[str] = sc["paths_created"]
+    for d in ("res://scenes/", "res://scripts/", "res://assets/", "res://shaders/"):
+        assert d in plan, f"plan must list the directories it would create: {plan}"
+    assert "res://scripts/game_state.gd" in plan
+    assert "res://project.godot" in plan
+    assert any(p.endswith(".tscn") for p in plan), f"plan must include the main scene: {plan}"
+    assert sc["autoloads_registered"] == ["GameState"]
+    assert "cmd_scaffold_project" not in _commands(conn)  # still a pure preview
+
+
+async def test_scaffold_project_dry_run_runs_the_same_validation() -> None:
+    """An unknown scaffold type must fail a dry_run exactly like the real run."""
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "project_scaffold"})
+        with pytest.raises(ToolError, match="Unknown scaffold type"):
+            await client.call_tool(
+                "godot_project_scaffold",
+                {"type": "not_a_type", "dry_run": True},
+            )
 
 
 async def test_scaffold_project_safety_class() -> None:


### PR DESCRIPTION
### **User description**
## Summary

Fixes #426: `godot_project_scaffold` with `dry_run=true` returned `{created:false, paths_created:[], autoloads_registered:[]}` — a vacuous preview indistinguishable from a no-op, useless for the preview-before-broad-mutation flow a `destructive` tool exists to support.

### Fix

The dry-run now computes and returns the **actual plan** the real run executes, mirroring the addon handler's steps (`project_scaffold.gd`):

```
paths_created: [res://scenes/, res://scripts/, res://assets/, res://shaders/,
                res://project.godot, res://scripts/game_state.gd, res://scenes/<main>.tscn]
autoloads_registered: [GameState]
created: false (nothing happened) · dry_run: true
```

- Validation parity: the unknown-`type` rejection already runs before the dry-run branch — now pinned by a test (`test_scaffold_project_dry_run_runs_the_same_validation`), so a preview can't pass validation that the real run would fail.
- The plan is pure/deterministic (no bridge round-trip) — a preview must not have side effects or depend on addon availability.
- The real run's path is unchanged (`route` → addon).

### Acceptance criteria (#426)

- [x] `dry_run` returns the plan: directories it would create, the settings artifact (`res://project.godot`), the autoload script it would write, and the root scene
- [x] `dry_run` performs the same validation as the real run (unknown type fails the preview too)
- [x] Preview performs nothing (`cmd_scaffold_project` never sent) — asserted

### Test plan

- `test_scaffold_project_dry_run_returns_the_real_plan` (new, red first): full plan contents, `created:false`, no bridge command sent
- `test_scaffold_project_dry_run_runs_the_same_validation` (new): unknown type fails the preview like the real run
- Existing dry-run/gating/confirm tests unchanged and passing; full suite 733 pass; mypy/ruff/zero-skip clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- `dry_run` now returns actual scaffold plan

- Preview lists directories, settings, autoload, scene

- Unknown type validation applies to previews

- Hard-coded plan may drift from addon


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scaffold_project"] -- "dry_run" --> B["Build concrete plan"]
  B -- "created false" --> C["ScaffoldProjectResult"]
  A -- "real run" --> D["route to addon"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project_scaffold.py</strong><dd><code>Return concrete scaffold plan for dry runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/project_scaffold.py

<ul><li>Replaces <code>run_or_preview</code> with direct <code>route</code> for real runs.<br> <li> Normalizes <code>project_name</code> and <code>main_scene</code> defaults before routing.<br> <li> Builds dry-run plan with directories, <code>project.godot</code>, autoload script, <br>scene.<br> <li> Returns <code>ScaffoldProjectResult</code> with <code>created=false</code> and <code>dry_run=true</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/451/files#diff-8660d5903f7d4910de781db7dcd47a1af4328e5f64d438127e9a95f065d19d2e">+27/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_project_scaffold.py</strong><dd><code>Add dry-run plan and validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_project_scaffold.py

<ul><li>Adds test asserting dry-run returns full scaffold plan.<br> <li> Adds test that unknown type fails dry-run validation.<br> <li> Imports <code>ToolError</code> for expected tool error assertion.<br> <li> Keeps existing dry-run no-command assertion.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/451/files#diff-06dd859c8a3223526a255e9e1b987f69d570361263d9845a0a03d89183ef8af7">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

