### PR TITLE
Fix Vector4 shader parameter coercion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,7 @@ declared type to reconstruct the Godot value) landed with the mutation tools in 
 |------------|------------|
 | `Vector2` / `Vector2i` | `{ "x": float, "y": float }` |
 | `Vector3` / `Vector3i` | `{ "x": float, "y": float, "z": float }` |
+| `Vector4` / `Vector4i` | `{ "x": float, "y": float, "z": float, "w": float }` |
 | `Color` | `{ "r": float, "g": float, "b": float, "a": float }` |
 | `Rect2` / `Rect2i` | `{ "position": {x,y}, "size": {x,y} }` |
 | `NodePath` / `StringName` | string |

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -55,6 +55,7 @@ The accepted shapes:
 |------------|---------------|---------|
 | `Vector2` / `Vector2i` | `{"x":…,"y":…}` or `[x, y]` or `"Vector2(x, y)"` | `{"x": 100, "y": 64}` |
 | `Vector3` / `Vector3i` | `{"x":…,"y":…,"z":…}` or `[x, y, z]` | `{"x": 1, "y": 2, "z": 3}` |
+| `Vector4` / `Vector4i` | `{"x":…,"y":…,"z":…,"w":…}` or `[x, y, z, w]` or `"Vector4(x, y, z, w)"` | `{"x": 1, "y": 0.5, "z": 0.25, "w": 1}` |
 | `Color` | `{"r":…,"g":…,"b":…,"a":…}` or hex string | `"#ff0000"` / `{"r":1,"g":0,"b":0,"a":1}` |
 | `Rect2` / `Rect2i` | `{"position":{x,y},"size":{x,y}}` or `"Rect2(x, y, w, h)"` | `{"position":{"x":0,"y":0},"size":{"x":4,"y":5}}` |
 | `NodePath` / `StringName` | string | `"Player/Sprite2D"` |

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -10,18 +10,6 @@ const Coerce := preload("../type_coerce.gd")
 var _router: MCPCommandRouter
 
 
-
-func _to_vec4(value: Variant) -> Vector4:
-	if value is Array and (value as Array).size() == 4:
-		return Vector4(float(value[0]), float(value[1]), float(value[2]), float(value[3]))
-	if value is Dictionary:
-		return Vector4(
-			float(value.get("x", 0.0)), float(value.get("y", 0.0)),
-			float(value.get("z", 0.0)), float(value.get("w", 0.0))
-		)
-	return Vector4.ZERO
-
-
 func _init(router: MCPCommandRouter) -> void:
 	_router = router
 
@@ -177,7 +165,7 @@ func _coerce_shader_value(value: Variant, param_type: String) -> Variant:
 		"vector3":
 			return Coerce.from_json(value, TYPE_VECTOR3)
 		"vector4":
-			return _router._to_vec4(value)
+			return Coerce.from_json(value, TYPE_VECTOR4)
 		_:
 			if value is Array:
 				match (value as Array).size():
@@ -186,7 +174,7 @@ func _coerce_shader_value(value: Variant, param_type: String) -> Variant:
 					3:
 						return Coerce.from_json(value, TYPE_VECTOR3)
 					4:
-						return _router._to_vec4(value)
+						return Coerce.from_json(value, TYPE_VECTOR4)
 			if value is String and value.is_valid_html_color():
 				return Color.html(value)
 			return value

--- a/godot/addons/godot_mcp/type_coerce.gd
+++ b/godot/addons/godot_mcp/type_coerce.gd
@@ -9,7 +9,7 @@ extends RefCounted
 ## now; from_json() lands with the mutation tools (#6).
 ##
 ## Shapes (documented in docs/architecture.md):
-##   Vector2 → {x, y}      Vector3 → {x, y, z}
+##   Vector2 → {x, y}      Vector3 → {x, y, z}      Vector4 → {x, y, z, w}
 ##   Color   → {r, g, b, a}  Rect2  → {position:{x,y}, size:{x,y}}
 ##   NodePath → string       Resource → its resource_path (or class name)
 ##   Arrays/Dictionaries are coerced element-wise; primitives pass through.
@@ -21,6 +21,8 @@ static func to_json(value: Variant) -> Variant:
 			return {"x": value.x, "y": value.y}
 		TYPE_VECTOR3, TYPE_VECTOR3I:
 			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_VECTOR4, TYPE_VECTOR4I:
+			return {"x": value.x, "y": value.y, "z": value.z, "w": value.w}
 		TYPE_COLOR:
 			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
 		TYPE_RECT2, TYPE_RECT2I:
