### PR TITLE
fix(persistence): correct persistence truth for shader mutations and previews (closes #475)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -655,7 +655,8 @@ to `material` (CanvasItem) or `material_override` (GeometryInstance3D), reportin
 **Persistence truth (#458).** Both mutations always apply live, then report whether the change
 survives a scene save. `persisted: false` comes with a stable `reason` token and a `hint`;
 A `dry_run` preview applies nothing but asks the addon for the same verdict
-(`cmd_node_persistence`), so it carries `persisted`/`reason`/`hint` too. `set_param` reports
+(`cmd_node_persistence`), so it carries `persisted`/`reason`/`hint` too — for `set_param` the
+probe follows the node's current material, like the real run. `set_param` reports
 the landed `value` read back after the set; a uniform the shader does not declare is a
 `VALIDATION_ERROR`.
 

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -659,7 +659,7 @@ survives a scene save. `persisted: false` comes with a stable `reason` token and
 |----------|---------|
 | `instanced_child_not_editable` | The node (or an ancestor) is inside an instanced scene without Editable Children — Godot never packs it. |
 | `node_not_owned` | The node (or an ancestor) has no owner in the edited scene (e.g. added by a `@tool` script). |
-| `material_embedded_in_other_resource` | `set_param` only: the ShaderMaterial is a sub-resource of another scene (or of a resource file that is no longer loaded), which the editor does not re-save. |
+| `embedded_in_other_resource` | `set_param` only: the ShaderMaterial is a sub-resource of another scene (or of a resource file that is no longer loaded), which the editor does not re-save. |
 
 A material in its own `.tres` file is saved by the editor alongside the scene, so edits to it
 report `persisted: true` even when the node itself is an instanced child.

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -640,8 +640,8 @@ Author shaders — create/read `.gdshader` files, assign a ShaderMaterial, set u
 |------|--------|---------|
 | `godot_shader_create` | `shader_path, code=<canvas_item default>` | `ShaderResult { shader_path, created }` |
 | `godot_shader_read` | `shader_path` | `ShaderReadResult { shader_path, code }` (read_only) |
-| `godot_shader_assign_material` | `node_path, shader_path` | `ShaderMaterialResult { node_path, shader_path, material_property }` |
-| `godot_shader_set_param` | `node_path, name, value, param_type?` | `ShaderParamResult { node_path, name }` |
+| `godot_shader_assign_material` | `node_path, shader_path` | `ShaderMaterialResult { node_path, shader_path, material_property, persisted, reason?, hint? }` |
+| `godot_shader_set_param` | `node_path, name, value, param_type?` | `ShaderParamResult { node_path, name, persisted, reason?, hint? }` |
 | `godot_shader_get_param` | `node_path, name` | `ShaderParamReadResult { node_path, name, value, exists }` (`read_only`) |
 
 `godot_shader_create` writes a `res://*.gdshader` file (undo restores the prior content or
@@ -650,6 +650,19 @@ to `material` (CanvasItem) or `material_override` (GeometryInstance3D), reportin
 `godot_shader_set_param` sets a uniform on the node's ShaderMaterial; `param_type`
 (float/int/bool/vector2/vector3/vector4/color) coerces `value`, or it is inferred
 (number/bool as-is, `[x,y,z]` → vector, HTML string → color).
+
+**Persistence truth (#458).** Both mutations always apply live, then report whether the change
+survives a scene save. `persisted: false` comes with a stable `reason` token and a `hint`;
+`persisted` is `null` on a `dry_run` preview (only the editor can tell).
+
+| `reason` | Meaning |
+|----------|---------|
+| `instanced_child_not_editable` | The node (or an ancestor) is inside an instanced scene without Editable Children — Godot never packs it. |
+| `node_not_owned` | The node (or an ancestor) has no owner in the edited scene (e.g. added by a `@tool` script). |
+| `material_embedded_in_other_resource` | `set_param` only: the ShaderMaterial is a sub-resource of another scene (or of a resource file that is no longer loaded), which the editor does not re-save. |
+
+A material in its own `.tres` file is saved by the editor alongside the scene, so edits to it
+report `persisted: true` even when the node itself is an instanced child.
 
 #### Visual shaders (issue #107) — category: `visual_shader` (gated off by default)
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -470,6 +470,51 @@ func _resolve(raw_path: Variant) -> Dictionary:
 	return {"ok": true, "node": node}
 
 
+# -- persistence truth (#458) -------------------------------------------------
+
+## Whether a change to this node survives a scene save. Mirrors 4.7's
+## SceneState::_parse_node: a node is packed only when its owner is the edited root or
+## an editable instance, and a skipped node's subtree is never visited — so every node
+## on the path up to the root must qualify. Returns {ok: true} or {ok: false, reason, hint}.
+func _persistent_target(node: Node) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null or node == null:
+		return _not_persisted("node_not_owned", "No scene is open, so nothing can be saved.")
+	var current := node
+	while current != root:
+		if current == null:
+			return _not_persisted("node_not_owned", "The target is not inside the edited scene, so changes to it are never saved.")
+		var node_owner := current.owner
+		if node_owner == null:
+			return _not_persisted(
+				"node_not_owned",
+				"'%s' has no owner in the edited scene (e.g. it was added by a @tool script), so it is not saved — the change shows in the editor but is lost on reload." % root.get_path_to(current)
+			)
+		if node_owner != root and not root.is_editable_instance(node_owner):
+			var instance := str(root.get_path_to(node_owner))
+			return _not_persisted(
+				"instanced_child_not_editable",
+				"'%s' is inside the instanced scene '%s', which does not have Editable Children enabled — the change shows in the editor but will not be saved. Enable Editable Children on '%s', or target a node the scene owns." % [root.get_path_to(node), instance, instance]
+			)
+		current = current.get_parent()
+	return {"ok": true}
+
+
+func _not_persisted(reason: String, hint: String) -> Dictionary:
+	return {"ok": false, "reason": reason, "hint": hint}
+
+
+## Stamp a persistence verdict onto a mutation result: always `persisted`, plus `reason`
+## and `hint` when the applied change will not be saved.
+func _with_persistence(result: Dictionary, verdict: Dictionary) -> Dictionary:
+	var persisted := bool(verdict.get("ok", false))
+	result["persisted"] = persisted
+	if not persisted:
+		result["reason"] = str(verdict.get("reason", ""))
+		result["hint"] = str(verdict.get("hint", ""))
+	return result
+
+
 ## The Variant.Type of an object's property, or -1 if it has no such property.
 ## Uses a per-object cache so repeated lookups (e.g. batch operations) are O(1)
 ## instead of O(n) over the property list. Cache refreshes automatically on a

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -515,6 +515,32 @@ func _with_persistence(result: Dictionary, verdict: Dictionary) -> Dictionary:
 	return result
 
 
+## Whether an edit to a resource the node uses survives a scene save. `chain` lists the
+## edited resource and what holds it, innermost first; the first one with a path decides.
+## Embedded in the edited scene: saved with its node. Its own file: the editor saves it
+## alongside the scene (EditorNode::_save_external_resources, 4.7). A sub-resource of a
+## loaded non-scene file: saved with that file. A sub-resource of another scene: never
+## re-saved. No path anywhere: saved (or not) with its node.
+func _resource_persistence(node: Node, chain: Array) -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	for item in chain:
+		var resource := item as Resource
+		if resource == null or resource.resource_path.is_empty():
+			continue
+		var container := resource.resource_path.get_slice("::", 0)
+		if root != null and container == root.scene_file_path:
+			break
+		if not resource.resource_path.contains("::"):
+			return {"ok": true}
+		if ResourceLoader.has_cached(container) and not (ResourceLoader.get_cached_ref(container) is PackedScene):
+			return {"ok": true}
+		return _not_persisted(
+			"embedded_in_other_resource",
+			"This %s is embedded in '%s', which is not saved with the current scene — the change shows in the editor but is lost on reload. Edit it in '%s' directly, or give the node its own %s." % [resource.get_class(), container, container, resource.get_class()]
+		)
+	return _persistent_target(node)
+
+
 ## The Variant.Type of an object's property, or -1 if it has no such property.
 ## Uses a per-object cache so repeated lookups (e.g. batch operations) are O(1)
 ## instead of O(n) over the property list. Cache refreshes automatically on a

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -134,13 +134,24 @@ func _cmd_node_exists(params: Dictionary) -> Dictionary:
 func _cmd_node_persistence(params: Dictionary) -> Dictionary:
 	# #458 dry-run probe: persistence truth for a target, no mutation. Lets a
 	# dry_run preview carry the same persisted/reason fields as the real run.
+	# `resource_properties` names the node properties an edit reaches through (e.g. a
+	# material's slots); the first one holding a resource decides where it saves (#475).
 	if not params.has("node_path"):
 		return _router._fail("VALIDATION_ERROR", "'node_path' is required.")
+	var properties: Variant = params.get("resource_properties", [])
+	if not (properties is Array):
+		return _router._fail("VALIDATION_ERROR", "'resource_properties' must be an array of property names.")
 	var found := _router._resolve(params["node_path"])
 	if not found["ok"]:
 		return found
 	var node: Node = found["node"]
-	var truth := _router._persistent_target(node)
+	var chain := []
+	for property in properties:
+		var held: Variant = node.get(str(property))
+		if held is Resource:
+			chain.append(held)
+			break
+	var truth := _router._resource_persistence(node, chain)
 	var body := {
 		"node_path": str(params["node_path"]),
 		"persisted": truth["ok"],

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -107,7 +107,7 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	if name.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'name' must be a non-empty string.")
 	var value: Variant = _coerce_shader_value(params.get("value"), str(params.get("param_type", "")))
-	var persistence := _material_persistence(node, material)
+	var persistence := _router._resource_persistence(node, [material])
 	var prev: Variant = material.get_shader_parameter(name)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set shader param %s" % name)
@@ -161,27 +161,6 @@ func _cmd_get_shader_param(params: Dictionary) -> Dictionary:
 		"value": Coerce.to_json(value),
 		"exists": exists,
 	})
-
-
-## Whether a uniform edit on this material survives a scene save (#458), decided by where
-## the material lives. Embedded in the edited scene (or never saved): it saves with its
-## node. Its own resource file: the editor saves it alongside the scene
-## (EditorNode::_save_external_resources, 4.7). A sub-resource of another file: saved only
-## while that container is loaded and is not a PackedScene — the editor never re-saves
-## other scenes.
-func _material_persistence(node: Node, material: Resource) -> Dictionary:
-	var path := material.resource_path
-	var container := path.get_slice("::", 0)
-	if path.is_empty() or container == EditorInterface.get_edited_scene_root().scene_file_path:
-		return _router._persistent_target(node)
-	if not path.contains("::"):
-		return {"ok": true}
-	if ResourceLoader.has_cached(container) and not (ResourceLoader.get_cached_ref(container) is PackedScene):
-		return {"ok": true}
-	return _router._not_persisted(
-		"embedded_in_other_resource",
-		"This material is embedded in '%s', which is not saved with the current scene — the change shows in the editor but is lost on reload. Edit the material in '%s' directly, or assign a material this scene owns." % [container, container]
-	)
 
 
 func _material_property_for(node: Node) -> String:

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -172,7 +172,7 @@ func _material_persistence(node: Node, material: Resource) -> Dictionary:
 	if ResourceLoader.has_cached(container) and not (ResourceLoader.get_cached_ref(container) is PackedScene):
 		return {"ok": true}
 	return _router._not_persisted(
-		"material_embedded_in_other_resource",
+		"embedded_in_other_resource",
 		"This material is embedded in '%s', which is not saved with the current scene — the change shows in the editor but is lost on reload. Edit the material in '%s' directly, or assign a material this scene owns." % [container, container]
 	)
 

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -83,6 +83,7 @@ func _cmd_assign_shader_material(params: Dictionary) -> Dictionary:
 	var shader: Resource = ResourceLoader.load(shader_path)
 	if not (shader is Shader):
 		return _router._fail("VALIDATION_ERROR", "'%s' is not a Shader." % shader_path)
+	var persistence := _router._persistent_target(node)
 	var material := ShaderMaterial.new()
 	material.shader = shader
 	var prev: Variant = node.get(prop)
@@ -94,11 +95,11 @@ func _cmd_assign_shader_material(params: Dictionary) -> Dictionary:
 	if prev is Resource:  # keep the prior material alive for undo
 		ur.add_undo_reference(prev)
 	ur.commit_action()
-	return _router._ok({
+	return _router._ok(_router._with_persistence({
 		"node_path": str(params.get("node_path")),
 		"shader_path": shader_path,
 		"material_property": prop,
-	})
+	}, persistence))
 
 
 
@@ -117,13 +118,14 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	if name.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'name' must be a non-empty string.")
 	var value: Variant = _coerce_shader_value(params.get("value"), str(params.get("param_type", "")))
+	var persistence := _material_persistence(node, material)
 	var prev: Variant = material.get_shader_parameter(name)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Set shader param %s" % name)
 	ur.add_do_method(material, "set_shader_parameter", name, value)
 	ur.add_undo_method(material, "set_shader_parameter", name, prev)
 	ur.commit_action()
-	return _router._ok({"node_path": str(params.get("node_path")), "name": name})
+	return _router._ok(_router._with_persistence({"node_path": str(params.get("node_path")), "name": name}, persistence))
 
 
 func _cmd_get_shader_param(params: Dictionary) -> Dictionary:
@@ -152,6 +154,27 @@ func _cmd_get_shader_param(params: Dictionary) -> Dictionary:
 		"value": Coerce.to_json(value),
 		"exists": exists,
 	})
+
+
+## Whether a uniform edit on this material survives a scene save (#458), decided by where
+## the material lives. Embedded in the edited scene (or never saved): it saves with its
+## node. Its own resource file: the editor saves it alongside the scene
+## (EditorNode::_save_external_resources, 4.7). A sub-resource of another file: saved only
+## while that container is loaded and is not a PackedScene — the editor never re-saves
+## other scenes.
+func _material_persistence(node: Node, material: Resource) -> Dictionary:
+	var path := material.resource_path
+	var container := path.get_slice("::", 0)
+	if path.is_empty() or container == EditorInterface.get_edited_scene_root().scene_file_path:
+		return _router._persistent_target(node)
+	if not path.contains("::"):
+		return {"ok": true}
+	if ResourceLoader.has_cached(container) and not (ResourceLoader.get_cached_ref(container) is PackedScene):
+		return {"ok": true}
+	return _router._not_persisted(
+		"material_embedded_in_other_resource",
+		"This material is embedded in '%s', which is not saved with the current scene — the change shows in the editor but is lost on reload. Edit the material in '%s' directly, or assign a material this scene owns." % [container, container]
+	)
 
 
 func _material_property_for(node: Node) -> String:

--- a/mcp_server/models/persistence.py
+++ b/mcp_server/models/persistence.py
@@ -11,7 +11,7 @@ class PersistenceReport(BaseModel):
     ``persisted`` is ``None`` when unknown — a ``dry_run`` preview, since only the editor
     can tell. ``False`` always comes with a stable ``reason`` token
     (``instanced_child_not_editable``, ``node_not_owned``,
-    ``material_embedded_in_other_resource``) and an actionable ``hint``.
+    ``embedded_in_other_resource``) and an actionable ``hint``.
     """
 
     persisted: bool | None = None

--- a/mcp_server/models/persistence.py
+++ b/mcp_server/models/persistence.py
@@ -1,0 +1,19 @@
+"""Persistence truth for node mutation results (issue #458)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PersistenceReport(BaseModel):
+    """Whether a change that applied live in the editor will survive a scene save.
+
+    ``persisted`` is ``None`` when unknown — a ``dry_run`` preview, since only the editor
+    can tell. ``False`` always comes with a stable ``reason`` token
+    (``instanced_child_not_editable``, ``node_not_owned``,
+    ``material_embedded_in_other_resource``) and an actionable ``hint``.
+    """
+
+    persisted: bool | None = None
+    reason: str | None = None
+    hint: str | None = None

--- a/mcp_server/models/shader.py
+++ b/mcp_server/models/shader.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from mcp_server.models.persistence import PersistenceReport
+
 
 class ShaderResult(BaseModel):
     shader_path: str
@@ -18,14 +20,14 @@ class ShaderReadResult(BaseModel):
     code: str
 
 
-class ShaderMaterialResult(BaseModel):
+class ShaderMaterialResult(PersistenceReport):
     node_path: str
     shader_path: str
     material_property: str
     dry_run: bool = False
 
 
-class ShaderParamResult(BaseModel):
+class ShaderParamResult(PersistenceReport):
     node_path: str
     name: str
     dry_run: bool = False

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -29,6 +29,21 @@ from mcp_server.tools._route import route, run_or_preview
 
 SHADER = {SHADER_TAG}
 
+# The slots a node's ShaderMaterial can sit in (CanvasItem, GeometryInstance3D).
+MATERIAL_PROPERTIES = ["material", "material_override"]
+
+
+def assign_material_probe(node_path: str) -> dict[str, Any]:
+    """``cmd_node_persistence`` params for an ``assign_shader_material`` preview: the new
+    material has no file yet, so it saves (or not) with its node."""
+    return {"node_path": node_path}
+
+
+def set_param_probe(node_path: str) -> dict[str, Any]:
+    """``cmd_node_persistence`` params for a ``set_shader_param`` preview: a uniform edit
+    saves wherever the node's current material lives (#475)."""
+    return {"node_path": node_path, "resource_properties": MATERIAL_PROPERTIES}
+
 
 def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
     """Register the shader tools."""
@@ -65,7 +80,7 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         if dry_run:
             # #458 round-2: the preview must be honest about persistence — probe
             # the addon read-only instead of hardcoding persisted:true.
-            truth = await route(bridge, "cmd_node_persistence", {"node_path": node_path})
+            truth = await route(bridge, "cmd_node_persistence", assign_material_probe(node_path))
             return ShaderMaterialResult(
                 node_path=node_path,
                 shader_path=shader_path,
@@ -105,7 +120,7 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
             # #458 round-2: the preview carries the same persistence truth as the
             # real run (read-only probe), so an instanced-child preview isn't
             # dishonest about saving.
-            truth = await route(bridge, "cmd_node_persistence", {"node_path": node_path})
+            truth = await route(bridge, "cmd_node_persistence", set_param_probe(node_path))
             return ShaderParamResult(
                 node_path=node_path,
                 name=name,

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -55,7 +55,10 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
     ) -> ShaderMaterialResult:
         """Create a ShaderMaterial wrapping the shader at ``shader_path`` and assign it to
         the node at ``node_path`` (``material`` for CanvasItem, ``material_override`` for
-        GeometryInstance3D). Returns which material property was set.
+        GeometryInstance3D). Returns which material property was set, and ``persisted``:
+        ``False`` (with a ``reason`` token and ``hint``) when the material applies live but
+        will not be saved — e.g. the node is inside an instanced scene without Editable
+        Children. ``persisted`` is ``None`` on a ``dry_run`` preview.
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "shader_path": shader_path}
@@ -85,6 +88,9 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
         ``{"x":1,"y":2}``/``[1,2]``, Color as ``{"r":1,"g":0,"b":0,"a":1}`` or
         ``"#ff0000"``, Rect2 as ``{"position":{...},"size":{...}}``, NodePath/StringName
         as a string, primitives as-is. See docs/tool-contracts.md#value-shapes.
+        Reports ``persisted`` like ``assign_shader_material``: ``False`` when the edit will
+        not be saved — the node is inside an instance without Editable Children, or the
+        material is embedded in another scene/resource file (``reason`` says which).
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "name": name, "value": value, "param_type": param_type}

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -73,8 +73,10 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                 },
             )
         case "cmd_node_persistence":  # the read-only probe behind a dry_run preview
+            material = "material" in p.get("resource_properties", [])
             return ResponseEnvelope.success(
-                cmd.id, {"node_path": p["node_path"], **_persistence(p["node_path"])}
+                cmd.id,
+                {"node_path": p["node_path"], **_persistence(p["node_path"], material=material)},
             )
         case "cmd_get_shader_param":
             if p.get("name") == "missing":
@@ -208,6 +210,27 @@ async def test_dry_run_carries_the_probed_verdict_without_mutating() -> None:
     assert sent.count("cmd_node_persistence") == 2
     assert "cmd_assign_shader_material" not in sent
     assert "cmd_set_shader_param" not in sent
+
+
+async def test_set_param_preview_follows_the_material_not_just_the_node() -> None:
+    """#475: a uniform edit saves wherever the material lives, so the preview's probe
+    must name the material slots — otherwise it predicts the node's verdict instead."""
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        param = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": FOREIGN_MATERIAL, "name": "pulse_speed", "value": 3.0, "dry_run": True},
+        )
+        assigned = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": FOREIGN_MATERIAL, "shader_path": "res://fx.gdshader", "dry_run": True},
+        )
+    assert param.structured_content["persisted"] is False
+    assert param.structured_content["reason"] == "embedded_in_other_resource"
+    # assign replaces the material with a fresh one, so only the node decides
+    assert assigned.structured_content["persisted"] is True
+    assert "cmd_set_shader_param" not in _commands(conn)
 
 
 async def test_default_code_passed_when_omitted() -> None:

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -31,7 +31,7 @@ def _persistence(node_path: str, *, material: bool = False) -> dict[str, Any]:
     if material and node_path == FOREIGN_MATERIAL:
         return {
             "persisted": False,
-            "reason": "material_embedded_in_other_resource",
+            "reason": "embedded_in_other_resource",
             "hint": "Edit the material in 'res://relic.tscn', or assign one this scene owns.",
         }
     return {"persisted": True}
