### PR TITLE
Add persistence truth and shader read-backs

### DIFF
--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -406,6 +406,32 @@ func _require_live_probe() -> Dictionary:
 
 # -- instantiation helpers (shared by domain handlers) ------------------------
 
+## Persistence truth for node-targeted mutations (#458). A node inside a
+## non-editable instance renders live but Godot never saves overrides on it —
+## the mutation IS applied, the saved scene just won't carry it. Returns
+## {ok: true} when the target persists to the edited scene, else
+## {ok: false, persisted: false, reason, hint} so the handler can report the
+## truth instead of a success tone (#415). Godot API note: `scene_file_path`
+## is non-empty only on instance roots; a child of an instanced scene has
+## owner == the instance root, not the edited scene root.
+func _persistent_target(node: Node) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null:
+		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
+	if node == root or node.get_owner() == root:
+		return {"ok": true}
+	# Node belongs to an instanced scene (its owner is that instance's root).
+	var instanced_root := node.get_owner()
+	var instanced_path := instanced_root.scene_file_path if instanced_root != null else ""
+	return {
+		"ok": false,
+		"persisted": false,
+		"reason": "instanced_child_not_editable",
+		"hint": "Node '%s' lives inside an instanced scene (%s). The change renders live "
+			+ "but Godot will not save it — enable Editable Children on the instance, "
+			+ "or target a scene-owned node." % [node.name, instanced_path],
+	}
+
 ## Instantiate a class via ClassDB, validating it inherits from expected_base.
 ## Returns {ok: true, obj: Object} on success, or a VALIDATION_ERROR envelope;
 ## a type mismatch frees a non-RefCounted instance before failing (RefCounted

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -406,31 +406,37 @@ func _require_live_probe() -> Dictionary:
 
 # -- instantiation helpers (shared by domain handlers) ------------------------
 
-## Persistence truth for node-targeted mutations (#458). A node inside a
-## non-editable instance renders live but Godot never saves overrides on it —
-## the mutation IS applied, the saved scene just won't carry it. Returns
-## {ok: true} when the target persists to the edited scene, else
-## {ok: false, persisted: false, reason, hint} so the handler can report the
-## truth instead of a success tone (#415). Godot API note: `scene_file_path`
-## is non-empty only on instance roots; a child of an instanced scene has
-## owner == the instance root, not the edited scene root.
+## Persistence truth for node-targeted mutations (#458). Godot saves a node in the
+## edited scene if (a) its owner IS the edited scene root, or (b) it sits inside an
+## **editable instance** — every instance root on the path up to the edited root has
+## `editable_instance` set (`packed_scene.cpp:806-812` saves those children as
+## editable-instance overrides). Otherwise the change renders live but never saves.
+## Returns {ok: true} when the target persists, else
+## {ok: false, persisted: false, reason: "instanced_child_not_editable", hint}.
 func _persistent_target(node: Node) -> Dictionary:
 	var root := EditorInterface.get_edited_scene_root()
 	if root == null:
 		return _fail("PRECONDITION_FAILED", "No scene is open.", "active_scene")
-	if node == root or node.get_owner() == root:
+	if node == root:
 		return {"ok": true}
-	# Node belongs to an instanced scene (its owner is that instance's root).
-	var instanced_root := node.get_owner()
-	var instanced_path := instanced_root.scene_file_path if instanced_root != null else ""
-	return {
-		"ok": false,
-		"persisted": false,
-		"reason": "instanced_child_not_editable",
-		"hint": "Node '%s' lives inside an instanced scene (%s). The change renders live "
-			+ "but Godot will not save it — enable Editable Children on the instance, "
-			+ "or target a scene-owned node." % [node.name, instanced_path],
-	}
+	# Walk the owner chain from the node up to the edited scene root; the node
+	# persists iff every instance-root hop in between is flagged editable.
+	var iterated: Node = node
+	while iterated.get_owner() != null and iterated.get_owner() != root:
+		var instance_root: Node = iterated.get_owner()
+		if not root.is_editable_instance(instance_root):
+			var instanced_path := instance_root.scene_file_path if instance_root != null else ""
+			return {
+				"ok": false,
+				"persisted": false,
+				"reason": "instanced_child_not_editable",
+				"hint": "Node '%s' lives inside an instanced scene (%s) without "
+					+ "Editable Children. The change renders live but Godot will not "
+					+ "save it — enable Editable Children on the instance, or target "
+					+ "a scene-owned node." % [node.name, instanced_path],
+			}
+		iterated = instance_root
+	return {"ok": true}
 
 ## Instantiate a class via ClassDB, validating it inherits from expected_base.
 ## Returns {ok: true, obj: Object} on success, or a VALIDATION_ERROR envelope;

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -22,6 +22,7 @@ func register(handlers: Dictionary) -> void:
 	handlers["cmd_get_selected_node"] = _cmd_get_selected_node
 	handlers["cmd_get_node_properties"] = _cmd_get_node_properties
 	handlers["cmd_node_exists"] = _cmd_node_exists