@@ -55,7 +57,8 @@ static func to_json(value: Variant) -> Variant:
 ## ([x, y]); NodePath/StringName from string; primitives coerced to the type.
 ##
 ## Composite types also accept agent-friendly string forms (issue #51):
-##   "Vector2(100, 200)", "Vector3(1, 2, 3)", "Rect2(0, 0, 4, 5)" (via str_to_var)
+##   "Vector2(100, 200)", "Vector3(1, 2, 3)", "Vector4(1, 2, 3, 4)", "Rect2(0, 0, 4, 5)"
+##   (via str_to_var)
 ##   and HTML/hex colors "#ff0000" / "#ff0000ff" (via Color.html).
 static func from_json(value: Variant, type: int) -> Variant:
 	if value is String:
@@ -74,6 +77,16 @@ static func from_json(value: Variant, type: int) -> Variant:
 		TYPE_VECTOR3I:
 			return Vector3i(
 				_component(value, "x", 0), _component(value, "y", 1), _component(value, "z", 2)
+			)
+		TYPE_VECTOR4:
+			return Vector4(
+				_component(value, "x", 0), _component(value, "y", 1),
+				_component(value, "z", 2), _component(value, "w", 3)
+			)
+		TYPE_VECTOR4I:
+			return Vector4i(
+				_component(value, "x", 0), _component(value, "y", 1),
+				_component(value, "z", 2), _component(value, "w", 3)
 			)
 		TYPE_COLOR:
 			return Color(
@@ -112,6 +125,8 @@ const _CTOR_PREFIX := {
 	TYPE_VECTOR2I: "Vector2i(",
 	TYPE_VECTOR3: "Vector3(",
 	TYPE_VECTOR3I: "Vector3i(",
+	TYPE_VECTOR4: "Vector4(",
+	TYPE_VECTOR4I: "Vector4i(",
 	TYPE_RECT2: "Rect2(",
 	TYPE_RECT2I: "Rect2i(",
 }

--- a/godot/tests/inspect_smoke.gd
+++ b/godot/tests/inspect_smoke.gd
@@ -35,13 +35,17 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector4) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded.
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])
 
 
 func _test_type_coerce(failures: Array[String]) -> void:
 	_eq(failures, "vector2", Coerce.to_json(Vector2(1, 2)), {"x": 1.0, "y": 2.0})
 	_eq(failures, "vector3", Coerce.to_json(Vector3(1, 2, 3)), {"x": 1.0, "y": 2.0, "z": 3.0})
+	_eq(failures, "vector4", Coerce.to_json(Vector4(1, 2, 3, 4)), {"x": 1.0, "y": 2.0, "z": 3.0, "w": 4.0})
+	_eq(failures, "vector4i", Coerce.to_json(Vector4i(1, 2, 3, 4)), {"x": 1, "y": 2, "z": 3, "w": 4})
 	_eq(failures, "color", Coerce.to_json(Color(1, 0, 0, 1)), {"r": 1.0, "g": 0.0, "b": 0.0, "a": 1.0})
 	_eq(failures, "nodepath", Coerce.to_json(NodePath("a/b")), "a/b")
 	_eq(failures, "array", Coerce.to_json([Vector2(0, 0), 5]), [{"x": 0.0, "y": 0.0}, 5])
@@ -60,6 +64,11 @@ func _test_from_json(failures: Array[String]) -> void:
 	_eq(failures, "fj.vector2.dict", Coerce.from_json({"x": 1, "y": 2}, TYPE_VECTOR2), Vector2(1, 2))
 	_eq(failures, "fj.vector2.arr", Coerce.from_json([1, 2], TYPE_VECTOR2), Vector2(1, 2))
 	_eq(failures, "fj.vector3", Coerce.from_json({"x": 1, "y": 2, "z": 3}, TYPE_VECTOR3), Vector3(1, 2, 3))
+	# Vector4 (#464): shader vec4 uniforms coerce through here.
+	_eq(failures, "fj.vector4.dict", Coerce.from_json({"x": 1, "y": 2, "z": 3, "w": 4}, TYPE_VECTOR4), Vector4(1, 2, 3, 4))
+	_eq(failures, "fj.vector4.arr", Coerce.from_json([1, 0.5, 0.25, 1], TYPE_VECTOR4), Vector4(1, 0.5, 0.25, 1))
+	_eq(failures, "fj.vector4i.arr", Coerce.from_json([1, 2, 3, 4], TYPE_VECTOR4I), Vector4i(1, 2, 3, 4))
+	_eq(failures, "fj.vector4.roundtrip", Coerce.from_json(Coerce.to_json(Vector4(5, 6, 7, 8)), TYPE_VECTOR4), Vector4(5, 6, 7, 8))
 	_eq(failures, "fj.color", Coerce.from_json({"r": 1, "g": 0, "b": 0, "a": 1}, TYPE_COLOR), Color(1, 0, 0, 1))
 	_eq(failures, "fj.nodepath", Coerce.from_json("a/b", TYPE_NODE_PATH), NodePath("a/b"))
 	_eq(failures, "fj.int", Coerce.from_json(5, TYPE_INT), 5)
