### PR TITLE
fix(bridge): handler GDScript errors answer INTERNAL_ERROR, not 10s TIMEOUT

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,9 @@ Precondition failure (richer form, so the agent knows what to satisfy):
   bridge boundary on its own side and converted to an `ok: false` envelope.
 - **Stable error codes only**, drawn from the enumerated set below — never ad-hoc strings.
 - **A timed-out request resolves to a `TIMEOUT` envelope**; it never hangs the agent.
+- **A handler that dies on a GDScript error resolves to `INTERNAL_ERROR`**, not a `TIMEOUT`:
+  the router answers for it, and the server resolves any reply that names a pending `id`
+  but isn't a valid envelope (#466).
 - **No partial success.** Half-completed work returns `ok: false`, not `ok: true` with a
   truncated `result`.
 

--- a/godot/addons/godot_mcp/command_router.gd
+++ b/godot/addons/godot_mcp/command_router.gd
@@ -170,6 +170,10 @@ func _init() -> void:
 ## Dispatch one envelope ({ id, command, params }) and return a response envelope.
 func handle(envelope: Dictionary) -> Dictionary:
 	var body := _route(envelope)
+	if not body.has("ok"):
+		# A handler that died on a GDScript error returns nothing. Answer now instead of
+		# sending an ok-less body the server can only drop and time out on (#466).
+		body = _fail("INTERNAL_ERROR", "'%s' failed inside the addon without producing a response (a GDScript error — see the editor Output panel)." % str(envelope.get("command", "")))
 	body["id"] = str(envelope.get("id", ""))
 	return body
 

--- a/godot/tests/bridge_smoke.gd
+++ b/godot/tests/bridge_smoke.gd
@@ -48,6 +48,21 @@ func _initialize() -> void:
 	if bad_params.get("error") != "VALIDATION_ERROR":
 		failures.append("bad params error code: %s" % str(bad_params.get("error")))
 
+	# A handler that dies on a GDScript error yields nothing; handle() must answer with
+	# INTERNAL_ERROR naming the command, not an ok-less body the server drops (#466).
+	# (The SCRIPT ERROR this prints is expected.)
+	router._handlers["cmd_test_script_error"] = func(_params: Dictionary) -> Dictionary:
+		var target: Variant = RefCounted.new()
+		target.call("no_such_method")
+		return {"ok": true, "result": {}}
+	var crashed: Dictionary = router.handle({"id": "5", "command": "cmd_test_script_error", "params": {}})
+	if crashed.get("id") != "5":
+		failures.append("crashed handler id not echoed: %s" % str(crashed))
+	if crashed.get("ok") != false or crashed.get("error") != "INTERNAL_ERROR":
+		failures.append("crashed handler should be INTERNAL_ERROR: %s" % str(crashed))
+	if not str(crashed.get("hint", "")).contains("cmd_test_script_error"):
+		failures.append("crashed handler hint should name the command: %s" % str(crashed))
+
 	router = null
 
 	if failures.is_empty():

--- a/mcp_server/bridge.py
+++ b/mcp_server/bridge.py
@@ -271,13 +271,39 @@ class Bridge:
 
     def _resolve(self, raw: str) -> None:
         try:
-            response = ResponseEnvelope.model_validate(json.loads(raw))
-        except (json.JSONDecodeError, ValueError):
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
             logger.error("dropping unparseable bridge message")
+            return
+        try:
+            response = ResponseEnvelope.model_validate(payload)
+        except ValueError:
+            self._fail_malformed(payload)
             return
         future = self._pending.pop(response.id, None)
         if future is not None and not future.done():
             future.set_result(response)
+
+    def _fail_malformed(self, payload: Any) -> None:
+        """Answer a reply that isn't a valid envelope but still names a waiting request.
+
+        The addon did reply (typically a handler that hit a GDScript error), so the caller
+        gets ``INTERNAL_ERROR`` now instead of waiting out the request timeout (#466).
+        """
+        msg_id = payload.get("id") if isinstance(payload, dict) else None
+        if not isinstance(msg_id, str) or (future := self._pending.pop(msg_id, None)) is None:
+            logger.error("dropping unparseable bridge message")
+            return
+        logger.error("malformed response envelope", extra={"id": msg_id})
+        if not future.done():
+            future.set_result(
+                ResponseEnvelope.failure(
+                    msg_id,
+                    ErrorCode.INTERNAL_ERROR,
+                    "Godot replied without a valid response envelope; the addon handler "
+                    "most likely hit a GDScript error (see the editor Output panel).",
+                )
+            )
 
     def _fail_pending(self, error: str, hint: str) -> None:
         for msg_id, future in list(self._pending.items()):

