### PR TITLE
Fix debugger session leak and add cap diagnostics

### DIFF
--- a/godot/addons/godot_mcp/handlers/runtime_session.gd
+++ b/godot/addons/godot_mcp/handlers/runtime_session.gd
@@ -76,12 +76,16 @@ func _cmd_get_game_scene_tree(_params: Dictionary) -> Dictionary:
 		return _router._fail("INTERNAL_ERROR", "Debugger plugin is unavailable.")
 	if not _router._debugger.is_connected_to_probe():
 		# Playing, but the probe hasn't announced itself — usually means the consuming
-		# project hasn't added the godot_mcp runtime probe autoload yet.
+		# project hasn't added the godot_mcp runtime probe autoload yet. #454: after
+		# several play/stop cycles the engine's debugger session caps (or its DAP/LSP
+		# client caps, which log "max client limits reached") can leave the new game
+		# silently unattached — name that so it's diagnosable from the addon.
 		return _router._ok({
 			"playing": true,
 			"connected": false,
 			"tree": null,
-			"hint": "Add the godot_mcp runtime probe (addons/godot_mcp/mcp_runtime_probe.gd) as an autoload in the game to enable live inspection.",
+			"hint": "Add the godot_mcp runtime probe (addons/godot_mcp/mcp_runtime_probe.gd) as an autoload in the game to enable live inspection. If the autoload IS registered and repeated play/stop cycles precede this, the engine may have exhausted its debugger session/client caps (editor log: \"max client limits reached\") — restart the editor to recover.",
+			"probe_never_connected": true,
 		})
 	var tree: Variant = _router._debugger.get_cached_scene_tree()
 	_router._debugger.request_scene_tree()  # refresh the cache for the next call

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -21,6 +21,10 @@ var _probe_ready: bool = false
 # session drops the previous session's signal wiring (no accumulating lambdas
 # across play/stop cycles) and a diagnostic names multiple live sessions.
 var _previous_session_id: int = -1
+# The specific callables THIS plugin connected on the current session (round-2
+# review: disconnect only ours — the editor's own debugger infrastructure also
+# listens on these signals, and a blanket disconnect breaks its tab bookkeeping).
+var _owned_connections: Array = []
 var _scene_tree: Variant = null  # last godot_mcp:scene_tree payload (Dictionary) or null
 var _input_acks: int = 0  # count of synthesized inputs the game has acknowledged (#36)
 var _property_samples: Variant = null  # last godot_mcp:property_samples payload (#35)
@@ -130,8 +134,15 @@ func _setup_session(session_id: int) -> void:
 	var session := get_session(session_id)
 	if session == null:
 		return
-	session.started.connect(func() -> void: _on_started(session_id))
+	var on_start := func() -> void: _on_started(session_id)
+	session.started.connect(on_start)
 	session.stopped.connect(_on_stopped)
+	# Track exactly what this plugin connected (round-2 review: the detach must
+	# only remove ours — the editor's own consumers share these signals).
+	_owned_connections = [
+		{"signal": session.started, "callable": on_start},
+		{"signal": session.stopped, "callable": _on_stopped},
+	]
 	# A session arriving while another is still live is the pre-condition for
 	# the engine's session cap — surface it instead of staying silent (#454).
 	var live: Array = []
@@ -153,15 +164,20 @@ func _on_started(session_id: int) -> void:
 
 ## Drop the previous session's signal wiring (#454). The engine keeps every
 ## debugger tab; without this, each play/stop cycle leaves one more connected
-## started/stopped lambda pair — invisible until a cap bites.
+## lambda pair — invisible until a cap bites. Only the plugin's OWN callables are
+## disconnected (tracked in _owned_connections): the editor's internal debugger
+## consumers also listen on these signals, and a blanket disconnect would break
+## their tab bookkeeping (Qodo #455 review).
 func _detach_previous_session(_new_session_id: int) -> void:
 	var previous := get_session(_previous_session_id)
 	if previous == null:
 		return
