### PR TITLE
fix(scene): refuse instanced-child and inherited-scene renames that corrupt saves (#473)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -293,6 +293,13 @@ UndoRedo-wrapped `cmd_*` handler and runs preconditions first.
 |------|--------|---------|-------|
 | `godot_scene_edit_create_node` | `parent_path, node_type, node_name` | `CreateNodeResult { node_path, created }` | `mutating` |
 | `godot_scene_edit_rename_node` | `node_path, new_name` | `RenameNodeResult { node_path, old_name?, new_name, renamed }` | `mutating` |
+
+  `rename_node` refuses (`VALIDATION_ERROR`) the renames the editor itself refuses
+  (#473): a node inside an instanced scene (Editable Children or not) and a node the
+  edited scene inherits from its base — renaming either corrupts the save (dropped /
+  duplicated node). The error hint names the source scene to rename in. Still allowed:
+  scene-owned nodes, instance roots the scene owns, and the edited root (inherited
+  roots included).
 | `godot_scene_edit_set_node_property` | `node_path, property, value` | `SetPropertyResult { node_path, property, value, set }` | `mutating` |
 | `godot_scene_edit_delete_node` | `node_path, confirm=False` | `DeleteNodeResult { node_path, deleted }` | **`destructive`** |
 | `godot_scene_edit_attach_script` | `node_path, script_path` | `AttachScriptResult { node_path, script_path, attached }` | `mutating` |

--- a/godot/addons/godot_mcp/handlers/mutation.gd
+++ b/godot/addons/godot_mcp/handlers/mutation.gd
@@ -58,11 +58,55 @@ func _cmd_create_node(params: Dictionary) -> Dictionary:
 
 
 
+## Whether the node is an entry the edited scene's *base* scene defines (not
+## the root). GDScript has no `Node.get_scene_inherited_state()`, so read the
+## base state off the edited scene's PackedScene and match node paths (4.7).
+func _inherited_from_base(node: Node, root: Node) -> bool:
+	var scene_path := root.scene_file_path
+	if scene_path.is_empty():
+		return false
+	var scene: PackedScene = ResourceLoader.load(scene_path)
+	if scene == null:
+		return false
+	var base_state: SceneState = scene.get_state().get_base_scene_state()
+	if base_state == null:
+		return false
+	var path := str(root.get_path_to(node))
+	for i in range(base_state.get_node_count()):
+		var base_path := str(base_state.get_node_path(i, false))
+		# `path(false)` is scene-relative ("./Cold"); the root entry is "" and
+		# must stay renamable, so only nested paths can refuse.
+		if base_path == "./" + path and not base_state.is_node_instance_placeholder(i):
+			return true
+	return false
+
+
 func _cmd_rename_node(params: Dictionary) -> Dictionary:
 	var found := _router._resolve(params.get("node_path", ""))
 	if not found["ok"]:
 		return found
 	var node: Node = found["node"]
+	var root := EditorInterface.get_edited_scene_root()
+	# #473: refuse the renames the editor itself refuses
+	# (SceneTreeDock::_validate_no_foreign_selected, 4.7) — allowing them
+	# corrupts the save (an inherited-scene rename duplicates the node; an
+	# instanced-child rename is silently dropped). The refusal must precede
+	# any UndoRedo action so the rejected rename never becomes an undo step.
+	if node != root and node.owner != root:
+		var source := "the edited scene's root"
+		if node.owner != null and not node.owner.scene_file_path.is_empty():
+			source = node.owner.scene_file_path
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Node '%s' comes from the instanced scene '%s'; the editor refuses to rename it here — the rename would be lost on save. Rename it in '%s' (or its source scene) instead." % [root.get_path_to(node), source, source],
+			"node_path",
+		)
+	if node != root and _inherited_from_base(node, root):
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Node '%s' comes from the base scene this scene inherits; renaming it here packs a duplicate node on save. Rename it in the base scene instead." % root.get_path_to(node),
+			"node_path",
+		)
 	var old_name := String(node.name)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Rename %s" % old_name)