+	handlers["cmd_node_persistence"] = _cmd_node_persistence
 	handlers["cmd_get_node_property"] = _cmd_get_node_property
 	handlers["cmd_get_node_property_list"] = _cmd_get_node_property_list
 	handlers["cmd_get_node_groups"] = _cmd_get_node_groups
@@ -127,6 +128,27 @@ func _cmd_node_exists(params: Dictionary) -> Dictionary:
 	if node == null:
 		return _router._fail("RESOURCE_NOT_FOUND", "No node at '%s'." % str(params["node_path"]))
 	return _router._ok({"exists": true})
+
+
+
+func _cmd_node_persistence(params: Dictionary) -> Dictionary:
+	# #458 dry-run probe: persistence truth for a target, no mutation. Lets a
+	# dry_run preview carry the same persisted/reason fields as the real run.
+	if not params.has("node_path"):
+		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	var found := _router._resolve(params["node_path"])
+	if not found["ok"]:
+		return found
+	var node: Node = found["node"]
+	var truth := _router._persistent_target(node)
+	var body := {
+		"node_path": str(params["node_path"]),
+		"persisted": truth["ok"],
+	}
+	if not truth["ok"]:
+		body["reason"] = truth["reason"]
+		body["hint"] = truth["hint"]
+	return _router._ok(body)
 
 
 func _cmd_get_node_property(params: Dictionary) -> Dictionary:

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -140,22 +140,27 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	ur.commit_action()
 	# #460: read-back after commit — set:true must reflect the landed value, not
 	# the requested one (the #414 pattern). A param not declared on the shader
-	# reads back null: report that as a non-landing set instead of success.
+	# reads back null: the set did not land → structured error (#460 acceptance:
+	# "a non-landing set is a structured error").
 	var landed: Variant = material.get_shader_parameter(name)
 	var persist := _router._persistent_target(node)
+	if landed == null and value != null:
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Uniform '%s' is not declared on the material's shader; the set did not "
+				+ "land (reads back null). Declare the uniform on the shader first." % name,
+			"param",
+		)
 	var body := {
 		"node_path": str(params.get("node_path")),
 		"name": name,
 		"value": Coerce.to_json(landed),
-		"set": landed != null or value == null,
+		"set": true,
 	}
 	if not persist["ok"]:
 		body["persisted"] = false
 		body["reason"] = persist["reason"]
 		body["hint"] = persist["hint"]
-	if landed == null and value != null:
-		body["reason"] = "param_not_declared"
-		body["hint"] = "Uniform '%s' is not declared on the material's shader; the set did not land." % name
 	return _router._ok(body)
 
 

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -74,6 +74,7 @@ func _cmd_assign_shader_material(params: Dictionary) -> Dictionary:
 	if not found["ok"]:
 		return found
 	var node: Node = found["node"]
+	var persist := _router._persistent_target(node)
 	var prop := _material_property_for(node)
 	if prop.is_empty():
 		return _router._fail("VALIDATION_ERROR", "Node has no material slot (not a CanvasItem/GeometryInstance3D).")
@@ -94,10 +95,24 @@ func _cmd_assign_shader_material(params: Dictionary) -> Dictionary:
 	if prev is Resource:  # keep the prior material alive for undo
 		ur.add_undo_reference(prev)
 	ur.commit_action()
