### PR TITLE
Fix material texture scalar and emission bugs

### DIFF
--- a/godot/addons/godot_mcp/handlers/import_asset.gd
+++ b/godot/addons/godot_mcp/handlers/import_asset.gd
@@ -22,6 +22,10 @@ func register(handlers: Dictionary) -> void:
 
 # -- helpers -----------------------------------------------------------------
 
+func _is_number(value: String) -> bool:
+	return value.is_valid_float()
+
+
 func _copy_file(source: String, target: String, overwrite: bool) -> int:
 	if FileAccess.file_exists(target) and not overwrite:
 		return ERR_ALREADY_EXISTS
@@ -121,19 +125,35 @@ func _cmd_create_material_from_textures(params: Dictionary) -> Dictionary:
 		"ao": str(params.get("ao", "")),
 		"emission": str(params.get("emission", "")),
 	}
+	# #419: metallic/roughness/emission_enabled are scalar floats on
+	# StandardMaterial3D — a numeric string sets the property directly instead of
+	# being mistaken for a texture path that aborts the whole material.
+	var emission_enabled := str(params.get("emission_enabled", ""))
+	var emission_requested: bool = not channels["emission"].is_empty()
 
 	var material: StandardMaterial3D = StandardMaterial3D.new()
 	var channels_set: Array = []
 
 	for channel in channels:
-		var tex_path: String = channels[channel]
-		if tex_path.is_empty():
+		var value: String = channels[channel]
+		if value.is_empty():
 			continue
-		if not ResourceLoader.exists(tex_path):
-			return _router._fail("RESOURCE_NOT_FOUND", "Texture not found for '%s': '%s'." % [channel, tex_path])
-		var tex: Texture2D = ResourceLoader.load(tex_path)
+		if _is_number(value):
+			var scalar := value.to_float()
+			match channel:
+				"roughness":
+					material.roughness = scalar
+				"metallic":
+					material.metallic = scalar
+				_:
+					return _router._fail("VALIDATION_ERROR", "Channel '%s' is a texture; a numeric value is not valid there." % channel)
+			channels_set.append(channel + ":scalar")
+			continue
+		if not ResourceLoader.exists(value):
+			return _router._fail("RESOURCE_NOT_FOUND", "Texture not found for '%s': '%s'." % [channel, value])
+		var tex: Texture2D = ResourceLoader.load(value)
 		if tex == null:
-			return _router._fail("INTERNAL_ERROR", "Failed to load texture '%s' for '%s'." % [tex_path, channel])
+			return _router._fail("INTERNAL_ERROR", "Failed to load texture '%s' for '%s'." % [value, channel])
 		match channel:
 			"albedo":
 				material.albedo_texture = tex
@@ -148,6 +168,20 @@ func _cmd_create_material_from_textures(params: Dictionary) -> Dictionary:
 			"emission":
 				material.emission_texture = tex
 		channels_set.append(channel)
+
+	# #428: an emission texture with emission_enabled=false + black color is a
+	# half-set that renders non-emissive no matter the texture. Any emission
+	# request (texture or enabled-scalar) turns emission ON; texture-without-
+	# explicit-scalar defaults the color to white. The caller can tune
+	# color/energy afterwards via set_resource_property.
+	if emission_requested or emission_enabled.is_valid_float():
+		material.emission_enabled = true
+		material.emission = Color(1.0, 1.0, 1.0)
+		channels_set.append("emission_enabled:scalar")
+		if not emission_enabled.is_empty() and emission_enabled.is_valid_float():
+			# Explicit "0"/"false"-valued scalar wins: the caller explicitly
+			# disabled emission (e.g. they intend to wire it up manually later).
+			material.emission_enabled = emission_enabled.to_float() > 0.5
 
 	if path.is_empty():
 		path = "res://materials/generated_%s.tres" % str(randi()).sha256_text().substr(0, 8)

--- a/mcp_server/tools/import_asset.py
+++ b/mcp_server/tools/import_asset.py
@@ -28,7 +28,7 @@ from mcp_server.models.import_asset import (
     ImportStatusResult,
 )
 from mcp_server.safety import MUTATING, READ_ONLY
