### PR TITLE
Run read-helper smoke scripts and make _eq type-safe

### DIFF
--- a/godot/tests/animation_read_smoke.gd
+++ b/godot/tests/animation_read_smoke.gd
@@ -64,5 +64,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/audio_bus_capture_smoke.gd
+++ b/godot/tests/audio_bus_capture_smoke.gd
@@ -57,5 +57,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/input_action_read_smoke.gd
+++ b/godot/tests/input_action_read_smoke.gd
@@ -72,5 +72,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/particle_read_smoke.gd
+++ b/godot/tests/particle_read_smoke.gd
@@ -58,5 +58,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/run_commands_smoke.gd
+++ b/godot/tests/run_commands_smoke.gd
@@ -75,5 +75,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/theme_read_smoke.gd
+++ b/godot/tests/theme_read_smoke.gd
@@ -66,5 +66,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/godot/tests/visual_shader_read_smoke.gd
+++ b/godot/tests/visual_shader_read_smoke.gd
@@ -65,5 +65,7 @@ func _initialize() -> void:
 
 
 func _eq(failures: Array[String], label: String, got: Variant, want: Variant) -> void:
-	if got != want:
+	# Type first: comparing mismatched types (e.g. Dictionary vs Vector2) is a script
+	# error in Godot 4 that aborts _eq before the failure can be recorded (#467).
+	if typeof(got) != typeof(want) or got != want:
 		failures.append("%s: expected %s, got %s" % [label, str(want), str(got)])

