### PR TITLE
Fix `shader_get_param` uniform lookup from `Shader`

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -650,6 +650,9 @@ to `material` (CanvasItem) or `material_override` (GeometryInstance3D), reportin
 `godot_shader_set_param` sets a uniform on the node's ShaderMaterial; `param_type`
 (float/int/bool/vector2/vector3/vector4/color) coerces `value`, or it is inferred
 (number/bool as-is, `[x,y,z]` → vector, HTML string → color).
+`godot_shader_get_param` reads a uniform back: `exists` is whether the material's shader
+declares it, and `value` is the JSON-coerced current value, or `null` when the uniform has
+never been set on this material (the shader's own default applies).
 
 #### Visual shaders (issue #107) — category: `visual_shader` (gated off by default)
 

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -140,11 +140,14 @@ func _cmd_get_shader_param(params: Dictionary) -> Dictionary:
 	var name := str(params.get("name", ""))
 	if name.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'name' must be a non-empty string.")
+	# The uniform list lives on the Shader; ShaderMaterial has no list of its own (#465).
 	var exists := false
-	for param in material.get_shader_parameter_list():
-		if param.name == name:
-			exists = true
-			break
+	var shader: Shader = material.shader
+	if shader != null:
+		for uniform in shader.get_shader_uniform_list():
+			if str(uniform.get("name", "")) == name:
+				exists = true
+				break
 	var value: Variant = material.get_shader_parameter(name)
 	return _router._ok({
 		"node_path": str(params.get("node_path")),

--- a/mcp_server/tools/shader.py
+++ b/mcp_server/tools/shader.py
@@ -97,7 +97,9 @@ def register_shader(mcp: FastMCP, bridge: Bridge) -> None:
     async def get_shader_param(node_path: str, name: str) -> ShaderParamReadResult:
         """Read the live value of shader uniform ``name`` on the node's
         ShaderMaterial — the read-only inverse of ``set_shader_param``. Returns
-        ``exists=False`` when the parameter is not declared on the material.
+        ``exists=False`` when the material's shader does not declare the uniform.
+        ``value`` is null when the uniform has never been set on this material (the
+        shader's own default applies).
         """
         await require_node_exists(bridge, node_path)
         params = {"node_path": node_path, "name": name}

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -94,6 +94,19 @@ async def _run() -> None:
         )
         assert param["name"] == "strength"
 
+        # #465: read the uniform back (set on the 2D material, unset on the 3D one) and a
+        # name the shader does not declare
+        got = await _ok(bridge, "cmd_get_shader_param", {"node_path": "Sprite", "name": "strength"})
+        assert got["exists"] is True and got["value"] == 0.5, got
+        unset = await _ok(bridge, "cmd_get_shader_param", {"node_path": "Mesh", "name": "strength"})
+        # declared but never set on this material: Godot reports no value (the shader's
+        # own default applies), and neither ShaderMaterial nor RenderingServer exposes it
+        assert unset["exists"] is True and unset["value"] is None, unset
+        undeclared = await _ok(
+            bridge, "cmd_get_shader_param", {"node_path": "Sprite", "name": "no_such_uniform"}
+        )
+        assert undeclared["exists"] is False and undeclared["value"] is None, undeclared
+
         # validation: no material slot, no ShaderMaterial yet, bad paths
         await _create(bridge, "Plain", "Node")
         no_slot = await bridge.send(

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -21,6 +21,11 @@ SCRATCH_FILE = GODOT_PROJECT / "tmp_e2e_shader.tscn"
 SHADER_PATH = "res://tmp_e2e_shader.gdshader"
 SHADER_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader"
 SHADER_UID_FILE = GODOT_PROJECT / "tmp_e2e_shader.gdshader.uid"  # Godot 4.4+ sidecar
+BLANK = "res://tmp_e2e_blank_material.tres"  # a ShaderMaterial with no shader (#465)
+BLANK_FILES = [
+    GODOT_PROJECT / "tmp_e2e_blank_material.tres",
+    GODOT_PROJECT / "tmp_e2e_blank_material.tres.uid",
+]
 
 SHADER_CODE = (
     "shader_type canvas_item;\n"
@@ -106,6 +111,18 @@ async def _run() -> None:
             bridge, "cmd_get_shader_param", {"node_path": "Sprite", "name": "no_such_uniform"}
         )
         assert undeclared["exists"] is False and undeclared["value"] is None, undeclared
+        # a ShaderMaterial with no shader declares nothing: exists false, not a script error
+        await _ok(bridge, "cmd_create_resource", {"type": "ShaderMaterial", "resource_path": BLANK})
+        await _create(bridge, "Shaderless", "Sprite2D")
+        await _ok(
+            bridge,
+            "cmd_set_node_property",
+            {"node_path": "Shaderless", "property": "material", "value": BLANK},
+        )
+        blank = await _ok(
+            bridge, "cmd_get_shader_param", {"node_path": "Shaderless", "name": "strength"}
+        )
+        assert blank["exists"] is False and blank["value"] is None, blank
 
         # validation: no material slot, no ShaderMaterial yet, bad paths
         await _create(bridge, "Plain", "Node")
@@ -158,3 +175,5 @@ def test_live_shader() -> None:
         SCRATCH_FILE.unlink(missing_ok=True)
         SHADER_FILE.unlink(missing_ok=True)
         SHADER_UID_FILE.unlink(missing_ok=True)
+        for path in BLANK_FILES:
+            path.unlink(missing_ok=True)


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Closes #465. `godot_shader_get_param` never returned on Godot 4.7. The handler called `ShaderMaterial.get_shader_parameter_list()`, which doesn't exist in Godot 4, so it aborted on a script error and the agent got the bridge's generic 10s `TIMEOUT`, for every uniform type and on a normally drawing editor.

This is the `shader_get_param` half of #416, which was closed as a stalled-router side effect of the screenshot capture. It reproduces with no capture in flight.

### Changes
- **`handlers/shaders.gd`:** `exists` now comes from `material.shader.get_shader_uniform_list()` (the uniform list lives on the `Shader`); a material with no shader reports `exists: false`. `value` was already JSON-coerced.
- **`tools/shader.py` docstring and `docs/tool-contracts.md`:** document `exists` (declared by the material's shader) and that `value` is `null` for a uniform never set on this material. Godot keeps the shader's default out of reach: `ShaderMaterial.get_shader_parameter` and `RenderingServer.shader_get_parameter_default` both return `null` for `uniform float strength = 1.0` (verified on 4.7.2), so the tool documents that instead of guessing.

## Acceptance criteria (from #465)
- [x] `{node_path, name, value, exists}` with `exists` true for a declared uniform and `value` the current (JSON-coerced) value
- [x] Lookup via `material.shader.get_shader_uniform_list()`
- [x] Live e2e reads back a set uniform and an undeclared one (before this PR, no e2e called `cmd_get_shader_param`)

## Test plan
- **Red first:** the extended live e2e failed with `cmd_get_shader_param: TIMEOUT No response from Godot within 10.0s`.
- **Live e2e** (`test_shader_e2e.py`) covers three reads:
  - `strength` set to 0.5 on the 2D material → `exists: true, value: 0.5`
  - the same uniform unset on the 3D `material_override` → `exists: true, value: null`
  - an undeclared name → `exists: false, value: null`
- `uv run pytest tests/unit tests/contract -q`: 700 passed
- `uv run pytest tests/integration -q` (Godot 4.7.2): 45 passed, 0 skipped
- `ruff check .`, `mypy`, `check-no-skipped-tests.sh`: clean

## Related
- #466: the transport half. A handler that hits a script error surfaces as `TIMEOUT` instead of `INTERNAL_ERROR`; that's why this bug looked like a stall.
- #464 / #468: sibling shader fixes. All three touch `handlers/shaders.gd`, in separate functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEKghYW3XRFBDaWRvXmmzt


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Fix `shader_get_param` timeout bug

- Read `exists` from `Shader` list

- Return null for unset uniforms

- Add live e2e regression tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["shader_get_param tool"] -- "fix lookup" --> B["ShaderMaterial"]
  B -- "shader uniform list" --> C["Shader"]
  C -- "exists and value" --> D["JSON result"]
  E["live e2e tests"] -- "regression" --> A
  F["tool docs"] -- "semantics" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shader.py</strong><dd><code>Clarify `get_shader_param` docstring and semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/tools/shader.py

<ul><li>Update <code>get_shader_param</code> docstring.<br> <li> State <code>exists</code> depends on the material's shader declaration.<br> <li> Note <code>value</code> is null when the uniform was never set.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/470/files#diff-8b0346b019db1ddea50b19cf3836bae1105939f07e0d28fe3b570c834dbe3543">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document shader param read behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Add <code>godot_shader_get_param</code> contract details.<br> <li> Explain <code>exists</code> comes from the shader declaration.<br> <li> Explain <code>value</code> is null for never-set uniforms.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/470/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shader_e2e.py</strong><dd><code>Add shader param readback tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_shader_e2e.py

<ul><li>Add live e2e calls to <code>cmd_get_shader_param</code>.<br> <li> Assert a set uniform returns its value.<br> <li> Assert a declared unset uniform returns null.<br> <li> Assert an undeclared uniform returns <code>exists=false</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/470/files#diff-bc7ef1bc659274e0c12032dca5dc44767dd8789ef936e57f80a7aa309047723f">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shaders.gd</strong><dd><code>Fix shader param existence lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/shaders.gd

<ul><li>Replace invalid <code>ShaderMaterial.get_shader_parameter_list</code> call.<br> <li> Use <code>material.shader.get_shader_uniform_list</code> for <code>exists</code>.<br> <li> Report <code>exists=false</code> when the material has no shader.<br> <li> Keep <code>value</code> from <code>material.get_shader_parameter</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/470/files#diff-b46063a9edcb9e3e8867778c2e8de9598f6b5080224bce22daf8fb70c238fd0f">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