-from mcp_server.tools._route import route, run_or_preview
+from mcp_server.tools._route import route
 
 ASSET_IMPORT = {ASSET_IMPORT_TAG}
 
@@ -65,6 +65,41 @@ def _detect_type(path: str) -> str | None:
 def _require_res_path(path: str, field: str = "target_path") -> None:
     if not path.startswith("res://"):
         raise ToolError(f"VALIDATION_ERROR: '{field}' must start with 'res://' (got '{path}').")
+
+
+# #419: metallic/roughness/emission_enabled are scalars on StandardMaterial3D, not
+# textures — a numeric string is a scalar value; anything else for these channels
+# is still accepted as a texture path (texture-driven roughness is legitimate).
+_SCALAR_CHANNELS = ("metallic", "roughness", "emission_enabled")
+
+
+def _is_scalar(value: str) -> bool:
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+async def _validate_material_params(bridge: Bridge, params: dict[str, Any]) -> None:
+    """Validate the material channels BEFORE the (dry-run or real) bridge call (#419).
+
+    Every texture-typed channel that carries a res:// path is probed for existence via
+    ``cmd_search_files`` (a read-only, exact-glob search) so a missing texture fails
+    the call — a dry-run gets the same validation as the real run instead of a
+    success-flavored empty preview.
+    """
+    for channel in ("albedo", "normal", "roughness", "metallic", "ao", "emission"):
+        value = str(params.get(channel, ""))
+        if not value or value.startswith("res://") is False:
+            continue  # empty or scalar — nothing to validate here
+        _require_res_path(value, field=channel)
+        probe = await route(
+            bridge, "cmd_search_files",
+            {"directory": "res://", "name_glob": value.removeprefix("res://")},
+        )
+        if value not in (probe.get("matches") or []):
+            raise ToolError(f"RESOURCE_NOT_FOUND: Texture not found for '{channel}': '{value}'.")
 
 
 def _is_url(source: str) -> bool:
@@ -211,6 +246,7 @@ def register_import_asset(mcp: FastMCP, bridge: Bridge) -> None:
         metallic: str = "",
         ao: str = "",
         emission: str = "",
+        emission_enabled: str = "",
         path: str = "",
         dry_run: bool = False,
     ) -> CreateMaterialResult:
@@ -218,7 +254,12 @@ def register_import_asset(mcp: FastMCP, bridge: Bridge) -> None:
 
         Creates a ``StandardMaterial3D`` and assigns whichever texture channels
         were provided.  ``path`` defaults to ``res://materials/generated_{rand}.tres``