--- a/tests/unit/test_bridge_malformed_reply.py
+++ b/tests/unit/test_bridge_malformed_reply.py
@@ -1,0 +1,60 @@
+"""A reply the bridge can't parse as an envelope must not strand its request (#466).
+
+When an addon handler dies on a GDScript error, the router answers ``{"id": ...}`` with
+no ``ok``. Dropping that as unparseable left the caller waiting out the full request
+timeout for a reply that had already arrived; it now resolves as ``INTERNAL_ERROR``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from mcp_server.models.envelope import CommandEnvelope, ErrorCode
+from tests.fakes import FakeAddonConnection, connector_for
+
+pytestmark = pytest.mark.asyncio
+
+
+class _RawReplyConnection(FakeAddonConnection):
+    """Answers every command with a raw payload built from its id."""
+
+    def __init__(self, reply: str) -> None:
+        super().__init__()
+        self._reply = reply
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+        command = CommandEnvelope.model_validate_json(message)
+        await self._incoming.put(self._reply.replace("{id}", command.id))
+
+
+async def _send(reply: str, **kwargs: float) -> object:
+    bridge = Bridge(BridgeConfig(), connector=connector_for(_RawReplyConnection(reply)))
+    await bridge.connect()
+    try:
+        return await asyncio.wait_for(bridge.send("cmd_boom", {}, **kwargs), 2.0)
+    finally:
+        await bridge.close()
+
+
+async def test_ok_less_reply_resolves_as_internal_error_without_waiting() -> None:
+    response = await _send(json.dumps({"id": "{id}"}))
+    assert response.ok is False  # type: ignore[attr-defined]
+    assert response.error == ErrorCode.INTERNAL_ERROR  # type: ignore[attr-defined]
+    assert "editor Output" in (response.hint or "")  # type: ignore[attr-defined]
+
+
+async def test_malformed_reply_without_a_pending_id_is_still_dropped() -> None:
+    """No id to correlate: nothing to resolve, so the request times out as before."""
+    response = await _send(json.dumps({"ok": True}), timeout=0.2)
+    assert response.error == ErrorCode.TIMEOUT  # type: ignore[attr-defined]
+
+
+async def test_non_json_reply_is_dropped() -> None:
+    response = await _send("not json {id}", timeout=0.2)
+    assert response.error == ErrorCode.TIMEOUT  # type: ignore[attr-defined]


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

Closes #466. When an addon handler hit a GDScript runtime error, the agent waited the full 10s and then got `TIMEOUT: No response from Godot within 10.0s; check the editor and bridge.`, blaming the wrong layer, instead of an immediate structured error. That breaks the error-handling rule that a GDScript runtime error is converted to an `ok: false` envelope at the bridge boundary.

### Mechanism (verified on Godot 4.7.2)
1. A handler aborted by a script error leaves `_route` with an **empty Dictionary**.
2. `handle()` stamped the `id` on it and returned `{"id": "<id>"}`, with no `ok`.
3. `bridge.py:_resolve` failed `ResponseEnvelope` validation, logged `dropping unparseable bridge message`, and dropped it. The pending future waited out `request_timeout`.

This is how #465 (`shader_get_param`) presented as a stall.

### Fix: both sides of the boundary
- **Addon, `command_router.gd:handle()`:** a routed body without `ok` is replaced with `INTERNAL_ERROR`, hint `"'<command>' failed inside the addon without producing a response (a GDScript error — see the editor Output panel)."`
- **Server, `bridge.py:_resolve`:** a reply that parses as JSON and names a **pending** `id` but isn't a valid envelope now resolves that request as `INTERNAL_ERROR` instead of being dropped. This covers older addons and any other malformed reply. Non-JSON, or JSON with no correlatable id, is still dropped as before (nothing to resolve).
- **`docs/architecture.md`:** the error model states that a handler dying on a GDScript error resolves to `INTERNAL_ERROR`, not `TIMEOUT`.

`INTERNAL_ERROR` is already in the closed `ErrorCode` set; no contract change, and `CONTRACT_VERSION` stays 1.

## Acceptance criteria (from #466)
- [x] A handler that fails without producing a response is answered immediately with `INTERNAL_ERROR` naming the command
- [x] The server resolves a malformed-but-identified reply as `INTERNAL_ERROR` instead of timing out
- [x] Unit test for the bridge; headless addon test for the router

## Test plan
- **Red first:**
  - `bridge_smoke.gd`: a handler that raises a script error got back `{ "id": "5" }` (`BRIDGE_TEST_FAIL`)
  - the new unit test hung past its 2s guard
- **`godot/tests/bridge_smoke.gd`:** routes a handler that calls a nonexistent method; expects `ok: false`, `INTERNAL_ERROR`, the `id` echoed, and the command named in the hint. The script error it prints is expected. The runner doesn't reject `SCRIPT ERROR`; #471 deliberately leaves `bridge_smoke` out of that guard.
- **`tests/unit/test_bridge_malformed_reply.py`:**
  - an ok-less reply resolves as `INTERNAL_ERROR` inside 2s, while `request_timeout` is 10s
  - a malformed reply without an id is still dropped (→ `TIMEOUT`)
  - non-JSON is still dropped
- `run_commands_smoke.gd` (batch path through `handle()`): passes
- `uv run pytest tests/unit tests/contract -q`: 703 passed
- `uv run pytest tests/integration -q` (Godot 4.7.2): 45 passed, 0 skipped
- `ruff check .`, `mypy`, `check-no-skipped-tests.sh`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEKghYW3XRFBDaWRvXmmzt


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Crashed addon handlers answer INTERNAL_ERROR instead of TIMEOUT

- Server resolves malformed replies naming pending requests

- Unidentifiable replies still dropped, timing out as before

- Unit and smoke tests pin the new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Addon handler dies on GDScript error"] --> B["command_router.handle()"]
  B -- "routed body missing ok" --> C["INTERNAL_ERROR envelope naming the command"]
  C --> D["bridge.py _resolve"]
  D -- "reply names a pending id" --> E["Caller gets INTERNAL_ERROR immediately"]
  D -- "no id / non-JSON" --> F["Dropped, request times out as before"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bridge.py</strong><dd><code>Resolve malformed bridge replies as INTERNAL_ERROR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mcp_server/bridge.py

<ul><li>Splits <code>_resolve</code> JSON parsing from <code>ResponseEnvelope</code> validation<br> <li> Adds <code>_fail_malformed</code>: a reply that names a pending <code>id</code> but fails <br>envelope validation now resolves that request as <code>INTERNAL_ERROR</code> with a <br>hint pointing at the editor Output panel, instead of being dropped and <br>stranding the caller until the request timeout<br> <li> Non-JSON replies and replies with no correlatable pending id are still <br>dropped, so those requests time out as before</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/472/files#diff-155e02944cb4f2f6f7fdc1c90c4f439d6e4216c871d520eabc9818612cd816d7">+28/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>command_router.gd</strong><dd><code>Router answers crashed handlers with INTERNAL_ERROR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/command_router.gd

<ul><li><code>handle()</code> now checks whether the routed body contains an <code>ok</code> key<br> <li> A body without <code>ok</code> (handler aborted on a GDScript error) is replaced <br>with an <code>INTERNAL_ERROR</code> failure whose hint names the command and points <br>at the editor Output panel<br> <li> The <code>id</code> is still stamped on the returned envelope, so the server can <br>correlate it</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/472/files#diff-bb8342c846b9dd63ee16afe2e49d51501ebfe080786b092f8f9a55e03819b7ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bridge_malformed_reply.py</strong><dd><code>Unit tests pin malformed-reply INTERNAL_ERROR resolution</code>&nbsp; </dd></summary>
<hr>

tests/unit/test_bridge_malformed_reply.py

<ul><li>New unit test file covering the malformed-reply path (#466)<br> <li> An ok-less reply (<code>{"id": ...}</code>) resolves as <code>INTERNAL_ERROR</code> without <br>waiting out the request timeout, with the hint mentioning the editor <br>Output panel<br> <li> Replies without a pending id and non-JSON replies still resolve as <br><code>TIMEOUT</code>, pinning the drop behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/472/files#diff-db454e19bb624fd65bda317f1f8c60d6eaeb72d397825c660c6437ff296e72e3">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bridge_smoke.gd</strong><dd><code>Smoke test for crashed-handler INTERNAL_ERROR envelope</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/tests/bridge_smoke.gd

<ul><li>Registers a <code>cmd_test_script_error</code> handler that deliberately triggers a <br>GDScript script error via a nonexistent method call<br> <li> Asserts <code>handle()</code> returns <code>ok: false</code> with <code>INTERNAL_ERROR</code>, echoes the id, <br>and names the command in the hint<br> <li> Notes the printed SCRIPT ERROR from the crashing handler is expected</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/472/files#diff-a7ebbda064977552bac1ebedc3a2cd06f640af0257e67866148f8a33392a0cee">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>architecture.md</strong><dd><code>Document INTERNAL_ERROR resolution for crashed handlers</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/architecture.md

<ul><li>Error model now states a handler dying on a GDScript error resolves to <br><code>INTERNAL_ERROR</code>, never a <code>TIMEOUT</code><br> <li> Documents that the router answers for the crashed handler and the <br>server resolves any reply naming a pending <code>id</code> that fails envelope <br>validation</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/472/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