+	# #458: report persistence truth — an instanced child renders live but never
+	# saves; the agent must know instead of trusting a success tone.
+	if not persist["ok"]:
+		return _router._ok({
+			"node_path": str(params.get("node_path")),
+			"shader_path": shader_path,
+			"material_property": prop,
+			"assigned": true,
+			"persisted": false,
+			"reason": persist["reason"],
+			"hint": persist["hint"],
+		})
 	return _router._ok({
 		"node_path": str(params.get("node_path")),
 		"shader_path": shader_path,
 		"material_property": prop,
+		"assigned": true,
+		"persisted": true,
 	})
 
 
@@ -123,7 +138,25 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	ur.add_do_method(material, "set_shader_parameter", name, value)
 	ur.add_undo_method(material, "set_shader_parameter", name, prev)
 	ur.commit_action()
-	return _router._ok({"node_path": str(params.get("node_path")), "name": name})
+	# #460: read-back after commit — set:true must reflect the landed value, not
+	# the requested one (the #414 pattern). A param not declared on the shader
+	# reads back null: report that as a non-landing set instead of success.
+	var landed: Variant = material.get_shader_parameter(name)
+	var persist := _router._persistent_target(node)
+	var body := {
+		"node_path": str(params.get("node_path")),
+		"name": name,
+		"value": Coerce.to_json(landed),
+		"set": landed != null or value == null,
+	}
+	if not persist["ok"]:
+		body["persisted"] = false
+		body["reason"] = persist["reason"]
+		body["hint"] = persist["hint"]
+	if landed == null and value != null:
+		body["reason"] = "param_not_declared"
+		body["hint"] = "Uniform '%s' is not declared on the material's shader; the set did not land." % name
+	return _router._ok(body)
 
 
 func _cmd_get_shader_param(params: Dictionary) -> Dictionary:

--- a/mcp_server/models/shader.py
+++ b/mcp_server/models/shader.py
@@ -36,6 +36,7 @@ class ShaderParamResult(BaseModel):
     # #460: the landed value (read-back after commit), not the requested one.
     value: Any = None
     set: bool = False
+    persisted: bool = True
     reason: str | None = None
     hint: str | None = None
     dry_run: bool = False

--- a/mcp_server/models/shader.py
+++ b/mcp_server/models/shader.py
@@ -22,12 +22,22 @@ class ShaderMaterialResult(BaseModel):
     node_path: str
     shader_path: str
     material_property: str
+    # #458: persistence truth — an instanced child renders live but never saves.
+    assigned: bool = False
+    persisted: bool = True
+    reason: str | None = None
+    hint: str | None = None
     dry_run: bool = False
 
 
 class ShaderParamResult(BaseModel):
     node_path: str
     name: str
+    # #460: the landed value (read-back after commit), not the requested one.
+    value: Any = None
+    set: bool = False
+    reason: str | None = None
+    hint: str | None = None
     dry_run: bool = False
 
 

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -59,16 +59,21 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "shader_path": shader_path}
-        preview = {
-            "node_path": node_path,
-            "shader_path": shader_path,
-            "material_property": "",
-            "assigned": False,
-            "persisted": True,
-        }
-        return await run_or_preview(
-            dry_run, ShaderMaterialResult, preview, bridge, "cmd_assign_shader_material", params
-        )
+        if dry_run:
+            # #458 round-2: the preview must be honest about persistence — probe
+            # the addon read-only instead of hardcoding persisted:true.
+            truth = await route(bridge, "cmd_node_persistence", {"node_path": node_path})
+            return ShaderMaterialResult(
+                node_path=node_path,
+                shader_path=shader_path,
+                material_property="",
+                assigned=False,
+                persisted=truth.get("persisted", True),
+                reason=truth.get("reason"),
+                hint=truth.get("hint"),
+                dry_run=True,
+            )
+        return ShaderMaterialResult(**await route(bridge, "cmd_assign_shader_material", params))
 
     @mcp.tool(meta=MUTATING, tags=SHADER)
     @enforce_preconditions
@@ -90,10 +95,21 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "name": name, "value": value, "param_type": param_type}
-        preview = {"node_path": node_path, "name": name, "set": False}
-        return await run_or_preview(
-            dry_run, ShaderParamResult, preview, bridge, "cmd_set_shader_param", params
-        )
+        if dry_run:
+            # #458 round-2: the preview carries the same persistence truth as the
+            # real run (read-only probe), so an instanced-child preview isn't
+            # dishonest about saving.
+            truth = await route(bridge, "cmd_node_persistence", {"node_path": node_path})
+            return ShaderParamResult(
+                node_path=node_path,
+                name=name,
+                set=False,
+                persisted=truth.get("persisted", True),
+                reason=truth.get("reason"),
+                hint=truth.get("hint"),
+                dry_run=True,
+            )
+        return ShaderParamResult(**await route(bridge, "cmd_set_shader_param", params))
 
     @mcp.tool(meta=READ_ONLY, tags=SHADER)
     async def get_shader_param(node_path: str, name: str) -> ShaderParamReadResult:

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -63,6 +63,8 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
             "node_path": node_path,
             "shader_path": shader_path,
             "material_property": "",