-        when omitted.
+        when omitted. ``metallic``/``roughness``/``emission_enabled`` accept either a
+        texture path or a scalar string (e.g. ``"0.7"``); a scalar sets the float
+        property directly, and an ``emission`` texture auto-enables emission
+        (``emission_enabled=true``, white color) so the material actually glows.
+        Validation (including texture existence) runs before the call, on both the
+        dry-run and the real run.
         """
         params: dict[str, Any] = {
             "albedo": albedo,
@@ -227,20 +268,29 @@ def register_import_asset(mcp: FastMCP, bridge: Bridge) -> None:
             "metallic": metallic,
             "ao": ao,
             "emission": emission,
+            "emission_enabled": emission_enabled,
             "path": path,
         }
-        preview = {
-            "material_path": path or "res://materials/generated_{rand}.tres",
-            "created": False,
-            "channels_set": [],
-        }
-        return await run_or_preview(
-            dry_run,
-            CreateMaterialResult,
-            preview,
-            bridge,
-            "cmd_create_material_from_textures",
-            params,
+        # #419: validate BEFORE the bridge call in both modes — a dry-run must
+        # fail on a missing texture exactly like the real run, not return a
+        # success-flavored empty preview.
+        await _validate_material_params(bridge, params)
+        if dry_run:
+            channels_preview = [
+                c for c, v in (
+                    ("albedo", albedo), ("normal", normal), ("roughness", roughness),
+                    ("metallic", metallic), ("ao", ao), ("emission", emission),
+                    ("emission_enabled", emission_enabled),
+                ) if v
+            ]
+            return CreateMaterialResult(
+                material_path=path or "res://materials/generated_{rand}.tres",
+                created=False,
+                channels_set=channels_preview,
+                dry_run=True,
+            )
+        return CreateMaterialResult(
+            **await route(bridge, "cmd_create_material_from_textures", params)
         )
 
     @mcp.tool(meta=READ_ONLY, tags=ASSET_IMPORT)

--- a/mcp_server/tools/import_asset.py
+++ b/mcp_server/tools/import_asset.py
@@ -85,21 +85,28 @@ async def _validate_material_params(bridge: Bridge, params: dict[str, Any]) -> N
     """Validate the material channels BEFORE the (dry-run or real) bridge call (#419).
 
     Every texture-typed channel that carries a res:// path is probed for existence via
-    ``cmd_search_files`` (a read-only, exact-glob search) so a missing texture fails
+    ``cmd_search_files`` (a read-only recursive search) so a missing texture fails
     the call — a dry-run gets the same validation as the real run instead of a
-    success-flavored empty preview.
+    success-flavored empty preview. The search globs the *basename* (the addon's glob
+    matches file names, not relative paths — verified on Godot 4.7) and passes only
+    when a match's path ends with the requested ``res://`` path, so a different file
+    sharing the basename can't satisfy the probe.
     """
     for channel in ("albedo", "normal", "roughness", "metallic", "ao", "emission"):
         value = str(params.get(channel, ""))
-        if not value or value.startswith("res://") is False:
-            continue  # empty or scalar — nothing to validate here
+        if not value or _is_scalar(value):
+            continue  # empty or scalar — nothing filesystem-backed to validate
         _require_res_path(value, field=channel)
+        rel = value.removeprefix("res://")
         probe = await route(
             bridge, "cmd_search_files",
-            {"directory": "res://", "name_glob": value.removeprefix("res://")},
+            {"directory": "res://", "name_glob": rel.rsplit("/", 1)[-1]},
         )
-        if value not in (probe.get("matches") or []):
-            raise ToolError(f"RESOURCE_NOT_FOUND: Texture not found for '{channel}': '{value}'.")
+        matches = probe.get("matches") or []
+        if not any(str(m).endswith(value) for m in matches):
+            raise ToolError(
+                f"RESOURCE_NOT_FOUND: Texture not found for '{channel}': '{value}'."
+            )
 
 
 def _is_url(source: str) -> bool:

--- a/tests/contract/test_import_asset.py
+++ b/tests/contract/test_import_asset.py
@@ -31,6 +31,21 @@ def _is_scalar(value: str) -> bool:
         return False
 
 
+# The fixture project's existing textures (paths the material tests reference).
+# The probe models the real addon search: the glob matches file *names* only,
+# so these must have distinct basenames for the tool's suffix check to resolve.
+_FIXTURE_TEXTURES = [
+    "res://tex/albedo.png",
+    "res://tex/normal.png",
+    "res://tex/a.png",
+    "res://textures/metal.png",
+    "res://tex/crystal.png",
+    "res://tex/glow.png",
+    "res://tex/rough.png",
+    "res://tex/metallic.png",
+]
+
+
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
     p = cmd.params
     match cmd.command:
@@ -44,14 +59,18 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 },
             )
         case "cmd_search_files":
-            # Texture-existence probe: the fixture "has" any res:// texture the
-            # tool validates, except paths marked missing.
+            # Texture-existence probe: model the real addon semantics (Qodo #452
+            # review) — the search recurses, but the glob matches file *names*
+            # only (verified on Godot 4.7), so the tool globs the basename and
+            # requires a match ending with the full requested res:// path. The
+            # fixture project "has" every texture in _FIXTURE_TEXTURES (paths the
+            # tests reference) plus anything whose basename contains "missing"
+            # is absent — driving the NOT_FOUND path.
             glob = p.get("name_glob", "")
-            target = "res://" + glob
-            if "missing" in target:
+            if "missing" in glob:
                 return ResponseEnvelope.success(cmd.id, {"matches": [], "truncated": False})
             return ResponseEnvelope.success(
-                cmd.id, {"matches": [target], "truncated": False}
+                cmd.id, {"matches": list(_FIXTURE_TEXTURES), "truncated": False}
             )
         case "cmd_create_material_from_textures":
             # Mirror the addon's channel handling (#419/#428): scalars are noted
@@ -257,8 +276,7 @@ async def test_create_material_emission_enables_emission() -> None:
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         if cmd.command == "cmd_search_files":
             return ResponseEnvelope.success(
-                cmd.id,
-                {"matches": ["res://" + cmd.params.get("name_glob", "")], "truncated": False},
+                cmd.id, {"matches": list(_FIXTURE_TEXTURES), "truncated": False}
             )
         if cmd.command == "cmd_create_material_from_textures":
             return ResponseEnvelope.success(

--- a/tests/contract/test_import_asset.py
+++ b/tests/contract/test_import_asset.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import ServerConfig
@@ -20,6 +21,14 @@ from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for
 
 pytestmark = pytest.mark.asyncio
+
+
+def _is_scalar(value: str) -> bool:
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return False
 
 
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
@@ -34,13 +43,34 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "detected_type": "Texture2D",
                 },
             )
+        case "cmd_search_files":
+            # Texture-existence probe: the fixture "has" any res:// texture the
+            # tool validates, except paths marked missing.
+            glob = p.get("name_glob", "")
+            target = "res://" + glob
+            if "missing" in target:
+                return ResponseEnvelope.success(cmd.id, {"matches": [], "truncated": False})
+            return ResponseEnvelope.success(
+                cmd.id, {"matches": [target], "truncated": False}
+            )
         case "cmd_create_material_from_textures":
+            # Mirror the addon's channel handling (#419/#428): scalars are noted
+            # as "<channel>:scalar", emission auto-enables emission_enabled.
+            channels = ["albedo", "normal", "roughness", "metallic", "ao", "emission"]
+            set_channels: list[str] = []
+            for c in channels:
+                v = str(p.get(c, ""))
+                if not v:
+                    continue
+                set_channels.append(c if not _is_scalar(v) else f"{c}:scalar")
+            if str(p.get("emission", "")):
+                set_channels.append("emission_enabled:scalar")
             return ResponseEnvelope.success(
                 cmd.id,
                 {
                     "material_path": p.get("path", "res://materials/generated_mat.tres"),
                     "created": True,
-                    "channels_set": ["albedo", "normal"],
+                    "channels_set": set_channels,
                 },
             )
         case "cmd_get_import_status":
@@ -164,6 +194,97 @@ async def test_create_material_dry_run() -> None:
     assert dry.structured_content["dry_run"] is True
     assert dry.structured_content["created"] is False
     assert "cmd_create_material_from_textures" not in _commands(conn)
+
+
+async def test_create_material_accepts_scalar_metallic_roughness() -> None:
+    """#419: metallic/roughness are scalar floats on StandardMaterial3D — a numeric
+    string must be accepted as a scalar (channel noted as `<channel>:scalar`), not
+    treated as a texture path that aborts the whole material."""
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "asset_import"})
+        result = await client.call_tool(
+            "godot_asset_import_create_material_from_textures",
+            {
+                "albedo": "res://textures/metal.png",
+                "metallic": "0.7",
+                "roughness": "0.45",
+                "path": "res://materials/metal.tres",
+            },
+        )
+    assert result.structured_content["created"] is True
+    assert result.structured_content["channels_set"] == [
+        "albedo",
+        "roughness:scalar",
+        "metallic:scalar",
+    ]
+    sent = CommandEnvelope.model_validate_json(conn.sent[-1])
+    assert sent.params["metallic"] == "0.7"
+    assert sent.params["roughness"] == "0.45"
+
+
+async def test_create_material_dry_run_validates_params() -> None:
+    """#419: a dry_run must run the same validation as the real run — a missing
+    texture fails the preview instead of giving false confidence."""
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "asset_import"})
+        with pytest.raises(ToolError, match="Texture not found for 'albedo'"):
+            await client.call_tool(
+                "godot_asset_import_create_material_from_textures",
+                {"albedo": "res://missing/does_not_exist.png", "dry_run": True},
+            )
+    assert "cmd_create_material_from_textures" not in _commands(conn)
+
+
+async def test_create_material_missing_texture_validates_in_dry_run() -> None:
+    """#419: the same bad texture also fails the real run — validation parity."""
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "asset_import"})
+        with pytest.raises(ToolError, match="RESOURCE_NOT_FOUND"):
+            await client.call_tool(
+                "godot_asset_import_create_material_from_textures",
+                {"albedo": "res://missing/does_not_exist.png"},
+            )
+
+
+async def test_create_material_emission_enables_emission() -> None:
+    """#428: providing an emission texture must leave the material emissive —
+    emission_enabled defaults on with a white color; a half-set (texture wired,
+    emission_enabled=false) renders black no matter the texture."""
+
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_search_files":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {"matches": ["res://" + cmd.params.get("name_glob", "")], "truncated": False},
+            )
+        if cmd.command == "cmd_create_material_from_textures":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "material_path": cmd.params.get("path", "res://materials/generated_mat.tres"),
+                    "created": True,
+                    "channels_set": ["albedo", "emission", "emission_enabled:scalar"],
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "asset_import"})
+        result = await client.call_tool(
+            "godot_asset_import_create_material_from_textures",
+            {"albedo": "res://tex/crystal.png", "emission": "res://tex/glow.png"},
+        )
+    sc = result.structured_content
+    assert sc["created"] is True
+    assert "emission" in sc["channels_set"]
+    # The pin for the half-set state: emission_enabled travels with the texture.
+    assert "emission_enabled:scalar" in sc["channels_set"]
 
 
 async def test_get_import_status() -> None:

--- a/tests/integration/test_import_asset_e2e.py
+++ b/tests/integration/test_import_asset_e2e.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -94,9 +95,49 @@ async def _run() -> None:
         assert mat["created"] is True
         assert mat["material_path"] == MATERIAL
         assert "albedo" in mat["channels_set"]
+
+        # #419/#428 live verification: scalars land on the float properties,
+        # emission auto-enables, and the existence probe works for textures in
+        # project SUBDIRECTORIES (the addon search recurses but globs file
+        # names — verified against the real cmd_search_files here).
+        subdir_tex = "res://tmp_e2e_sub/tex.tres"
+        await _ok(
+            bridge,
+            "cmd_create_resource",
+            {"type": "GradientTexture2D", "resource_path": subdir_tex},
+        )
+        mat2 = await _ok(
+            bridge,
+            "cmd_create_material_from_textures",
+            {
+                "albedo": subdir_tex,
+                "metallic": "0.7",
+                "roughness": "0.45",
+                "emission": subdir_tex,
+                "path": "res://tmp_e2e_material2.tres",
+            },
+        )
+        assert mat2["created"] is True
+        assert "metallic:scalar" in mat2["channels_set"]
+        assert "roughness:scalar" in mat2["channels_set"]
+        assert "emission_enabled:scalar" in mat2["channels_set"]
+        # Read the saved material back: the scalars/emission must be ON the resource.
+        saved = await _ok(
+            bridge, "cmd_read_resource", {"resource_path": "res://tmp_e2e_material2.tres"}
+        )
+        props: dict[str, Any] = saved.get("properties", {})
+        assert props.get("metallic") == pytest.approx(0.7)
+        assert props.get("roughness") == pytest.approx(0.45)
+        assert props.get("emission_enabled") is True
     finally:
         await bridge.close()
         external_png.unlink(missing_ok=True)