--- a/tests/integration/test_addon_read_smokes.py
+++ b/tests/integration/test_addon_read_smokes.py
@@ -1,0 +1,34 @@
+"""Integration test: the headless read-helper smoke scripts pass (#467).
+
+Each ``godot/tests/<name>_smoke.gd`` builds real Godot objects, checks one addon helper,
+and prints its ``*_TEST_OK`` marker. These scripts were never wired into pytest, so CI
+never ran them. A ``SCRIPT ERROR`` also fails the run: a check aborted by a script error
+records no failure, so the marker alone can't be trusted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._godot import GODOT_BIN, run_godot
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+SMOKES = [
+    ("animation_read_smoke.gd", "ANIM_READ_TEST_OK"),
+    ("audio_bus_capture_smoke.gd", "AUDIO_BUS_CAPTURE_TEST_OK"),
+    ("input_action_read_smoke.gd", "INPUT_ACTION_READ_TEST_OK"),
+    ("particle_read_smoke.gd", "PARTICLE_READ_TEST_OK"),
+    ("run_commands_smoke.gd", "RUN_COMMANDS_TEST_OK"),
+    ("theme_read_smoke.gd", "THEME_READ_TEST_OK"),
+    ("visual_shader_read_smoke.gd", "VISUAL_SHADER_READ_TEST_OK"),
+]
+
+
+@pytest.mark.parametrize(("script", "marker"), SMOKES, ids=[s for s, _ in SMOKES])
+def test_read_helper_smoke(script: str, marker: str) -> None:
+    result = run_godot(["--script", f"res://tests/{script}"])
+    output = result.stdout + result.stderr
+    assert marker in output, f"{script} did not pass (exit {result.returncode}):\n{output}"
+    assert result.returncode == 0, f"{script}: expected exit 0, got {result.returncode}:\n{output}"
+    assert "SCRIPT ERROR" not in output, f"{script} raised a script error:\n{output}"


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Closes #467. Two ways the headless GDScript smoke tests could stay green without checking anything:

1. **Seven smoke scripts were never run.** `animation_read`, `audio_bus_capture`, `input_action_read`, `particle_read`, `run_commands`, `theme_read` and `visual_shader_read` (under `godot/tests/*_smoke.gd`) had no pytest runner. Nothing referenced or globbed them, so CI never ran them.
2. **Their `_eq` could not fail on a type mismatch.** `if got != want:` between incompatible types (e.g. `Dictionary` vs `Vector2`) is a script error in Godot 4, not `true`. It aborted `_eq` before the failure was appended, and the script still printed its OK marker.

### Changes
- **`tests/integration/test_addon_read_smokes.py`** (new): runs each script through `run_godot` and requires its `*_TEST_OK` marker, exit 0, and **no `SCRIPT ERROR`** in the output. The name matches the existing `tests/integration/test_addon_*.py` glob in `e2e.yml`, so the Godot runner picks it up with no workflow change.
- **The seven `_eq` helpers** compare `typeof` first.

`inspect_smoke.gd` (the eighth `_eq`, where this was found) is fixed with its runner in #469 / #464. The five scripts that already had runners (bridge, bridge_reconnect, dock, inspect, screenshot) are untouched. `bridge_smoke.gd` triggers a script error on purpose in #466, so a blanket `SCRIPT ERROR` guard there would be wrong.

## Acceptance criteria (from #467)
- [x] `_eq` compares types first in every affected script; existing cases stay green
- [x] The runner fails on any `SCRIPT ERROR`, not only a missing OK marker
- [x] Red proof with a deliberately type-mismatched case, then removed

## Test plan
- **Red proof:** a temporary `_eq(failures, "tmp.mismatch", {"x": 1}, Vector2(1, 0))` in `theme_read_smoke.gd` was run twice:
  - with the **old** `_eq`: the runner failed on the `SCRIPT ERROR` guard, while the script still printed `THEME_READ_TEST_OK`
  - with the **new** `_eq`: the runner failed on the missing marker (`FAIL: tmp.mismatch: expected (1.0, 0.0), got { "x": 1 }`)
  - then the case was removed
- `uv run pytest tests/integration/test_addon_read_smokes.py -q` (Godot 4.7.2): 7 passed, all seven scripts currently correct, zero script errors
- `ruff check .`, `mypy`, `check-no-skipped-tests.sh`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEKghYW3XRFBDaWRvXmmzt


___

### **PR Type**
Tests


___

### **Description**
- Add pytest runner for seven smoke scripts

- Make smoke equality checks type-safe

- Fail runs on Godot script errors

- Stricter tests may expose hidden failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Seven smoke scripts"] -- "no pytest runner" --> B["New integration runner"]
  C["_eq helper"] -- "type mismatch aborts" --> D["Type-safe comparison"]
  B -- "requires OK marker" --> E["Reliable smoke tests"]
  D -- "records failures" --> E
  F["Runner"] -- "fails on SCRIPT ERROR" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>test_addon_read_smokes.py</strong><dd><code>Add integration runner for smoke scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-3ccfb54c33fa7d0255b5fdea5fb8f47a1ca6bb9b3ec9fbcf18d14f8c2dc6a1b1">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>animation_read_smoke.gd</strong><dd><code>Make animation smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-f8b44220e9fa7dd173d5b40884ee81a4c406ccb4c7c8a2b5df2f17ed5776ae64">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio_bus_capture_smoke.gd</strong><dd><code>Make audio bus smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-5d36d9c45b39031cc6d396ecf6f06eaa5985d629e2c68e85ba6288abda2b28f3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_action_read_smoke.gd</strong><dd><code>Make input action smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-fc4f041d8d004c2713f431635736e93e45e699340f4bf3d3508639b262fd719f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>particle_read_smoke.gd</strong><dd><code>Make particle smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-8faf1bd3e32032b5386423eade0b8b029252390d4236149f8dd0090d79022911">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run_commands_smoke.gd</strong><dd><code>Make run commands smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-6a6f943c0a9ffab236bd0f8a208f7b5cde43e14d1bf0670817d7a0db39e3c521">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>theme_read_smoke.gd</strong><dd><code>Make theme smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-93cecb74fdb52bb85e4808fda3db5a04ff06aa89596e44e506fff9f4954ace4e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>visual_shader_read_smoke.gd</strong><dd><code>Make visual shader smoke equality type-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/471/files#diff-d74756ca45b0117a17eb37bfb9709cc8f04a82fec6040af6739c603d8ed04726">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