@@ -76,6 +85,9 @@ func _test_from_json(failures: Array[String]) -> void:
 	# String forms (issue #51): "Vector2(...)" / "Rect2(...)" via str_to_var, hex via Color.html.
 	_eq(failures, "fj.str.vec2", Coerce.from_json("Vector2(100, 200)", TYPE_VECTOR2), Vector2(100, 200))
 	_eq(failures, "fj.str.vec3", Coerce.from_json("Vector3(1, 2, 3)", TYPE_VECTOR3), Vector3(1, 2, 3))
+	_eq(failures, "fj.str.vec4", Coerce.from_json("Vector4(1, 2, 3, 4)", TYPE_VECTOR4), Vector4(1, 2, 3, 4))
+	_eq(failures, "fj.str.vec4i", Coerce.from_json("Vector4i(1, 2, 3, 4)", TYPE_VECTOR4I), Vector4i(1, 2, 3, 4))
+	_eq(failures, "fj.str.vec4.bad", Coerce.from_json("nope", TYPE_VECTOR4), Vector4())
 	_eq(failures, "fj.str.rect2", Coerce.from_json("Rect2(0, 0, 4, 5)", TYPE_RECT2), Rect2(0, 0, 4, 5))
 	_eq(failures, "fj.str.color", Coerce.from_json("#00ff00", TYPE_COLOR), Color(0, 1, 0, 1))
 	_eq(failures, "fj.str.color.alpha", Coerce.from_json("#0000ffff", TYPE_COLOR), Color(0, 0, 1, 1))

--- a/tests/integration/test_addon_inspect.py
+++ b/tests/integration/test_addon_inspect.py
@@ -22,3 +22,5 @@ def test_inspection_serializers() -> None:
         f"inspection smoke test did not pass (exit {result.returncode}):\n{output}"
     )
     assert result.returncode == 0, f"expected exit 0, got {result.returncode}:\n{output}"
+    # An aborted check records no failure, so a script error must fail the run (#464).
+    assert "SCRIPT ERROR" not in output, f"inspection smoke raised a script error:\n{output}"

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -25,6 +25,10 @@ SHADER_UID_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader.uid"  # Godot 4.4+ si
 SHADER_CODE = (
     "shader_type canvas_item;\n"
     "uniform float strength = 1.0;\n"
+    "uniform vec4 tint_array;\n"
+    "uniform vec4 tint_dict;\n"
+    "uniform vec4 tint_inferred;\n"
+    "uniform vec4 tint_string;\n"
     "void fragment() {\n\tCOLOR = vec4(strength);\n}\n"
 )
 
@@ -93,6 +97,26 @@ async def _run() -> None:
             {"node_path": "Sprite", "name": "strength", "value": 0.5, "param_type": "float"},
         )
         assert param["name"] == "strength"
+
+        # #464: vec4 uniforms, one per accepted input shape; the saved scene is the truth
+        vec4_sets: list[tuple[str, Any, str]] = [
+            ("tint_array", [1, 0.5, 0.25, 1], "vector4"),
+            ("tint_dict", {"x": 0.1, "y": 0.2, "z": 0.3, "w": 0.4}, "vector4"),
+            ("tint_inferred", [2, 3, 4, 5], ""),
+            ("tint_string", "Vector4(6, 7, 8, 9)", "vector4"),
+        ]
+        for uniform, value, param_type in vec4_sets:
+            await _ok(
+                bridge,
+                "cmd_set_shader_param",
+                {"node_path": "Sprite", "name": uniform, "value": value, "param_type": param_type},
+            )
+        await _ok(bridge, "cmd_save_scene", {})
+        saved = SCRATCH_FILE.read_text()
+        assert "shader_parameter/tint_array = Vector4(1, 0.5, 0.25, 1)" in saved, saved
+        assert "shader_parameter/tint_dict = Vector4(0.1, 0.2, 0.3, 0.4)" in saved, saved
+        assert "shader_parameter/tint_inferred = Vector4(2, 3, 4, 5)" in saved, saved
+        assert "shader_parameter/tint_string = Vector4(6, 7, 8, 9)" in saved, saved
 
         # validation: no material slot, no ShaderMaterial yet, bad paths
         await _create(bridge, "Plain", "Node")


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Closes #464. `godot_shader_set_param` with a Vector4 value (`param_type: "vector4"`, or an inferred 4-element array) returned `ok: true` but set the uniform to `null`, and `null` is what got saved. `_coerce_shader_value` called `_router._to_vec4`, which doesn't exist on the router (the #103 handler split moved the function but not its call sites).