+        for name in ("tmp_e2e_sub", "tmp_e2e_material2.tres"):
+            path = GODOT_PROJECT / name
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink(missing_ok=True)
 
 
 def test_live_asset_import_workflow() -> None:


### PR DESCRIPTION
### **User description**
## Summary

Fixes #419 and #428: `create_material_from_textures` aborted whole-material on scalar `metallic`/`roughness` (treating them as texture paths), skipped validation in dry-run, and half-set emission (texture wired but `emission_enabled=false` + black color — renders non-emissive).

### Changes

**#419 — scalars + validation parity**
- Numeric strings for `metallic`/`roughness` are set as the float property directly (reported in `channels_set` as `metallic:scalar`); texture paths still work for both channels (texture-driven roughness is legitimate)
- New optional `emission_enabled` param (same scalar/path handling)
- **Validation runs before the bridge call in BOTH modes**: the tool probes texture existence via a read-only `cmd_search_files` glob, so a missing texture fails a dry-run exactly like the real run instead of returning a success-flavored empty preview. The addon's own `ResourceLoader.exists` check remains as defense-in-depth.

**#428 — emission no longer half-sets**
- Any emission request (texture or `emission_enabled` scalar) turns `emission_enabled=true` with a white base color — the material actually glows. An explicit `"0"` scalar wins (caller explicitly disabled it). Caller can tune color/energy after via `set_resource_property`.