@@ -176,7 +176,7 @@ async def test_set_param_on_material_owned_by_other_resource_reports_not_persist
         )
     content = result.structured_content
     assert content["persisted"] is False
-    assert content["reason"] == "material_embedded_in_other_resource"
+    assert content["reason"] == "embedded_in_other_resource"
     assert content["hint"]
 
 

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastmcp import Client, FastMCP
 
@@ -12,6 +14,27 @@ from mcp_server.server import create_server
 from tests.fakes import FakeAddonConnection, connector_for
 
 pytestmark = pytest.mark.asyncio
+
+# #458: node paths the fake addon treats as non-persistable targets.
+INSTANCED_CHILD = "Relic/Orb"  # inside an instance without Editable Children
+FOREIGN_MATERIAL = "Relic2/Orb"  # editable child whose material lives in the instanced scene
+
+
+def _persistence(node_path: str, *, material: bool = False) -> dict[str, Any]:
+    """The persistence fields the addon stamps on a shader mutation result (#458)."""
+    if node_path == INSTANCED_CHILD:
+        return {
+            "persisted": False,
+            "reason": "instanced_child_not_editable",
+            "hint": "Enable Editable Children on 'Relic', or target a node the scene owns.",
+        }
+    if material and node_path == FOREIGN_MATERIAL:
+        return {
+            "persisted": False,
+            "reason": "material_embedded_in_other_resource",
+            "hint": "Edit the material in 'res://relic.tscn', or assign one this scene owns.",
+        }
+    return {"persisted": True}
 
 
 def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
