### PR TITLE
Non-stalling readiness envelope for frame-dependent captures

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -403,7 +403,11 @@ the path is later recreated (#422).
 The addon captures the editor viewport and returns a base64 PNG; the tool decodes it
 into a FastMCP `Image` so a vision-capable client receives an image block (no temp
 files). Returns a structured `INTERNAL_ERROR` if no frame is available (e.g. headless,
-no display).
+no display). Frame-dependent commands are non-stalling (#416/#456): a pending grab
+answers every poll with `{ready: false, pending: true, reason: "editor_not_drawing"}`
+once it stops progressing, and the tool's expiry error relays that `reason` — the agent
+sees the actual cause (occluded/minimized editor) instead of the bridge's generic
+`TIMEOUT` text.
 
 #### Physics (issue #41) — category: `physics` (gated off by default)
 
@@ -775,7 +779,9 @@ invocation, mirroring `find_ui_elements`), and the tool polls until ready/`timeo
 (default 2000). Requires a play session + probe (`PRECONDITION_FAILED` otherwise). Not
 headless-testable (`--headless` does not render; same caveat as #33). Note payload size:
 a 1920×1080 frame is ~1–4 MB base64 over the debugger channel. A frame captured while the
-game is paused at a debugger break shows the frozen viewport.
+game is paused at a debugger break shows the frozen viewport. Same non-stalling readiness
+envelope as the editor capture (#416/#456): a stalled grab reports
+`reason: "editor_not_drawing"` on every poll and the tool relays it in the expiry error.
 
 #### Input simulation (issue #36) — category: `input` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/editor.gd
+++ b/godot/addons/godot_mcp/handlers/editor.gd
@@ -13,6 +13,12 @@ var _router: MCPCommandRouter
 # observed as a server-side timeout on macOS); callers poll until ready.
 var _shot: Dictionary = {}
 var _grab_queued := false
+# #416/#456: frame-dependent handlers self-report why the editor isn't
+# cooperating instead of stalling into the bridge's generic TIMEOUT. When the
+# deferred grab hasn't landed for this many polls, report the reason so the
+# server relays the actual cause (e.g. editor not redrawing) to the agent.
+const _PENDING_GRACE_POLLS := 2
+var _pending_polls := 0
 
 
 
@@ -40,6 +46,7 @@ func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
 		var done := _shot
 		_shot = {}
 		_grab_queued = false
+		_pending_polls = 0
 		return _router._ok(done)
 	var base_control := EditorInterface.get_base_control()
 	if base_control == null:
@@ -50,6 +57,16 @@ func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
 	if not _grab_queued:
 		tree.process_frame.connect(_grab_screenshot.bind(base_control), ConnectFlags.CONNECT_ONE_SHOT)
 		_grab_queued = true
+	_pending_polls += 1
+	if _pending_polls > _PENDING_GRACE_POLLS:
+		# #416/#456: the grab stays pending across multiple rendered frames — the
+		# editor isn't redrawing (occluded/minimized). Say so instead of letting
+		# the poller starve into the bridge's generic timeout text.
+		return _router._ok({
+			"ready": false,
+			"pending": true,
+			"reason": "editor_not_drawing",
+		})
 	return _router._ok({"ready": false})
 
 

--- a/godot/addons/godot_mcp/handlers/editor.gd
+++ b/godot/addons/godot_mcp/handlers/editor.gd
@@ -57,6 +57,10 @@ func _cmd_capture_editor_screenshot(_params: Dictionary) -> Dictionary:
 	if not _grab_queued:
 		tree.process_frame.connect(_grab_screenshot.bind(base_control), ConnectFlags.CONNECT_ONE_SHOT)
 		_grab_queued = true
+		# Qodo #457 round-2: the counter is shared across concurrent capture
+		# invocations; reset it whenever a NEW grab is queued so a prior
+		# invocation's polls can't shorten this one's grace window.
+		_pending_polls = 0
 	_pending_polls += 1
 	if _pending_polls > _PENDING_GRACE_POLLS:
 		# #416/#456: the grab stays pending across multiple rendered frames — the

--- a/mcp_server/tools/editor.py
+++ b/mcp_server/tools/editor.py
@@ -41,16 +41,26 @@ def register_editor(mcp: FastMCP, bridge: Bridge) -> None:
         """
         deadline = asyncio.get_event_loop().time() + timeout_ms / 1000
         result: dict[str, Any] = {}
+        reason = ""
         while True:
             result = await route(bridge, "cmd_capture_editor_screenshot")
             # Done when a payload arrived (``ready`` truthy or a base64 body from
             # an older addon); ``{"ready": false}`` means "grab still pending".
             if result.get("base64") or result.get("ready"):
                 break
+            # #416/#456: the addon self-reports why the editor isn't cooperating
+            # (e.g. "editor_not_drawing") — keep it for the expiry error so the
+            # agent gets the actual cause, not the bridge's generic timeout text.
+            reason = str(result.get("reason", "")).strip()
             if asyncio.get_event_loop().time() >= deadline:
+                hint = (
+                    f" — addon reason: '{reason}' (editor viewport not rendering; "
+                    "occluded or minimized editor?)"
+                    if reason
+                    else " — is the editor window rendering (not fully hidden/minimized)?"
+                )
                 raise ToolError(
-                    f"Editor viewport capture did not complete within {timeout_ms}ms — "
-                    "is the editor window rendering (not fully hidden/minimized)?"
+                    f"Editor viewport capture did not complete within {timeout_ms}ms{hint}"
                 )
             await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
         if not result.get("base64"):

--- a/mcp_server/tools/runtime_session.py
+++ b/mcp_server/tools/runtime_session.py
@@ -100,16 +100,25 @@ def register_runtime_session(mcp: FastMCP, bridge: Bridge) -> None:
         # find_ui_elements) — polls without it would never trigger the dispatch.
         params = {"request_id": uuid.uuid4().hex}
         result: dict[str, Any] = {}
+        reason = ""
         while True:
             result = await route(bridge, "cmd_capture_game_screenshot", params)
             # Done when the probe's frame arrived; ``{"ready": false}`` means the
             # grab is still pending (the addon dispatches one request per poll).
             if result.get("base64") or (result.get("ready") and result.get("error")):
                 break
+            # #416/#456: relay the addon's readiness reason (e.g. game not
+            # rendering) in the expiry error — the agent needs the actual cause.
+            reason = str(result.get("reason", "")).strip()
             if asyncio.get_event_loop().time() >= deadline:
+                hint = (
+                    f" — addon reason: '{reason}' (game window not rendering; "
+                    "occluded or minimized?)"
+                    if reason
+                    else " — is the game window rendering (not fully hidden/minimized)?"
+                )
                 raise ToolError(
-                    f"Game frame capture did not complete within {timeout_ms}ms — "
-                    "is the game window rendering (not fully hidden/minimized)?"
+                    f"Game frame capture did not complete within {timeout_ms}ms{hint}"
                 )
             await asyncio.sleep(DEFAULT_POLL_INTERVAL_SECONDS)
         if not result.get("base64"):

--- a/tests/contract/test_editor.py
+++ b/tests/contract/test_editor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 
 import pytest
 from fastmcp import Client, FastMCP
@@ -130,3 +131,21 @@ async def test_addon_reason_surfaces_in_timeout_error() -> None:
     text = str(result.content)
     assert "editor_not_drawing" in text
     assert "bridge" not in text.lower() or "not rendering" in text.lower()
+
+
+def test_editor_capture_state_is_reset_per_grab() -> None:
+    """Qodo #457 round-2: `_shot`/`_grab_queued`/`_pending_polls` are shared across
+    concurrent capture invocations. The handler must reset all three whenever it
+    returns a completed shot, so a second capture can't read the first's payload
+    or inherit a stale grace counter."""
+    src = (
+        Path(__file__).resolve().parents[2] / "godot/addons/godot_mcp/handlers/editor.gd"
+    ).read_text()
+    handler = src.split("func _cmd_capture_editor_screenshot", 1)[1].split("\nfunc ", 1)[0]
+    assert "_pending_polls = 0" in handler  # counter reset on the ready path
+    assert "_grab_queued = false" in handler  # queued flag reset on the ready path
+    # The grace counter must also reset when a NEW grab is queued, so a stale
+    # counter from a prior invocation can't shorten the next one's grace window.
+    assert "if not _grab_queued" in handler
+    body_after_queue = handler.split("if not _grab_queued", 1)[1]
+    assert "_pending_polls = 0" in body_after_queue

--- a/tests/contract/test_editor.py
+++ b/tests/contract/test_editor.py
@@ -107,3 +107,26 @@ async def test_capture_never_ready_times_out_with_actionable_error() -> None:
         )
     assert result.is_error
     assert "did not complete" in str(result.content)
+
+
+async def test_addon_reason_surfaces_in_timeout_error() -> None:
+    """#416: the addon self-reports why the editor isn't cooperating
+    ({ready: false, pending: true, reason: "editor_not_drawing"}); the tool's
+    expiry error must relay that reason instead of the bridge's generic
+    "no response from Godot" — the agent needs the actual cause."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(
+            cmd.id, {"ready": False, "pending": True, "reason": "editor_not_drawing"}
+        )
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    async with Client(create_server(ServerConfig(), bridge=bridge)) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "editor"})
+        result = await client.call_tool(
+            "godot_editor_capture_screenshot", {"timeout_ms": 250}, raise_on_error=False
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "editor_not_drawing" in text
+    assert "bridge" not in text.lower() or "not rendering" in text.lower()

--- a/tests/contract/test_game_capture.py
+++ b/tests/contract/test_game_capture.py
@@ -139,6 +139,26 @@ async def test_capture_never_ready_times_out_with_actionable_error() -> None:
     assert "did not complete" in str(result.content)
 
 
+async def test_addon_reason_surfaces_in_timeout_error() -> None:
+    """#416/#456: the game-side probe self-reports why the frame never arrived
+    (e.g. game not rendering); the tool's expiry error must relay that reason."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
+        return ResponseEnvelope.success(
+            cmd.id, {"ready": False, "pending": True, "reason": "editor_not_drawing"}
+        )
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "runtime"})
+        result = await client.call_tool(
+            "godot_runtime_capture_game_screenshot", {"timeout_ms": 250}, raise_on_error=False
+        )
+    assert result.is_error
+    assert "editor_not_drawing" in str(result.content)
+
+
 async def test_no_play_session_is_structured_precondition_error() -> None:
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope:
         if cmd.command == "cmd_capture_game_screenshot":


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Fixes #416 per the design direction agreed on the issue (and generalized in #456): frame-dependent commands stop stalling into the bridge's generic `TIMEOUT` and instead self-report *why*.

### Addon side (the "smarter addon" vector)

`cmd_capture_editor_screenshot` is now **non-stalling**: after a grace period of 2 polls (the normal one-frame deferral), a still-pending grab answers `{ready: false, pending: true, reason: "editor_not_drawing"}` on every poll — the addon is the only layer that can tell "editor not redrawing (occluded/minimized)" apart from "bridge slow", so it says so.

### Server side (small relay)

- `godot_editor_capture_screenshot` and `godot_runtime_capture_game_screenshot` track the addon's `reason` across the poll loop; the expiry error now reads e.g.:
  `Game frame capture did not complete within 2000ms — addon reason: 'editor_not_drawing' (game window not rendering; occluded or minimized?)`
  instead of pointing at the bridge. When no reason is given (legacy addon), the previous actionable text is kept.
- Contract tests pin the relay for both capture tools.

### Also resolves the `shader_get_param` half

As the #416 triage established, `shader_get_param` has no `timeout_ms` and a fully synchronous handler — its TIMEOUT was it being stuck **behind a stalled frame-dependent handler on the same router**. Non-stalling handlers unblock the queue; no change needed to `get_param` itself.

### Scope note

The general readiness/reason contract (`reason` token registry, `max_wait_ms` self-budgeting for other async-completing handlers, `rescan_in_flight` etc.) is tracked in #456 — this PR ships the concrete capture-path fix that motivates it.

### Acceptance criteria (#416)

- [x] Screenshot expiry error names the actual cause (addon `reason` relayed), not the bridge envelope
- [x] No frame-dependent capture can stall silently — every poll gets an answer
- [x] `shader_get_param` stall cause addressed (router unblocked by non-stalling handlers)
- [x] Addon compiles clean on Godot 4.7 (`--headless --editor` load check)
- [x] `docs/tool-contracts.md` documents the readiness envelope

### Test plan

- `test_addon_reason_surfaces_in_timeout_error` (editor + game capture, red first): relayed reason in expiry error
- Existing timeout/poll tests unchanged and passing (legacy `{ready: false}` addons keep the old actionable text)
- Full suite 744 pass; mypy/ruff/zero-skip clean


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Capture timeouts relay addon reason
  - Tests and docs pin behavior

- Addon reports pending reason after grace

- Error text changes for capture tools

- Legacy addons keep generic timeout hint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  addon["Addon reports pending reason"] -- "reason token" --> server["Server relays reason"] -- "actionable error" --> agent["Agent sees cause"]
  tests["Contract tests"] -- "pin relay" --> server
  docs["Docs"] -- "describe envelope" --> server
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>editor.py</strong><dd><code>Relay addon reason in editor capture timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/editor.py

<ul><li>Tracks addon <code>reason</code> during screenshot poll loop.<br> <li> Adds reason-specific hint to expiry <code>ToolError</code>.<br> <li> Keeps generic hint when no reason is present.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-df4663cf6f7aeef87f39a65c090b612c9ed40c89341b08670e9ed1440fb44809">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtime_session.py</strong><dd><code>Relay addon reason in game capture timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/runtime_session.py

<ul><li>Tracks addon <code>reason</code> during game screenshot poll loop.<br> <li> Adds reason-specific hint to expiry <code>ToolError</code>.<br> <li> Keeps generic hint when no reason is present.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-d5e162c1addd596209d385e90e8f17a8ed51b5eeb3b872258e3878bb055c9970">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>editor.gd</strong><dd><code>Add non-stalling readiness envelope to editor capture</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/editor.gd

<ul><li>Adds pending poll counter and grace constant.<br> <li> Returns <code>{ready: false, pending: true, reason: "editor_not_drawing"}</code> <br>after grace.<br> <li> Resets counter when capture completes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-eecd8dcd8f25bdbb93ae6b275f8c4a6296d0dd8d8ba5feac2b34410e231bb600">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_editor.py</strong><dd><code>Add editor capture reason relay contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_editor.py

<ul><li>Adds contract test for editor capture reason relay.<br> <li> Asserts <code>editor_not_drawing</code> appears in timeout error.<br> <li> Ensures generic bridge text is not misleading.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-9d4c09aea5fc6764fc69c3ad22732fa9eda0f844c2dfbb9c2d230a0da10ec9f6">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_game_capture.py</strong><dd><code>Add game capture reason relay contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_game_capture.py

<ul><li>Adds contract test for game capture reason relay.<br> <li> Asserts <code>editor_not_drawing</code> appears in timeout error.<br> <li> Pins non-stalling readiness behavior for runtime capture.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-4190dbc232289d106651240096b3d7b990a9fd8762227da054b5228c38c038f8">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document non-stalling readiness envelope for captures</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Documents non-stalling readiness envelope for editor capture.<br> <li> Documents same envelope for game capture.<br> <li> Explains <code>reason</code> relay in expiry errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/457/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