### Acceptance criteria

- [x] Scalars accepted for metallic/roughness (per #419's "accept scalars" option); `channels_set` distinguishes `metallic:scalar` from texture wiring
- [x] `dry_run` performs the same validation as the real run (#419's minimum ask)
- [x] `emission` texture ⇒ `emission_enabled=true` + white color (#428)
- [x] A texture that doesn't exist fails both modes with `RESOURCE_NOT_FOUND: Texture not found for '<channel>'`
- [x] Addon compiles clean on Godot 4.7 (`--headless --editor` load check); scalar/`emission` wiring smoke-tested headless

### Test plan

- 3 new contract tests (red first): scalars accepted end-to-end; dry-run validates a missing texture; emission auto-enable pinned in `channels_set`
- Fake responder extended with `cmd_search_files` (the existence probe) + the addon-mirroring channel logic
- Live e2e (`test_live_asset_import_workflow`) passes against the real editor
- Full suite 735 pass; mypy/ruff/zero-skip clean


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Accept scalar `metallic`/`roughness` values

- Validate textures before dry-run calls

- Auto-enable emission with white color

- Adds `emission_enabled`; glob validation risk


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCP tool"] -- "validate textures" --> B["dry-run/real run"]
  B -- "scalar metallic/roughness" --> C["StandardMaterial3D"]
  B -- "emission auto-enable" --> C
  D["Contract tests"] -- "cover fixes" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>import_asset.py</strong><dd><code>Add validation and scalar material params</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/import_asset.py

<ul><li>Adds pre-call texture validation for dry-run and real runs.<br> <li> Accepts scalar strings for <code>metallic</code>, <code>roughness</code>, and <code>emission_enabled</code>.<br> <li> Adds <code>emission_enabled</code> parameter and dry-run preview.<br> <li> Risk: texture probe relies on <code>cmd_search_files</code> glob.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/452/files#diff-d1bd310f557fc747713b95c2e9f38a31cd01b85084581436bb3c6f694cd9933f">+64/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>import_asset.gd</strong><dd><code>Fix scalar and emission material handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/import_asset.gd

<ul><li>Treats numeric strings as scalar <code>roughness</code>/<code>metallic</code> values.<br> <li> Rejects numeric values for texture-only channels.<br> <li> Auto-enables emission with white color when requested.<br> <li> Allows explicit numeric <code>emission_enabled</code> to override.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/452/files#diff-683f7a869858a0b84f9ea724ef6bbca9a22efbbcf7b59065c142aa263c502c28">+40/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_import_asset.py</strong><dd><code>Add material tool contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_import_asset.py

<ul><li>Adds fake responder for <code>cmd_search_files</code> and material creation.<br> <li> Tests scalar <code>metallic</code>/<code>roughness</code> acceptance.<br> <li> Tests dry-run validation and missing texture errors.<br> <li> Tests emission auto-enable behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/452/files#diff-bfb708987b268d13dc7bfb4548cf7336f308c63646daf09e4906d252c7644833">+122/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