-	for conn in previous.started.get_connections():
-		previous.started.disconnect(conn["callable"])
-	for conn in previous.stopped.get_connections():
-		previous.stopped.disconnect(conn["callable"])
+	for owned in _owned_connections:
+		var signal_ref: Signal = owned["signal"]
+		var callable: Callable = owned["callable"]
+		if signal_ref.is_connected(callable):
+			signal_ref.disconnect(callable)
+	_owned_connections.clear()
 
 
 func _on_stopped() -> void:

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -14,6 +14,13 @@ const CAPTURE_PREFIX := "godot_mcp"
 var _session_id: int = -1
 var _session_active: bool = false
 var _probe_ready: bool = false
+# #454: the engine keeps every debugger tab ever created and caps *active*
+# sessions (4 — EditorDebuggerNode), printing "Max client limits reached" only
+# from its DAP/LSP servers when those caps hit. A session leak is otherwise
+# invisible, so the plugin enforces a one-active-session contract itself: a new
+# session drops the previous session's signal wiring (no accumulating lambdas
+# across play/stop cycles) and a diagnostic names multiple live sessions.
+var _previous_session_id: int = -1
 var _scene_tree: Variant = null  # last godot_mcp:scene_tree payload (Dictionary) or null
 var _input_acks: int = 0  # count of synthesized inputs the game has acknowledged (#36)
 var _property_samples: Variant = null  # last godot_mcp:property_samples payload (#35)
@@ -111,15 +118,50 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 
 
 func _setup_session(session_id: int) -> void:
+	# #454: one-active-session contract. When the editor hands us a new session,
+	# detach the previous session's signal wiring (each play/stop cycle otherwise
+	# leaves a connected lambda pair behind) and adopt the new one immediately —
+	# its ``started`` signal may never fire (orphaned-session recovery), so the
+	# new session is also reset+adopted right here, not just on _on_started.
+	if _session_id >= 0 and _session_id != session_id:
+		_previous_session_id = _session_id
+		_detach_previous_session(session_id)
 	_session_id = session_id
 	var session := get_session(session_id)
+	if session == null:
+		return
 	session.started.connect(func() -> void: _on_started(session_id))
 	session.stopped.connect(_on_stopped)
+	# A session arriving while another is still live is the pre-condition for
+	# the engine's session cap — surface it instead of staying silent (#454).
+	var live: Array = []
+	for s in get_sessions():
+		if s.is_active():
+			live.append(s.id)
+	if live.size() > 1:
+		print("[MCPDebugger] multiple live debugger sessions: %s — "
+			+ "engine caps concurrent sessions; if the new game connects but the probe never "
+			+ "announces, check the editor log for \"max client limits reached\" "
+			+ "(DAP/LSP client caps) and restart the editor if sessions are exhausted."
+			% str(live))
 
 
 func _on_started(session_id: int) -> void:
 	_session_active = true
 	_session_id = session_id
+
+
+## Drop the previous session's signal wiring (#454). The engine keeps every
+## debugger tab; without this, each play/stop cycle leaves one more connected
+## started/stopped lambda pair — invisible until a cap bites.
+func _detach_previous_session(_new_session_id: int) -> void:
+	var previous := get_session(_previous_session_id)
+	if previous == null:
+		return
+	for conn in previous.started.get_connections():
+		previous.started.disconnect(conn["callable"])
+	for conn in previous.stopped.get_connections():
+		previous.stopped.disconnect(conn["callable"])
 
 
 func _on_stopped() -> void:

--- a/godot/addons/godot_mcp/mcp_debugger.gd
+++ b/godot/addons/godot_mcp/mcp_debugger.gd
@@ -150,10 +150,10 @@ func _setup_session(session_id: int) -> void:
 		if s.is_active():
 			live.append(s.id)
 	if live.size() > 1:
-		print("[MCPDebugger] multiple live debugger sessions: %s — "
+		print(("[MCPDebugger] multiple live debugger sessions: %s — "
 			+ "engine caps concurrent sessions; if the new game connects but the probe never "
 			+ "announces, check the editor log for \"max client limits reached\" "
-			+ "(DAP/LSP client caps) and restart the editor if sessions are exhausted."
+			+ "(DAP/LSP client caps) and restart the editor if sessions are exhausted.")
 			% str(live))
 
 

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -360,6 +360,34 @@ def test_runtime_session_addon_files_present() -> None:
     assert "set_debugger" in entry
 
 
+def test_debugger_single_active_session_contract() -> None:
+    """#454: the engine caps concurrent debug sessions per editor (4 active —
+    EditorDebuggerNode) and prints "Max client limits reached" only from its DAP/LSP
+    servers, so a session leak is otherwise invisible. The plugin must enforce a
+    one-active-session contract itself: when a new session is set up, any prior
+    session's signal wiring is dropped, multiple live sessions are logged with
+    their ids, and a new session's arrival resets the probe state even if its
+    ``started`` signal never fires (orphaned-session recovery)."""
+    src = (ADDON_DIR / "mcp_debugger.gd").read_text()
+    setup = src.split("func _setup_session", 1)[1].split("\nfunc ", 1)[0]
+    # The setup must disconnect the previous session's signals (no accumulating lambdas
+    # over repeated play/stop cycles) and adopt the new session immediately.
+    assert "_detach_previous_session" in setup
+    detach = src.split("func _detach_previous_session", 1)[1].split("\nfunc ", 1)[0]
+    assert "disconnect" in detach  # drops the prior session's started/stopped wiring
+    # Diagnosability: when a new session arrives while another is still active, log it
+    # (the only signal short of the engine's own DAP/LSP "max client limits" line).
+    assert "push_warning" in src or "print" in src
+
+
+def test_runtime_handlers_surface_probe_connect_diagnostic() -> None:
+    """#454: when a play session is active but the probe never announces (engine
+    caps exhausted → silent debugger unresponsiveness), the runtime-session
+    handlers must say so with an actionable hint, not just ``connected: false``."""
+    source = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
+    assert "probe_never_connected" in source or "max client limits" in source.lower()
+
+
 def test_router_registers_scene_session_commands() -> None:
     source = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
     for command in (

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -166,13 +166,23 @@ def test_script_write_kicks_a_deferred_filesystem_rescan() -> None:
     ``class_name`` globals are indexed before the agent's next get_parse_errors —
     otherwise the parser reports transient "Could not find type" errors for
     correct code and the agent 'fixes' phantom errors."""
-    plugin = (ADDON_DIR / "godot_mcp.gd").read_text()
-    assert "command_completed" in plugin
+    plugin = (ADDON_DIR / "mcp_debugger.gd").read_text()
+    assert "command_completed" not in plugin
     # Isolate each handler body by its signature — splitting on the bare name can
-    # straddle two occurrences (Qodo #449 review).
-    hook = plugin.split("func _on_command_completed", 1)[1].split("\nfunc ", 1)[0]
-    assert "_rescan_after_script_write.call_deferred()" in hook
-    rescan = plugin.split("func _rescan_after_script_write", 1)[1].split("\nfunc ", 1)[0]
+    # straddle two occurrences (Qodo #449 review). The write-completion hook lives
+    # in the plugin entry (godot_mcp.gd); the debugger owns session lifecycle.
+    hook = plugin.split("func _setup_session", 1)[1].split("\nfunc ", 1)[0]
+    assert "_detach_previous_session" in hook
+    detach = plugin.split("func _detach_previous_session", 1)[1].split("\nfunc ", 1)[0]
+    # Must disconnect ONLY the plugin's own tracked callables — a blanket disconnect
+    # would break the editor's own debugger tab bookkeeping (Qodo #455 review).
+    assert "_owned_connections" in detach
+    assert "disconnect" in detach
+    # The setup must track what it connects.
+    assert "_owned_connections = [" in hook
+    rescan = (ADDON_DIR / "godot_mcp.gd").read_text().split(
+        "func _rescan_after_script_write", 1
+    )[1].split("\nfunc ", 1)[0]
     assert "scan()" in rescan
     assert "get_resource_filesystem" in rescan
 
@@ -374,7 +384,13 @@ def test_debugger_single_active_session_contract() -> None:
     # over repeated play/stop cycles) and adopt the new session immediately.
     assert "_detach_previous_session" in setup
     detach = src.split("func _detach_previous_session", 1)[1].split("\nfunc ", 1)[0]
-    assert "disconnect" in detach  # drops the prior session's started/stopped wiring
+    # Round-2 review: disconnect ONLY the plugin's own tracked callables — a blanket
+    # disconnect would break the editor's own debugger tab bookkeeping.
+    assert "_owned_connections" in detach
+    assert "disconnect" in detach
+    assert "_owned_connections.clear" in detach
+    # The setup must track exactly what it connects.
+    assert "_owned_connections = [" in setup
     # Diagnosability: when a new session arrives while another is still active, log it
     # (the only signal short of the engine's own DAP/LSP "max client limits" line).
     assert "push_warning" in src or "print" in src

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -166,23 +166,13 @@ def test_script_write_kicks_a_deferred_filesystem_rescan() -> None:
     ``class_name`` globals are indexed before the agent's next get_parse_errors —
     otherwise the parser reports transient "Could not find type" errors for
     correct code and the agent 'fixes' phantom errors."""
-    plugin = (ADDON_DIR / "mcp_debugger.gd").read_text()
-    assert "command_completed" not in plugin
-    # Isolate each handler body by its signature — splitting on the bare name can
-    # straddle two occurrences (Qodo #449 review). The write-completion hook lives
-    # in the plugin entry (godot_mcp.gd); the debugger owns session lifecycle.
-    hook = plugin.split("func _setup_session", 1)[1].split("\nfunc ", 1)[0]
-    assert "_detach_previous_session" in hook
-    detach = plugin.split("func _detach_previous_session", 1)[1].split("\nfunc ", 1)[0]
-    # Must disconnect ONLY the plugin's own tracked callables — a blanket disconnect
-    # would break the editor's own debugger tab bookkeeping (Qodo #455 review).
-    assert "_owned_connections" in detach
-    assert "disconnect" in detach
-    # The setup must track what it connects.
-    assert "_owned_connections = [" in hook
-    rescan = (ADDON_DIR / "godot_mcp.gd").read_text().split(
-        "func _rescan_after_script_write", 1
-    )[1].split("\nfunc ", 1)[0]
+    entry = (ADDON_DIR / "godot_mcp.gd").read_text()
+    assert "command_completed" in entry
+    # Isolate the handler body by its signature — splitting on the bare name can
+    # straddle two occurrences (Qodo #449 review).
+    hook = entry.split("func _on_command_completed", 1)[1].split("\nfunc ", 1)[0]
+    assert "_rescan_after_script_write.call_deferred()" in hook
+    rescan = entry.split("func _rescan_after_script_write", 1)[1].split("\nfunc ", 1)[0]
     assert "scan()" in rescan
     assert "get_resource_filesystem" in rescan
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes #454: play/stop cycles with the runtime probe eventually degrade debugger interaction for new runs, with the only signal being Godot's own "max client limits reached" log line.

### Root cause (verified against Godot 4.7 engine source)

- The editor keeps **every debugger tab ever created** and reuses only *inactive* ones (`editor_debugger_node.cpp:402-417`); it caps **4 concurrently active** sessions and silently disconnects further game connections.
- The exact phrase "Max client limits reached" exists in exactly two places: the DAP server (port 6006, `DAP_MAX_CLIENTS=8`) and the GDScript LSP (port 6005, `LSP_MAX_CLIENTS=8`) — editor-side TCP servers whose stale clients only get cleaned on socket error. When those caps hit, the new game still starts but the debugger plumbing around it is degraded, and our plugin is silent.
- `EditorDebuggerSession` exposes **no detach API** to GDScript — a plugin cannot drop another session's connection.

### What the addon fixes

- **Single-active-session contract** (`mcp_debugger.gd`): `_setup_session` now adopts the new session immediately and, when a prior session exists, **detaches its `started`/`stopped` signal wiring** (`_detach_previous_session`) — repeated play/stop cycles no longer accumulate a lambda pair per cycle.
- **Diagnosability**: when a new session arrives while another is still live, the plugin logs the live session ids with an actionable message naming the engine's session/client caps and the "max client limits reached" log line — the failure becomes visible from the addon, not only Godot's output.
- **Runtime handlers surface the diagnostic**: `get_game_scene_tree`'s not-connected hint now includes the cap-exhaustion recovery path (restart the editor) when the autoload *is* registered but the probe never announced (`probe_never_connected: true` for programmatic consumers).

### Deliberate scope

- No dock affordance in this PR (manual session stop/restart) — the engine-side caps that actually print this message are DAP/LSP, whose clients are IDE-facing; the one-session contract prevents our own accumulation and the diagnostic points at the log. Follow-up if live usage still shows transients.

### Acceptance criteria (#454)

- [x] New session drops the previous session's signal wiring (no accumulation across play/stop cycles)
- [x] Multiple live sessions are logged with ids + recovery guidance (add-on-side signal, not just Godot's output)
- [x] Not-connected hint names the cap condition and recovery (`probe_never_connected` field for agents)
- [x] Addon compiles clean on Godot 4.7 (`--headless --editor` load check)

### Test plan

- `test_debugger_single_active_session_contract` (new, red first): pins the detach wiring + diagnostic
- `test_runtime_handlers_surface_probe_connect_diagnostic` (new): the actionable hint ships
- Full suite 742 pass; mypy/ruff/zero-skip clean
- Manual: repeat play/stop cycles → single live session, diagnostic when >1


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevents debugger signal accumulation across play/stop cycles.

- Enforces one active session and logs live sessions.

- Adds `probe_never_connected` diagnostic to scene tree response.

- Risk: disconnects all prior session signal listeners.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Play/stop cycles"] --> B["mcp_debugger.gd"]
  B --> C["Detaches previous session signals"]
  B --> D["Logs multiple live sessions"]
  E["runtime_session.gd"] --> F["Adds probe_never_connected diagnostic"]
  G["Tests"] --> H["Validates session hygiene"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_addon_manifest.py</strong><dd><code>Adds debugger session hygiene contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_addon_manifest.py

<ul><li>Adds test for previous-session signal detachment.<br> <li> Adds test for <code>probe_never_connected</code> diagnostic.<br> <li> Validates single-active-session contract in source.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/455/files#diff-7b97e94c7bcb49783c2153046c691734b56f1f1b47497ab3d9e41aa815e6e135">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime_session.gd</strong><dd><code>Adds probe connection diagnostic to scene tree</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/runtime_session.gd

<ul><li>Expands not-connected hint with cap recovery guidance.<br> <li> Adds <code>probe_never_connected</code> field to response payload.<br> <li> Makes silent probe failure more diagnosable.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/455/files#diff-97d2675a84c1fba2465f143dd6ba64ae45158da6434f45afaf458af983c0e947">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp_debugger.gd</strong><dd><code>Enforces single active debugger session contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/mcp_debugger.gd

<ul><li>Tracks previous session id and detaches its signals.<br> <li> Adopts new session immediately for orphan recovery.<br> <li> Logs multiple live sessions when detected.<br> <li> Prevents accumulating signal callback connections.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/455/files#diff-c16d1a89bdde3198440746408f5db9412459963442fcca62abedf274114ed7c6">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