@@ -34,11 +57,17 @@ def _responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
                     "node_path": p["node_path"],
                     "shader_path": p["shader_path"],
                     "material_property": "material",
+                    **_persistence(p["node_path"]),
                 },
             )
         case "cmd_set_shader_param":
             return ResponseEnvelope.success(
-                cmd.id, {"node_path": p["node_path"], "name": p["name"]}
+                cmd.id,
+                {
+                    "node_path": p["node_path"],
+                    "name": p["name"],
+                    **_persistence(p["node_path"], material=True),
+                },
             )
         case "cmd_get_shader_param":
             if p.get("name") == "missing":
@@ -99,7 +128,78 @@ async def test_create_read_assign_set() -> None:
     assert created.structured_content["created"] is True
     assert read.structured_content["code"].startswith("shader_type")
     assert assigned.structured_content["material_property"] == "material"
+    assert assigned.structured_content["persisted"] is True
+    assert assigned.structured_content.get("reason") is None
     assert param.structured_content["name"] == "strength"
+    assert param.structured_content["persisted"] is True
+    assert param.structured_content.get("reason") is None
+
+
+async def test_assign_on_instanced_child_reports_not_persisted() -> None:
+    """#415: the material IS applied (effect reported) but the result must say it won't save."""
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": INSTANCED_CHILD, "shader_path": "res://fx.gdshader"},
+        )
+    content = result.structured_content
+    assert content["material_property"] == "material"
+    assert content["persisted"] is False
+    assert content["reason"] == "instanced_child_not_editable"
+    assert "Editable Children" in content["hint"]
+
+
+async def test_set_param_on_instanced_child_reports_not_persisted() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": INSTANCED_CHILD, "name": "pulse_speed", "value": 3.0},
+        )
+    content = result.structured_content
+    assert content["name"] == "pulse_speed"
+    assert content["persisted"] is False
+    assert content["reason"] == "instanced_child_not_editable"
+    assert content["hint"]
+
+
+async def test_set_param_on_material_owned_by_other_resource_reports_not_persisted() -> None:
+    server, _ = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        result = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": FOREIGN_MATERIAL, "name": "pulse_speed", "value": 3.0},
+        )
+    content = result.structured_content
+    assert content["persisted"] is False
+    assert content["reason"] == "material_embedded_in_other_resource"
+    assert content["hint"]
+
+
+async def test_dry_run_leaves_persistence_unknown() -> None:
+    """Persistence is only knowable editor-side; a preview must not claim either way."""
+    server, conn = _build()
+    async with Client(server) as client:
+        await client.call_tool("godot_enable_toolset", {"category": "shader"})
+        assigned = await client.call_tool(
+            "godot_shader_assign_material",
+            {"node_path": INSTANCED_CHILD, "shader_path": "res://fx.gdshader", "dry_run": True},
+        )
+        param = await client.call_tool(
+            "godot_shader_set_param",
+            {"node_path": INSTANCED_CHILD, "name": "pulse_speed", "value": 3.0, "dry_run": True},
+        )
+    for content in (assigned.structured_content, param.structured_content):
+        assert content["dry_run"] is True
+        assert content.get("persisted") is None
+        assert content.get("reason") is None
+    sent = _commands(conn)
+    assert "cmd_assign_shader_material" not in sent
+    assert "cmd_set_shader_param" not in sent
 
 
 async def test_default_code_passed_when_omitted() -> None:

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -162,7 +162,9 @@ async def _check_persistence(bridge: Bridge) -> None:
 
     glow = "res://tmp_e2e_persist_glow.gdshader"
 