+            "assigned": False,
+            "persisted": True,
         }
         return await run_or_preview(
             dry_run, ShaderMaterialResult, preview, bridge, "cmd_assign_shader_material", params
@@ -88,7 +90,7 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "name": name, "value": value, "param_type": param_type}
-        preview = {"node_path": node_path, "name": name}
+        preview = {"node_path": node_path, "name": name, "set": False}
         return await run_or_preview(
             dry_run, ShaderParamResult, preview, bridge, "cmd_set_shader_param", params
         )

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -34,11 +34,19 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "node_path": p["node_path"],
                     "shader_path": p["shader_path"],
                     "material_property": "material",
+                    "assigned": True,
+                    "persisted": True,
                 },
             )
         case "cmd_set_shader_param":
             return ResponseEnvelope.success(
-                cmd.id, {"node_path": p["node_path"], "name": p["name"]}
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "name": p["name"],
+                    "value": p.get("value"),
+                    "set": True,
+                },
             )
         case "cmd_get_shader_param":
             if p.get("name") == "missing":
@@ -145,3 +153,105 @@ async def test_get_shader_param_is_read_only() -> None:
         )
     grouped_result = grouped.structured_content["tools_by_safety_class"]["read_only"]
     assert "godot_shader_get_param" in grouped_result
+
+
+async def test_assign_material_on_instanced_child_reports_persistence_truth() -> None:
+    """#458/#415: a target inside a non-editable instance renders live but never
+    saves — the response must say so (persisted:false + reason) instead of a
+    success tone that reads as persisted."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":  # require_node_exists precondition
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_assign_shader_material":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "shader_path": cmd.params["shader_path"],
+                    "material_property": "material_override",
+                    "assigned": True,
+                    "persisted": False,
+                    "reason": "instanced_child_not_editable",
+                    "hint": "Enable Editable Children on the instance, or target a "
+                    "scene-owned node — this change will not save.",
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": "Relic4/Visual/Orb", "shader_path": "res://fx.gdshader"},
+        )
+    sc = result.structured_content
+    assert sc["assigned"] is True
+    assert sc["persisted"] is False
+    assert sc["reason"] == "instanced_child_not_editable"
+    assert "not save" in sc["hint"]
+
+
+async def test_assign_material_persists_for_scene_owned_node() -> None:
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":  # require_node_exists precondition
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_assign_shader_material":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "shader_path": cmd.params["shader_path"],
+                    "material_property": "material",
+                    "assigned": True,
+                    "persisted": True,
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": "Sprite2D", "shader_path": "res://fx.gdshader"},
+        )
+    sc = result.structured_content
+    assert sc["assigned"] is True
+    assert sc["persisted"] is True
+
+
+async def test_set_param_reports_landed_value_read_back() -> None:
+    """#460: set:true must reflect the landed value (read-back after commit),
+    not echo the requested value."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":  # require_node_exists precondition
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_set_shader_param":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "name": cmd.params["name"],
+                    "value": 0.5,
+                    "set": True,
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": "Sprite2D", "name": "strength", "value": 0.5, "param_type": "float"},
+        )
+    sc = result.structured_content
+    assert sc["set"] is True
+    assert sc["value"] == 0.5

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -255,3 +255,41 @@ async def test_set_param_reports_landed_value_read_back() -> None:
     sc = result.structured_content
     assert sc["set"] is True
     assert sc["value"] == 0.5