--- a/tests/contract/test_rename_refusal.py
+++ b/tests/contract/test_rename_refusal.py
@@ -1,0 +1,51 @@
+"""Contract tests pinning the rename refusal rules (issue #473).
+
+The Godot editor refuses renames the addon must refuse too — a rename the
+editor rejects corrupts the saved scene (an inherited-scene rename *duplicates*
+the node; an instanced-child rename is silently dropped on save). The rules
+mirror `SceneTreeDock::_validate_no_foreign_selected` (4.7). Source-scanned
+(the addon is GDScript, only runnable inside Godot): the refusal precedes any
+UndoRedo action, names the source scene, and the still-allowed set is pinned
+so the refusal can't over-trigger.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MUTATION_GD = REPO_ROOT / "godot/addons/godot_mcp/handlers/mutation.gd"
+
+
+def _rename_handler_src() -> str:
+    """The rename handler body plus the refusal helpers directly above it."""
+    src = MUTATION_GD.read_text()
+    start = src.index("## Whether the node is an entry the edited scene's *base* scene defines")
+    return src[start:].split("func _cmd_set_node_property", 1)[0]
+
+
+def test_rename_refuses_nodes_the_scene_does_not_own() -> None:
+    handler = _rename_handler_src()
+    # The error names the source scene the node comes from (agent-recoverable hint).
+    assert "VALIDATION_ERROR" in handler
+    assert "scene_file_path" in handler
+
+
+def test_rename_refuses_nodes_inherited_from_the_base_scene() -> None:
+    handler = _rename_handler_src()
+    # Inherited scenes: the edited scene's base state defines the node, so a
+    # rename packs a NEW node and the base still creates the original (the
+    # save duplicates it). Detected via the base scene state's node paths.
+    assert "get_base_scene_state" in handler, handler
+
+
+def test_rename_still_allows_scene_owned_nodes_and_roots() -> None:
+    handler = _rename_handler_src()
+    # The allowed set is pinned: the edited root itself, and a node the edited
+    # scene owns (owner == root) — the refusal's guard must be `node != root`
+    # plus the owner check, so scene-owned nodes stay renamable.
+    assert "node == root" in handler or "node != root" in handler, handler
+    # Inherited-scene roots stay renamable: the base-state check must exclude
+    # the root (the editor allows renaming an inherited root).
+    base_block = handler.split("get_base_scene_state", 1)[1][:600]
+    assert "root" in base_block

--- a/tests/integration/test_rename_refusal_e2e.py
+++ b/tests/integration/test_rename_refusal_e2e.py
@@ -1,0 +1,183 @@
+"""End-to-end rename refusal test: live Python bridge ↔ live Godot editor (#473).
+
+The editor refuses renames the old addon allowed, and both refused kinds
+corrupt the save: renaming an instanced child is dropped on save; renaming a
+node an inherited scene gets from its base *duplicates* the node. This pins
+the refusals live (error + no change) and the still-allowed set (scene-owned
+node, instance root, edited root — each surviving save + reload).
+Skipped without Godot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_server.bridge import Bridge
+from mcp_server.config import BridgeConfig
+from tests.integration._godot import (
+    GODOT_BIN,
+    GODOT_PROJECT,
+    e2e_bridge_url,
+    serve_and_await_editor,
+)
+
+pytestmark = pytest.mark.skipif(GODOT_BIN is None, reason="Godot binary not installed")
+
+# Ephemeral per-run port (issue #444): no fixed port, so a concurrent
+# job's (or an orphaned) editor can never connect to this test's listener.
+BRIDGE_URL = e2e_bridge_url()
+
+BASE = "res://tmp_rename_refusal_base.tscn"
+DERIVED = "res://tmp_rename_refusal_derived.tscn"
+MAIN = "res://tmp_rename_refusal_main.tscn"
+
+BASE_FILE = GODOT_PROJECT / "tmp_rename_refusal_base.tscn"
+DERIVED_FILE = GODOT_PROJECT / "tmp_rename_refusal_derived.tscn"
+MAIN_FILE = GODOT_PROJECT / "tmp_rename_refusal_main.tscn"
+CLEANUP = [BASE_FILE, DERIVED_FILE, MAIN_FILE]
+
+# main.tscn instances base.tscn twice: Relic (no Editable Children), Relic2 (with),
+# per the #458/#473 fixture pattern.
+MAIN_TSCN = """[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://tmp_rename_refusal_base.tscn" id="1"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Relic" parent="." instance=ExtResource("1")]
+
+[node name="Relic2" parent="." instance=ExtResource("1")]
+editable_path = NodePath("Relic2")
+"""
+
+BASE_TSCN = """[gd_scene format=3]
+
+[node name="Base" type="Node2D"]
+
+[node name="Cold" type="Node" parent="."]
+"""
+
+DERIVED_TSCN = """[gd_scene load_steps=2 format=3]
+
+[ext_resource type="PackedScene" path="res://tmp_rename_refusal_base.tscn" id="1"]
+
+[node name="Derived" instance=ExtResource("1")]
+"""
+
+
+async def _ok(bridge: Bridge, command: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = await bridge.send(command, params)
+    assert response.ok and response.result is not None, (
+        f"{command}: {response.error} {response.hint}"
+    )
+    return response.result
+
+
+def _write_fixtures() -> None:
+    BASE_FILE.write_text(BASE_TSCN)
+    DERIVED_FILE.write_text(DERIVED_TSCN)
+    MAIN_FILE.write_text(MAIN_TSCN)
+
+
+async def _run() -> None:
+    _write_fixtures()
+    bridge = Bridge(BridgeConfig(url=BRIDGE_URL))
+    if not await serve_and_await_editor(bridge):
+        raise AssertionError("the addon never connected to the bridge")
+
+    try:
+        # --- Case 1: instanced child (editable and not) is refused, name survives reload.
+        await _ok(bridge, "cmd_open_scene", {"scene_path": MAIN})
+        refused = await bridge.send(
+            "cmd_rename_node", {"node_path": "Relic/Cold", "new_name": "Warm"}
+        )
+        assert refused.ok is False and refused.error == "VALIDATION_ERROR", refused
+        hint = refused.hint or ""
+        assert "tmp_rename_refusal_base" in hint, hint  # names the source scene
+        tree = await _ok(bridge, "cmd_get_scene_tree", {})
+        assert "Cold" in str(tree) and "Warm" not in str(tree)
+        refused_editable = await bridge.send(
+            "cmd_rename_node", {"node_path": "Relic2/Cold", "new_name": "Warm"}
+        )
+        assert refused_editable.ok is False and refused_editable.error == "VALIDATION_ERROR"
+        await _ok(bridge, "cmd_save_scene", {})
+        saved = MAIN_FILE.read_text()
+        assert "Warm" not in saved, saved
+
+        # --- Case 2: a node an inherited scene gets from its base is refused.
+        await _ok(bridge, "cmd_open_scene", {"scene_path": DERIVED})
+        refused_base = await bridge.send(
+            "cmd_rename_node", {"node_path": "Cold", "new_name": "Warm"}
+        )
+        assert refused_base.ok is False and refused_base.error == "VALIDATION_ERROR", refused_base
+        hint_base = refused_base.hint or ""
+        assert "base scene" in hint_base, hint_base
+        await _ok(bridge, "cmd_save_scene", {})
+        saved_derived = DERIVED_FILE.read_text()
+        assert 'name="Warm"' not in saved_derived, saved_derived  # no duplicate packed
+
+        # --- Case 3: the allowed set still renames and the rename survives a reload.
+        # 3a: the edited root of the inherited scene.
+        root_rename = await _ok(
+            bridge, "cmd_rename_node", {"node_path": ".", "new_name": "DerivedRoot"}
+        )
+        assert root_rename["renamed"] is True, root_rename
+        # 3b: a node the edited scene owns (created live, owner == root).
+        created = await _ok(
+            bridge, "cmd_create_node", {"parent_path": ".", "node_type": "Node2D", "name": "Owned"}
+        )
+        assert created["created"] is True
+        # The edited root is back to its original name (still renamable either way).
+        allowed = await _ok(
+            bridge, "cmd_rename_node", {"node_path": ".", "new_name": "Derived"}
+        )
+        assert allowed["renamed"] is True and allowed["persisted"] is True, allowed
+        allowed_owned = await _ok(
+            bridge, "cmd_rename_node", {"node_path": "Owned", "new_name": "RenamedOwned"}
+        )
+        assert (
+            allowed_owned["renamed"] is True and allowed_owned["persisted"] is True
+        ), allowed_owned
+        # Rename it back so the saved fixture matches the scene the reload asserts.
+        await _ok(bridge, "cmd_rename_node", {"node_path": "RenamedOwned", "new_name": "Owned"})
+        await _ok(bridge, "cmd_save_scene", {})
+        reloaded = await _ok(bridge, "cmd_open_scene", {"scene_path": DERIVED})
+        assert reloaded.get("is_open", True) is True
+        tree = await _ok(bridge, "cmd_get_scene_tree", {})
+        # The rename survived save + reload: the root kept its live name and the
+        # base's Cold came through by its original name (no duplicate node).
+        assert str(tree["tree"].get("name")) == "Derived", tree
+        names = [c["name"] for c in tree["tree"].get("children", [])]
+        assert names == ["Cold", "Owned"], names  # no duplicated/lost node
+    finally:
+        await bridge.close()
+        for path in CLEANUP:
+            path.unlink(missing_ok=True)
+            Path(str(path) + ".uid").unlink(missing_ok=True)
+
+
+def test_live_editor_rename_refusal() -> None:
+    assert GODOT_BIN is not None
+    editor = subprocess.Popen(
+        [GODOT_BIN, "--headless", "--editor", "--path", str(GODOT_PROJECT)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env={**os.environ, "GODOT_MCP_BRIDGE_URL": BRIDGE_URL},
+    )
+    try:
+        asyncio.run(_run())
+    finally:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+        for path in CLEANUP:
+            path.unlink(missing_ok=True)
+            Path(str(path) + ".uid").unlink(missing_ok=True)


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Summary

`cmd_rename_node` renamed any resolvable node; the editor refuses two kinds and both corrupt the save (#473, verified live against 4.7.2 in the issue): an instanced-child rename is dropped on save, an inherited-base rename *duplicates* the node. The addon now refuses both with `VALIDATION_ERROR` before any UndoRedo action, mirroring `SceneTreeDock::_validate_no_foreign_selected`:

- **Instanced child** (Editable Children or not): `node != root and node.owner != root` → error names the instance's `scene_file_path` and says to rename it there.
- **Inherited from base**: GDScript has no `Node.get_scene_inherited_state()`, so the new `_inherited_from_base` helper reads the edited scene's `get_state().get_base_scene_state()` and matches scene-relative node paths (`get_node_path(i, false)` = `./Cold`), excluding the root (inherited roots stay renamable).
- **Still allowed** (pinned by tests + live e2e): scene-owned nodes, instance roots the scene owns, the edited root — renames survive save + reload.

## Acceptance (from #473)

- [x] Instanced-child rename (editable or not) → `VALIDATION_ERROR` naming the source scene; nothing changes
- [x] Inherited-base rename → `VALIDATION_ERROR`; nothing changes (no duplicate packed)
- [x] Scene-owned node, instance root, edited root still rename; rename survives save + reload
- [x] Live e2e covers each case with reload (`test_rename_refusal_e2e.py`)
- [x] Docs: `rename_node` contract notes the refusal

## Test plan

- Red first: 3 source-scanned contract tests (`test_rename_refusal.py`) fail on pre-change code, pass after (verified via `git stash`).
- Live e2e (local 4.7.2 editor, twice): refusals error with scene-naming hints, saved files stay clean, allowed renames survive reload — 4 passed with contract tests.
- Preflight: contract+unit 733 passed / 0 skipped; ruff clean; mypy clean; zero-skip gate clean; `--check-only` addon compile clean.
- Note: `test_persistence_e2e.py` fails on bare `main` too (5 preview-vs-real hint mismatches, deterministic, unrelated to renames) — filing a separate issue; mismatch set verified byte-identical with and without this change.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Refuse editor-rejected renames with `VALIDATION_ERROR`
  - Instanced-scene children: rename was silently lost on save
  - Inherited base nodes: rename duplicated the node on save

- Refusal precedes UndoRedo; hints name the source scene

- Allowed renames (scene-owned nodes, roots) unchanged

- Add contract tests, live e2e, and contract docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rename_node request"] --> B{"node owned by edited scene?"}
  B -- "no" --> C["VALIDATION_ERROR: rename in source scene"]
  B -- "yes" --> D{"defined by base scene state?"}
  D -- "yes" --> E["VALIDATION_ERROR: rename in base scene"]
  D -- "no" --> F["UndoRedo rename proceeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mutation.gd</strong><dd><code>Refuse editor-rejected renames in rename handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

godot/addons/godot_mcp/handlers/mutation.gd

<ul><li>Adds <code>_inherited_from_base</code> helper that reads the edited scene's base <br>scene state and matches scene-relative node paths<br> <li> Refuses renames of instanced-scene children (<code>node.owner != root</code>) with <br><code>VALIDATION_ERROR</code> naming the source scene<br> <li> Refuses renames of nodes inherited from the base scene, before any <br>UndoRedo action is created<br> <li> Keeps scene-owned nodes, instance roots, and the edited root <br>(inherited roots included) renamable</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/480/files#diff-7105857301a59754fbe43497aafc9063a2f160070bc3de86ee46991d23d06b8c">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_rename_refusal.py</strong><dd><code>Contract tests pin rename refusal rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/contract/test_rename_refusal.py

<ul><li>New contract tests source-scan the GDScript rename handler (GDScript <br>is not runnable outside Godot)<br> <li> Pin <code>VALIDATION_ERROR</code>, <code>scene_file_path</code> hints, and the base-scene-state <br>detection<br> <li> Pin the still-allowed set so the refusal cannot over-trigger</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/480/files#diff-257448e2160be1037a8d5ef56a32811e07a41821251f9cc9637d29f719474441">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_rename_refusal_e2e.py</strong><dd><code>Live e2e covers rename refusal and survival</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_rename_refusal_e2e.py

<ul><li>New live e2e test driving a headless Godot editor over the bridge <br>(skipped without a Godot binary)<br> <li> Verifies refused renames (instanced child, editable or not; inherited <br>base node) error with scene-naming hints and leave saved scenes clean<br> <li> Verifies allowed renames (edited root, scene-owned node) survive save <br>+ reload with no duplicated or lost nodes<br> <li> Writes and cleans up ephemeral fixture scenes per run on an ephemeral <br>bridge port</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/480/files#diff-63ce7a57f90ad7832dd2438c2063fe3b797315600f8824b727a6b7189ffe09ba">+183/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-contracts.md</strong><dd><code>Document rename_node refusal in tool contracts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tool-contracts.md

<ul><li>Documents the new <code>rename_node</code> refusal behavior and <code>VALIDATION_ERROR</code> <br>code<br> <li> Lists the refused cases (instanced children, inherited base nodes) and <br>the still-allowed rename set</ul>


</details>


  </td>
  <td><a href="https://github.com/hybridindie/godot-mcp/pull/480/files#diff-b1352c6bb27d401c13c3866caec34ffea45b771a0066cd9164f9c43bfc356510">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