-    async def previewed(probe: dict[str, Any], command: str, params: dict[str, Any]) -> Any:
+    async def previewed(
+        probe: dict[str, Any], command: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
         # the dry_run preview's probe (sent exactly as the tool sends it) must predict the
         # real run's verdict (#475)
         preview = await _ok(bridge, "cmd_node_persistence", probe)

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -182,8 +182,8 @@ async def _check_persistence(bridge: Bridge) -> None:
     assert editable["persisted"] is True and "reason" not in editable, editable
     assert (await set_param("Relic2/Plain", 6.0))["persisted"] is True
     # a material embedded in the instanced scene file never saves with this scene
-    assert_not_persisted(await set_param("Relic2/Orb", 7.0), "material_embedded_in_other_resource")
-    assert_not_persisted(await set_param("Relic/Orb", 8.0), "material_embedded_in_other_resource")
+    assert_not_persisted(await set_param("Relic2/Orb", 7.0), "embedded_in_other_resource")
+    assert_not_persisted(await set_param("Relic/Orb", 8.0), "embedded_in_other_resource")
     # external .tres (saved alongside the scene) and a material this scene embeds
     assert (await set_param("OwnExt", 9.0))["persisted"] is True
     assert (await set_param("OwnEmbedded", 5.0))["persisted"] is True

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -22,6 +22,79 @@ SHADER_PATH = "res://tmp_e2e_shader.gdshader"
 SHADER_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader"
 SHADER_UID_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader.uid"  # Godot 4.4+ sidecar
 
+# #458: an instanced scene placed twice — "Relic" without Editable Children, "Relic2" with —
+# plus scene-owned nodes carrying an external (.tres) and an embedded material.
+PERSIST_GLOW = GODOT_PROJECT / "tmp_e2e_persist_glow.gdshader"
+PERSIST_MAT = GODOT_PROJECT / "tmp_e2e_persist_mat.tres"
+PERSIST_MAT_INNER = GODOT_PROJECT / "tmp_e2e_persist_mat_inner.tres"
+PERSIST_INNER = GODOT_PROJECT / "tmp_e2e_persist_inner.tscn"
+PERSIST_MAIN = GODOT_PROJECT / "tmp_e2e_persist_main.tscn"
+PERSIST_FIXTURES = {
+    PERSIST_GLOW: (
+        "shader_type spatial;\nuniform float pulse_speed = 1.0;\n"
+        "void fragment() {\n\tALBEDO = vec3(pulse_speed);\n}\n"
+    ),
+    PERSIST_MAT: """[gd_resource type="ShaderMaterial" format=3]
+
+[ext_resource type="Shader" path="res://tmp_e2e_persist_glow.gdshader" id="1"]
+
+[resource]
+shader = ExtResource("1")
+shader_parameter/pulse_speed = 1.0
+""",
+    PERSIST_MAT_INNER: """[gd_resource type="ShaderMaterial" format=3]
+
+[ext_resource type="Shader" path="res://tmp_e2e_persist_glow.gdshader" id="1"]
+
+[resource]
+shader = ExtResource("1")
+shader_parameter/pulse_speed = 1.0
+""",
+    PERSIST_INNER: """[gd_scene format=3]
+
+[ext_resource type="Shader" path="res://tmp_e2e_persist_glow.gdshader" id="1"]
+[ext_resource type="ShaderMaterial" path="res://tmp_e2e_persist_mat_inner.tres" id="2"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_inner"]
+shader = ExtResource("1")
+shader_parameter/pulse_speed = 1.0
+
+[node name="Inner" type="Node3D"]
+
+[node name="Orb" type="MeshInstance3D" parent="."]
+material_override = SubResource("ShaderMaterial_inner")
+
+[node name="Plain" type="MeshInstance3D" parent="."]
+
+[node name="ExtOrb" type="MeshInstance3D" parent="."]
+material_override = ExtResource("2")
+""",
+    PERSIST_MAIN: """[gd_scene format=3]
+
+[ext_resource type="PackedScene" path="res://tmp_e2e_persist_inner.tscn" id="1"]
+[ext_resource type="Shader" path="res://tmp_e2e_persist_glow.gdshader" id="2"]
+[ext_resource type="ShaderMaterial" path="res://tmp_e2e_persist_mat.tres" id="3"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_main"]
+shader = ExtResource("2")
+shader_parameter/pulse_speed = 1.0
+
+[node name="Main" type="Node3D"]
+
+[node name="Relic" parent="." instance=ExtResource("1")]
+
+[node name="Relic2" parent="." instance=ExtResource("1")]
+
+[node name="OwnExt" type="MeshInstance3D" parent="."]
+material_override = ExtResource("3")
+
+[node name="OwnEmbedded" type="MeshInstance3D" parent="."]
+material_override = SubResource("ShaderMaterial_main")
+
+[editable path="Relic2"]
+""",
+}
+
 SHADER_CODE = (
     "shader_type canvas_item;\n"
     "uniform float strength = 1.0;\n"
@@ -50,6 +123,73 @@ async def _wait_scene_open(bridge: Bridge) -> None:
             return
         await asyncio.sleep(0.25)
     raise AssertionError("scene did not open")
+
+
+async def _check_persistence(bridge: Bridge) -> None:
+    """#458/#415: every reported ``persisted`` flag must match what the editor writes."""
+    main_path = "res://tmp_e2e_persist_main.tscn"
+    await _ok(bridge, "cmd_open_scene", {"scene_path": main_path})
+    for _ in range(40):
+        r = await bridge.send("cmd_get_active_scene")
+        if r.ok and (r.result or {}).get("path") == main_path:
+            break
+        await asyncio.sleep(0.25)
+    else:
+        raise AssertionError("persistence fixture scene did not become active")
+
+    glow = "res://tmp_e2e_persist_glow.gdshader"
+
+    async def assign(node_path: str) -> dict[str, Any]:
+        return await _ok(
+            bridge, "cmd_assign_shader_material", {"node_path": node_path, "shader_path": glow}
+        )
+
+    async def set_param(node_path: str, value: float) -> dict[str, Any]:
+        return await _ok(
+            bridge,
+            "cmd_set_shader_param",
+            {"node_path": node_path, "name": "pulse_speed", "value": value, "param_type": "float"},
+        )
+
+    def assert_not_persisted(result: dict[str, Any], reason: str) -> None:
+        assert result["persisted"] is False, result
+        assert result["reason"] == reason, result
+        assert result["hint"], result
+
+    # the #415 repro: applied live, but the instance has no Editable Children
+    assert_not_persisted(await assign("Relic/Plain"), "instanced_child_not_editable")
+    assert_not_persisted(await set_param("Relic/Plain", 4.0), "instanced_child_not_editable")
+    # Editable Children on -> the override and its fresh material are scene-owned
+    editable = await assign("Relic2/Plain")
+    assert editable["persisted"] is True and "reason" not in editable, editable
+    assert (await set_param("Relic2/Plain", 6.0))["persisted"] is True
+    # a material embedded in the instanced scene file never saves with this scene
+    assert_not_persisted(await set_param("Relic2/Orb", 7.0), "material_embedded_in_other_resource")
+    assert_not_persisted(await set_param("Relic/Orb", 8.0), "material_embedded_in_other_resource")
+    # external .tres (saved alongside the scene) and a material this scene embeds
+    assert (await set_param("OwnExt", 9.0))["persisted"] is True
+    assert (await set_param("OwnEmbedded", 5.0))["persisted"] is True
+    # the edit lands in the .tres, which the editor saves even though the node is skipped
+    assert (await set_param("Relic/ExtOrb", 2.5))["persisted"] is True
+    # scene-owned nodes created under an instanced child: the packer never visits the
+    # subtree of a skipped node, so the whole parent path decides
+    await _create(bridge, "Extra", "MeshInstance3D", parent="Relic/Plain")
+    assert_not_persisted(await assign("Relic/Plain/Extra"), "instanced_child_not_editable")
+    await _create(bridge, "Extra", "MeshInstance3D", parent="Relic2/Plain")
+    assert (await assign("Relic2/Plain/Extra"))["persisted"] is True
+
+    await _ok(bridge, "cmd_save_scene", {})
+    main_text = PERSIST_MAIN.read_text()
+    inner_text = PERSIST_INNER.read_text()
+    assert 'parent="Relic"' not in main_text, "non-editable instance override was saved"
+    assert 'parent="Relic/Plain"' not in main_text, "node under a skipped instance child saved"
+    assert 'name="Extra" type="MeshInstance3D" parent="Relic2/Plain"' in main_text
+    assert "pulse_speed = 6.0" in main_text and "pulse_speed = 5.0" in main_text
+    assert "pulse_speed = 7.0" not in main_text + inner_text
+    assert "pulse_speed = 8.0" not in main_text + inner_text
+    assert "pulse_speed = 4.0" not in main_text
+    assert "pulse_speed = 9.0" in PERSIST_MAT.read_text()
+    assert "pulse_speed = 2.5" in PERSIST_MAT_INNER.read_text()
 
 
 async def _run() -> None:
@@ -122,12 +262,16 @@ async def _run() -> None:
             {"node_path": "Sprite", "shader_path": "res://nope.gdshader"},
         )
         assert bad_shader.ok is False and bad_shader.error == "RESOURCE_NOT_FOUND"
+
+        await _check_persistence(bridge)
     finally:
         await bridge.close()
 
 
 def test_live_shader() -> None:
     assert GODOT_BIN is not None
+    for fixture, text in PERSIST_FIXTURES.items():
+        fixture.write_text(text)
     editor = subprocess.Popen(
         [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
         stdout=subprocess.DEVNULL,
@@ -145,3 +289,5 @@ def test_live_shader() -> None:
         SCRATCH_FILE.unlink(missing_ok=True)
         SHADER_FILE.unlink(missing_ok=True)
         SHADER_UID_FILE.unlink(missing_ok=True)
+        for leftover in GODOT_PROJECT.glob("tmp_e2e_persist_*"):
+            leftover.unlink(missing_ok=True)

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -23,11 +23,13 @@ SHADER_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader"
 SHADER_UID_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader.uid"  # Godot 4.4+ sidecar
 
 # #458: an instanced scene placed twice — "Relic" without Editable Children, "Relic2" with —
-# plus scene-owned nodes carrying an external (.tres) and an embedded material.
+# plus scene-owned nodes carrying an external (.tres) and an embedded material. "Shell"/"Shell2"
+# nest that scene one level deeper (Mid -> Core): editable at the outer level only, and at both.
 PERSIST_GLOW = GODOT_PROJECT / "tmp_e2e_persist_glow.gdshader"
 PERSIST_MAT = GODOT_PROJECT / "tmp_e2e_persist_mat.tres"
 PERSIST_MAT_INNER = GODOT_PROJECT / "tmp_e2e_persist_mat_inner.tres"
 PERSIST_INNER = GODOT_PROJECT / "tmp_e2e_persist_inner.tscn"
+PERSIST_MID = GODOT_PROJECT / "tmp_e2e_persist_mid.tscn"
 PERSIST_MAIN = GODOT_PROJECT / "tmp_e2e_persist_main.tscn"
 PERSIST_FIXTURES = {
     PERSIST_GLOW: (
@@ -69,11 +71,20 @@ material_override = SubResource("ShaderMaterial_inner")
 [node name="ExtOrb" type="MeshInstance3D" parent="."]
 material_override = ExtResource("2")
 """,
+    PERSIST_MID: """[gd_scene format=3]
+
+[ext_resource type="PackedScene" path="res://tmp_e2e_persist_inner.tscn" id="1"]
+
+[node name="Mid" type="Node3D"]
+
+[node name="Core" parent="." instance=ExtResource("1")]
+""",
     PERSIST_MAIN: """[gd_scene format=3]
 
 [ext_resource type="PackedScene" path="res://tmp_e2e_persist_inner.tscn" id="1"]
 [ext_resource type="Shader" path="res://tmp_e2e_persist_glow.gdshader" id="2"]
 [ext_resource type="ShaderMaterial" path="res://tmp_e2e_persist_mat.tres" id="3"]
+[ext_resource type="PackedScene" path="res://tmp_e2e_persist_mid.tscn" id="4"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_main"]
 shader = ExtResource("2")
@@ -91,7 +102,14 @@ material_override = ExtResource("3")
 [node name="OwnEmbedded" type="MeshInstance3D" parent="."]
 material_override = SubResource("ShaderMaterial_main")
 
+[node name="Shell" parent="." instance=ExtResource("4")]
+
+[node name="Shell2" parent="." instance=ExtResource("4")]
+
 [editable path="Relic2"]
+[editable path="Shell"]
+[editable path="Shell2"]
+[editable path="Shell2/Core"]
 """,
 }
 
@@ -177,6 +195,10 @@ async def _check_persistence(bridge: Bridge) -> None:
     assert_not_persisted(await assign("Relic/Plain/Extra"), "instanced_child_not_editable")
     await _create(bridge, "Extra", "MeshInstance3D", parent="Relic2/Plain")
     assert (await assign("Relic2/Plain/Extra"))["persisted"] is True
+    # nested instances: Editable Children on the outer instance does not reach the instance
+    # inside it — the root stores a flag per level ("Shell2/Core") and every level needs one
+    assert_not_persisted(await assign("Shell/Core/Plain"), "instanced_child_not_editable")
+    assert (await assign("Shell2/Core/Plain"))["persisted"] is True
 
     await _ok(bridge, "cmd_save_scene", {})
     main_text = PERSIST_MAIN.read_text()
@@ -190,6 +212,8 @@ async def _check_persistence(bridge: Bridge) -> None:
     assert "pulse_speed = 4.0" not in main_text
     assert "pulse_speed = 9.0" in PERSIST_MAT.read_text()
     assert "pulse_speed = 2.5" in PERSIST_MAT_INNER.read_text()
+    assert 'parent="Shell/Core' not in main_text, "override in a non-editable nested instance saved"
+    assert 'parent="Shell2/Core"' in main_text, "override in an editable nested instance lost"
 
 
 async def _run() -> None:

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -11,6 +11,7 @@ import pytest
 
 from mcp_server.bridge import Bridge
 from mcp_server.config import BridgeConfig
+from mcp_server.tools.shader import assign_material_probe, set_param_probe
 from tests.integration._godot import GODOT_BIN, GODOT_PROJECT, serve_and_await_editor
 
 pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
@@ -161,17 +162,24 @@ async def _check_persistence(bridge: Bridge) -> None:
 
     glow = "res://tmp_e2e_persist_glow.gdshader"
 
+    async def previewed(probe: dict[str, Any], command: str, params: dict[str, Any]) -> Any:
+        # the dry_run preview's probe (sent exactly as the tool sends it) must predict the
+        # real run's verdict (#475)
+        preview = await _ok(bridge, "cmd_node_persistence", probe)
+        result = await _ok(bridge, command, params)
+        verdict = {k: result.get(k) for k in ("persisted", "reason")}
+        assert {k: preview.get(k) for k in ("persisted", "reason")} == verdict, (preview, result)
+        return result
+
     async def assign(node_path: str) -> dict[str, Any]:
-        return await _ok(
-            bridge, "cmd_assign_shader_material", {"node_path": node_path, "shader_path": glow}
-        )
+        params = {"node_path": node_path, "shader_path": glow}
+        probe = assign_material_probe(node_path)
+        return await previewed(probe, "cmd_assign_shader_material", params)
 
     async def set_param(node_path: str, value: float) -> dict[str, Any]:
-        return await _ok(
-            bridge,
-            "cmd_set_shader_param",
-            {"node_path": node_path, "name": "pulse_speed", "value": value, "param_type": "float"},
-        )
+        params = {"node_path": node_path, "name": "pulse_speed", "value": value}
+        probe = set_param_probe(node_path)
+        return await previewed(probe, "cmd_set_shader_param", {**params, "param_type": "float"})
 
     def assert_not_persisted(result: dict[str, Any], reason: str) -> None:
         assert result["persisted"] is False, result


### PR DESCRIPTION
## Summary

Shader mutations report whether their change survives a scene save, and the dry-run probe tells the truth about the material.

Upstream #463 merged (closing #458/#415/#460) with its own `_persistent_target` and a `cmd_node_persistence` dry-run probe, but it had bugs — filed as #475. This PR reconciles that merge and fixes the shader part of #475:

- **Parent-walk `_persistent_target` kept, #463's duplicate dropped.** The auto-merge produced both; ours walks every node from the target up to the edited scene root (matching the engine's pack rule in `packed_scene.cpp:798`), so scene-owned nodes under a non-editable instance are not falsely reported as persistent.
- **`%` hint formatting fixed.** `%` binds tighter than `+`, so #463's hints rendered a literal `%s`. (part of #475)
- **The dry-run probe now follows the material.** Previously the probe ignored the material, so `set_shader_param` previews could disagree with the real verdict. The probe takes `resource_properties` (`process_material`, etc.); a new router helper `_resource_persistence` replaces `shaders.gd`'s `_material_persistence`. (closes #475)
- **The e2e asserts every preview against the real run's verdict** (red first against the old probe).

## The persistence rule (verified on Godot 4.7 source + live editor)

`SceneState::_parse_node` skips a node — and its whole subtree — unless its owner is the scene root or an instance with Editable Children. So `_persistent_target` walks **every node from the target up to the root**, not just the target's owner. A scene-owned node created under a non-editable instance is lost too; the live e2e pins that case.

For `set_shader_param` the material also has to save. Following `EditorNode::_save_external_resources`:

| Material lives in | Result |
|---|---|
| the edited scene (embedded) | same rule as the node |
| an external `.tres` | `persisted: true`: the editor saves it on scene save, even through an instanced child |
| a sub-resource of **another** scene (e.g. the instanced `.tscn`) | `persisted: false`, `reason: material_embedded_in_other_resource` |

### Reason tokens
- `instanced_child_not_editable` — a node on the path belongs to an instance without Editable Children
- `node_not_owned` — no owner in the edited scene (e.g. added by a `@tool` script), or outside the scene
- `embedded_in_other_resource` / `material_embedded_in_other_resource` — see the table above

## Changes
- `command_router.gd`: `_persistent_target`, `_not_persisted`, `_with_persistence`, `_resource_persistence`.
- `handlers/shaders.gd`: both mutations stamp the verdict; `set_shader_param`'s verdict follows the material.
- `models/persistence.py`: `PersistenceReport` (`persisted`/`reason`/`hint`, all optional — additive, `CONTRACT_VERSION` stays 1), mixed into `ShaderMaterialResult`/`ShaderParamResult`.
- `tools/shader.py`: `assign_material_probe` / `set_param_probe` for dry-run previews.
- Tool docstrings and `docs/tool-contracts.md` document the fields and tokens.
- `tests/contract/test_shader.py` and the live e2e in `tests/integration/test_shader_e2e.py`.

## Acceptance criteria
- [x] `_persistent_target` helper on the router (ours, kept across the #463 merge)
- [x] `shader_assign_material`/`shader_set_param` report `persisted`/`reason`/`hint` (driver case for #415)
- [x] Contract tests: instanced-child target → `persisted: false` + `reason`; scene-owned → `persisted: true`; material in another scene → `embedded_in_other_resource`
- [x] Dry-run probe follows the material so previews match the real verdict (closes #475)
- [x] `%` hint formatting fixed (part of #475)
- [x] Addon compiles clean on Godot 4.7; live e2e covers the instanced-child path and checks the saved `.tscn` on disk
- [x] Remaining consumers (theme/physics/animation/composite/3D/navigation/particles): tracked separately (PR 2 / new issue, since #458 closed)

## Test plan
- **Red first:** the live e2e failed against the unmodified addon (`KeyError: 'persisted'`); the probe vs. real-verdict assertion was red against #463's material-blind probe.
- `uv run pytest tests/unit tests/contract -q`: 712 passed
- Live e2e (`test_shader_e2e.py`, Godot 4.7.2), bridge smoke, editor load: green on the working branch
- `ruff check .`, `mypy`, `check-no-skipped-tests.sh`: clean
- Graphify refresh skipped: `graphify` isn't installed in this environment (`graphify-out/` is gitignored); the change adds one small model module and router helpers, no new bridge edges.

## Related
- #463 (upstream persistence truth, merged), #475 (its bugs, fixed here), #474 (set_shader_param confirms undeclared uniforms — tracked separately), #458/#415/#460 (closed by the #463 merge).