### Changes
- **`type_coerce.gd`:** `Vector4`/`Vector4i` are now first-class, like the other vectors. `to_json` emits `{x, y, z, w}`; `from_json` accepts the dict, `[x, y, z, w]`, or `"Vector4(…)"`/`"Vector4i(…)"` (constructor-prefix table). This follows `addon.md`: coercion lives only here.
- **`handlers/shaders.gd`:** both call sites use `Coerce.from_json(value, TYPE_VECTOR4)`; the stranded local `_to_vec4` is deleted. Side effect: `set_node_property` on `Vector4` properties now coerces too, through the same table.
- **Docs:** Vector4 rows in the value-shape tables (`docs/architecture.md`, `docs/tool-contracts.md`).

### Test-harness fix found along the way (scoped to the test this PR relies on)
The new `inspect_smoke.gd` cases **passed before the fix existed**. `_eq` did `got != want`, and comparing mismatched types (`Vector4` vs `Dictionary`) is a GDScript error in 4.x. That aborted `_eq` before the failure was recorded, so the script still printed `INSPECT_TEST_OK`. `_eq` now compares types first, and `test_addon_inspect.py` also fails on any `SCRIPT ERROR`. The same flaw in seven other smoke scripts is tracked in #467 (none hides a failure today).

## Acceptance criteria (from #464)
- [x] `TYPE_VECTOR4`/`TYPE_VECTOR4I` in `type_coerce.gd`: dict, array and string in; `{x,y,z,w}` out
- [x] `_coerce_shader_value` uses `Coerce.from_json(value, TYPE_VECTOR4)`; local `_to_vec4` removed
- [x] Live e2e sets vec4 uniforms through every path, saves, and asserts `Vector4(…)` in the `.tscn`

## Test plan
- **Red first:**
  - live e2e failed on the saved `.tscn` (`shader_parameter/tint_array = null`)
  - smoke cases failed with 8 `FAIL:` lines once `_eq` was fixed
- **Live e2e** (`test_shader_e2e.py`): four vec4 uniforms, one per input shape (array + `param_type`, dict, inferred array, `"Vector4(…)"` string), then `save_scene` and assert each saved line.
- **`inspect_smoke.gd`:** `to_json` for Vector4/Vector4i; `from_json` for dict/array/Vector4i/round-trip/strings/invalid string → `Vector4()`.
- `uv run pytest tests/unit tests/contract -q`: 700 passed
- `uv run pytest tests/integration -q` (Godot 4.7.2): 45 passed, 0 skipped
- `ruff check .`, `mypy`, `check-no-skipped-tests.sh`: clean
- Graphify refresh not needed (no new modules or edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEKghYW3XRFBDaWRvXmmzt


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Vec4 shader params no longer null

- Vector4 values now coerce correctly

- Smoke tests fail on script errors

- Docs add Vector4 shapes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vec4 shader param"] --> B["missing _to_vec4"]
  B --> C["null uniform"]
  C --> D["type_coerce Vector4"]
  D --> E["Vector4 uniform"]
  F["smoke tests"] --> G["type-safe checks"]
  H["docs"] --> I["Vector4 shapes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_addon_inspect.py</strong><dd><code>Fail inspection smoke on script errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-dc0ee44a182a199c83fd2c940e366011dbab0afaf62071c748b48510994ccaad">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_shader_e2e.py</strong><dd><code>Add vec4 shader e2e assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-bc7ef1bc659274e0c12032dca5dc44767dd8789ef936e57f80a7aa309047723f">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inspect_smoke.gd</strong><dd><code>Make smoke equality checks type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-a046752542cde07fc09ed46ac7b1541937a79a2a282322efcc4711ca346621dd">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>shaders.gd</strong><dd><code>Route vec4 coercion through type_coerce</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-b46063a9edcb9e3e8867778c2e8de9598f6b5080224bce22daf8fb70c238fd0f">+2/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>type_coerce.gd</strong><dd><code>Add Vector4 and Vector4i coercion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-28c7345bea182a56e26f4ab210915106f814f6395a5f414af2913e1b299ada05">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>architecture.md</strong><dd><code>Document Vector4 JSON shape table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool-contracts.md</strong><dd><code>Document Vector4 accepted value shapes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/469/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