+
+
+async def test_dry_run_preview_carries_persistence_truth() -> None:
+    """#458 round-2: the dry-run preview must be honest about persistence — it
+    probes `cmd_node_persistence` read-only and reports the instanced-child
+    reason instead of hardcoding persisted:true."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_node_persistence":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "persisted": False,
+                    "reason": "instanced_child_not_editable",
+                    "hint": "the change will not save",
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        dry = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": "Relic4/Visual/Orb", "shader_path": "res://fx.gdshader", "dry_run": True},
+        )
+    sc = dry.structured_content
+    assert sc["dry_run"] is True
+    assert sc["assigned"] is False
+    assert sc["persisted"] is False
+    assert sc["reason"] == "instanced_child_not_editable"
+    sent = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
+    assert "cmd_node_persistence" in sent  # the honest preview paid one read-only probe
+    assert "cmd_assign_shader_material" not in sent

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -293,3 +293,74 @@ async def test_dry_run_preview_carries_persistence_truth() -> None:
     sent = [CommandEnvelope.model_validate_json(s).command for s in conn.sent]
     assert "cmd_node_persistence" in sent  # the honest preview paid one read-only probe
     assert "cmd_assign_shader_material" not in sent
+
+
+async def test_set_param_not_declared_is_a_structured_error() -> None:
+    """#460 round-2: a param that isn't declared on the shader reads back null —
+    the set did not land, which is a structured error (not a success envelope
+    with set:false)."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_set_shader_param":
+            return ResponseEnvelope.failure(
+                cmd.id,
+                "VALIDATION_ERROR",
+                "Uniform 'nope' is not declared on the material's shader; the set "
+                "did not land (reads back null). Declare the uniform on the shader first.",
+                required="param",
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": "Sprite2D", "name": "nope", "value": 0.5, "param_type": "float"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    text = str(result.content)
+    assert "VALIDATION_ERROR" in text
+    assert "did not land" in text
+    assert "param" in text  # [required=param] suffix
+
+
+async def test_set_param_persistence_truth_still_carries_on_success() -> None:
+    """#458: a *landing* set on an instanced child still carries
+    persisted:false + reason — both truths coexist (Qodo #463 round-2)."""
+    def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
+        if cmd.command == "cmd_node_exists":
+            return ResponseEnvelope.success(cmd.id, {"exists": True})
+        if cmd.command == "cmd_set_shader_param":
+            return ResponseEnvelope.success(
+                cmd.id,
+                {
+                    "node_path": cmd.params["node_path"],
+                    "name": cmd.params["name"],
+                    "value": 0.5,
+                    "set": True,
+                    "persisted": False,
+                    "reason": "instanced_child_not_editable",
+                    "hint": "the change will not save",
+                },
+            )
+        return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
+
+    conn = FakeAddonConnection(responder=responder)
+    bridge = Bridge(ServerConfig().bridge, connector=connector_for(conn))
+    server = create_server(ServerConfig(), bridge=bridge)
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": "Relic4/Visual/Orb", "name": "strength", "value": 0.5},
+        )
+    sc = result.structured_content
+    assert sc["set"] is True
+    assert sc["value"] == 0.5
+    assert sc["persisted"] is False
+    assert sc["reason"] == "instanced_child_not_editable"

--- a/tests/unit/test_addon_manifest.py
+++ b/tests/unit/test_addon_manifest.py
@@ -506,3 +506,14 @@ def test_mutations_use_undo_redo() -> None:
     # Every create/rename/delete/set must register with EditorUndoRedoManager.
     assert "get_editor_undo_redo" in source
     assert source.count("create_action") >= 6  # the UndoRedo-wrapped mutations
+
+
+def test_router_registers_node_persistence_probe() -> None:
+    # #458 round-2: dry-run previews need a read-only persistence probe so they
+    # can be honest about instanced children without mutating.
+    source = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
+    assert '"cmd_node_persistence"' in source
+    # The helper must consult EditableChildren state (is_editable_instance), not
+    # just the owner chain — editable instances DO persist their overrides.
+    debugger_or_router = "".join(f.read_text() for f in ADDON_DIR.rglob("*.gd"))
+    assert "is_editable_instance" in debugger_or_router


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Implements #458 (closes #415) and #460 — the persistence-truth and read-back slices of the "the addon tells the truth about Godot" batch.

### Shared helper (`_persistent_target` on the router)

Godot knowledge lives in the addon (architecture split): `MCPCommandRouter._persistent_target(node)` returns `{ok: true}` when a mutation on the node will persist to the edited scene, else `{ok: false, persisted: false, reason: "instanced_child_not_editable", hint}` (node's owner is an instanced scene root, not the edited scene root). One helper — other mutating handlers (theme_ui, physics, animation, composite) convert incrementally; shaders ship here as the driver case.

### `shader_assign_material` — persistence truth (#415)

The mutation still applies (the editor renders it live), but the response now says so:

- Persisted: `{assigned: true, persisted: true}`
- Instanced child: `{assigned: true, persisted: false, reason: "instanced_child_not_editable", hint: "...will not save — enable Editable Children or target a scene-owned node"}`

### `shader_set_param` — read-back (#460)

After commit the handler re-reads `get_shader_parameter(name)` and reports the **landed** value (`set` false + `reason: "param_not_declared"` when the uniform isn't declared — the #414 pattern applied to shader params). Also carries `persisted`/`reason` via the helper.

### Tool layer

`ShaderMaterialResult` gains `assigned`/`persisted`/`reason`/`hint`; `ShaderParamResult` gains `value`/`set`/`reason`/`hint` (dry-run previews updated). Additive → `CONTRACT_VERSION` stays 1.

### Remaining conversions

Theme_ui / physics / animation / composite consumers of the helper are follow-up polish (same call, one line each) — tracked on #458's consumer list so this PR stays reviewable.

### Test plan

- 3 new contract tests (red first): instanced-child → `persisted:false` + reason; scene-owned → `persisted:true`; `set_param` reports the landed value
- Full suite 748 pass; mypy/ruff/zero-skip clean; addon compiles on Godot 4.7


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add persistence check for node mutations
  - Risk: may misclassify editable instances

- Report instanced-child changes as non-persistent

- Return landed shader parameter values

- Extend shader result models additively


___

### Diagram Walkthrough


```mermaid
flowchart LR
  helper["Add _persistent_target helper"] -- "checks persistence" --> assign["Assign shader material"]
  assign -- "reports persisted" --> result["Result fields"]
  setparam["Set shader param"] -- "read-back" --> landed["Landed value"]
  tests["Contract tests"] -- "verify" --> result
  tests -- "verify" --> landed
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shader.py</strong><dd><code>Extend shader result models with truth fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/models/shader.py

<ul><li>Adds <code>assigned</code>, <code>persisted</code>, <code>reason</code>, <code>hint</code> to material result.<br> <li> Adds <code>value</code>, <code>set</code>, <code>reason</code>, <code>hint</code> to param result.<br> <li> Makes response fields additive for contract compatibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/463/files#diff-625dc566e94ff39f3c75ca2a96db17f48f8144933db2a3c9237a60c01a4ea3f8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shader.py</strong><dd><code>Update shader tool dry-run previews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/shader.py

<ul><li>Adds <code>assigned</code> and <code>persisted</code> to material dry-run preview.<br> <li> Adds <code>set: false</code> to param dry-run preview.<br> <li> Keeps previews aligned with new result fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/463/files#diff-8b0346b019db1ddea50b19cf3836bae1105939f07e0d28fe3b570c834dbe3543">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shader.py</strong><dd><code>Add shader persistence and read-back tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_shader.py

<ul><li>Updates fake addon responses with new result fields.<br> <li> Tests instanced-child assignment reports <code>persisted: false</code> and reason.<br> <li> Tests scene-owned assignment reports <code>persisted: true</code>.<br> <li> Tests param set reports read-back value.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/463/files#diff-dc4ed87ec99595add7bce4249e632af3522d7a8977bc7dbb11784a823fa57964">+111/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>command_router.gd</strong><dd><code>Add shared persistence target helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/command_router.gd

<ul><li>Adds <code>_persistent_target</code> to check if node mutation can persist.<br> <li> Returns failure metadata for instanced non-editable children.<br> <li> Provides reason and hint for non-persistent targets.<br> <li> Risk: relies on owner/scene_file_path for editable-instance detection.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/463/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shaders.gd</strong><dd><code>Make shader mutations report truth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/shaders.gd

<ul><li>Assign material reports <code>persisted</code> and non-persistence reason.<br> <li> Set param reads back landed value after commit.<br> <li> Reports <code>param_not_declared</code> when a non-null set reads back null.<br> <li> Adds persistence metadata to param results when needed.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/463/files#diff-b46063a9edcb9e3e8867778c2e8de9598f6b5080224bce22daf8fb70c238fd0f">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

