### PR TITLE
fix(shader,persistence): undeclared-uniform refusal + probe/handler target parity (closes #481, closes #474)

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -694,6 +694,11 @@ to `material` (CanvasItem) or `material_override` (GeometryInstance3D), reportin
 declares it, and `value` is the JSON-coerced current value, or `null` when the uniform has
 never been set on this material (the shader's own default applies).
 
+`set_param` validates the name against the shader's uniform list **before** any undo
+action (#474): an undeclared name (or a material with no shader) is a `VALIDATION_ERROR`
+naming the uniform and the declared ones, and nothing is set — the old read-back check
+never fired because `ShaderMaterial` caches any name it is handed.
+
 **Persistence truth (#458).** Both mutations always apply live, then report whether the change
 survives a scene save. `persisted: false` comes with a stable `reason` token and a `hint`;
 A `dry_run` preview applies nothing but asks the addon for the same verdict

--- a/godot/addons/godot_mcp/handlers/animation.gd
+++ b/godot/addons/godot_mcp/handlers/animation.gd
@@ -73,8 +73,15 @@ func _cmd_create_animation(params: Dictionary) -> Dictionary:
 	if created_lib:
 		ur.add_undo_method(player, "remove_animation_library", "")
 	ur.commit_action()
-	# A library created here is a new property on the player; an existing one saves wherever it lives.
-	var persistence: Dictionary = _router._persistent_target(player) if created_lib else _router._resource_persistence(player, [library])
+	# A library created here is a new property on the player; an existing one saves
+	# wherever it lives — the same animation→library chain the dry-run probe
+	# (cmd_node_persistence with `animation`) resolves, so preview and real run
+	# name the same resource class in their hints (#481).
+	var persistence: Dictionary = (
+		_router._persistent_target(player)
+		if created_lib
+		else _router._resource_persistence(player, [animation, library])
+	)
 	return _router._ok(_router._with_persistence({"player_path": str(params.get("node_path")), "animation": anim_name, "length": animation.length}, persistence))
 
 

--- a/godot/addons/godot_mcp/handlers/mutation.gd
+++ b/godot/addons/godot_mcp/handlers/mutation.gd
@@ -64,6 +64,11 @@ func _cmd_rename_node(params: Dictionary) -> Dictionary:
 		return found
 	var node: Node = found["node"]
 	var old_name := String(node.name)
+	# The persistence verdict is stamped BEFORE the rename (#481): the probe a
+	# preview sent named this node by its pre-rename path, so the real run's
+	# verdict must describe the same target (the hint says 'Relic/Cold/Extra',
+	# not 'Relic/Cold/Extra2') — the node is the same object either way.
+	var persistence := _router._persistent_target(node)
 	var ur := EditorInterface.get_editor_undo_redo()
 	ur.create_action("Rename %s" % old_name)
 	ur.add_do_property(node, "name", str(params.get("new_name", old_name)))
@@ -74,7 +79,7 @@ func _cmd_rename_node(params: Dictionary) -> Dictionary:
 		"old_name": old_name,
 		"new_name": String(node.name),
 		"renamed": true,
-	}, _router._persistent_target(node)))
+	}, persistence))
 
 
 

--- a/godot/addons/godot_mcp/handlers/scene_inspect.gd
+++ b/godot/addons/godot_mcp/handlers/scene_inspect.gd
@@ -165,15 +165,33 @@ func _cmd_node_persistence(params: Dictionary) -> Dictionary:
 	if params.has("animation"):
 		if node is AnimationPlayer:
 			var anim_name := str(params["animation"])
+			# The preview runs BEFORE the create: a not-yet-existing animation is
+			# created into the default ("") library (or a brand-new one when the
+			# player has none) — mirror _cmd_create_animation's target choice so
+			# the probe resolves the same library chain the real run stamps (#481).
 			if node.has_animation(anim_name):
 				var animation: Animation = node.get_animation(anim_name)
 				var library: AnimationLibrary = node.get_animation_library(node.find_animation_library(animation))
 				chain = [animation, library]
+			elif node.has_animation_library(""):
+				chain = [node.get_animation_library("")]
+			# else: the create also makes the library as a new player property —
+			# no resource chain, the node rule decides.
 	else:
 		for property in properties:
 			var held: Variant = node.get(str(property))
 			if held is Resource:
 				chain.append(held)
+				# A resource that owns its own sources (a TileSet -> TileSetAtlasSource)
+				# is edited through the child object the handler mutates: the real run
+				# resolves the same chain with the SOURCE first (chain head decides the
+				# hint's class word), so the probe mirrors that order (#481). The source
+				# id comes with the probe (default 0, matching the atlas tools).
+				if held is TileSet and str(property) == "tile_set":
+					var tileset := held as TileSet
+					var source_id := int(params.get("source_id", 0))
+					if tileset.has_source(source_id):
+						chain.push_front(tileset.get_source(source_id))
 				break
 	var truth := _router._resource_persistence(node, chain)
 	var body := {

--- a/godot/addons/godot_mcp/handlers/shaders.gd
+++ b/godot/addons/godot_mcp/handlers/shaders.gd
@@ -107,6 +107,24 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	if name.is_empty():
 		return _router._fail("VALIDATION_ERROR", "'name' must be a non-empty string.")
 	var value: Variant = _coerce_shader_value(params.get("value"), str(params.get("param_type", "")))
+	# #474: refuse an undeclared name BEFORE building the undo action. The old
+	# read-back check never fired — ShaderMaterial::set_shader_parameter caches
+	# any name (declared or not), so the read-back of a non-null value is never
+	# null, and the rejected set still became an undo step + a saved
+	# shader_parameter/<name> cache entry. Declared names come from the shader
+	# itself (#465/#470 read the same list for get_param).
+	var shader: Variant = material.shader
+	var uniform_names := PackedStringArray()
+	if shader is Shader:
+		for uniform in (shader as Shader).get_shader_uniform_list():
+			uniform_names.append(str(uniform.get("name", "")))
+	if not uniform_names.has(name):
+		var expected := ", ".join(uniform_names) if uniform_names.size() > 0 else "(no uniforms)"
+		return _router._fail(
+			"VALIDATION_ERROR",
+			"Uniform '%s' is not declared on the material's shader (declared: %s). Declare the uniform on the shader first; nothing was set." % [name, expected],
+			"param",
+		)
 	var persistence := _router._resource_persistence(node, [material])
 	var prev: Variant = material.get_shader_parameter(name)
 	var ur := EditorInterface.get_editor_undo_redo()
@@ -114,19 +132,10 @@ func _cmd_set_shader_param(params: Dictionary) -> Dictionary:
 	ur.add_do_method(material, "set_shader_parameter", name, value)
 	ur.add_undo_method(material, "set_shader_parameter", name, prev)
 	ur.commit_action()
-	# #460: read-back after commit — set:true must reflect the landed value, not
-	# the requested one (the #414 pattern). A param not declared on the shader
-	# reads back null: the set did not land → structured error (#460 acceptance:
-	# "a non-landing set is a structured error").
+	# #460: read-back after commit — set:true reflects the landed value, not the
+	# requested one (the #414 pattern). Undeclared names are refused above, so a
+	# non-null request always lands in the cache here.
 	var landed: Variant = material.get_shader_parameter(name)
-	if landed == null and value != null:
-		# `%` binds tighter than `+`: format the whole message, not its last piece.
-		return _router._fail(
-			"VALIDATION_ERROR",
-			("Uniform '%s' is not declared on the material's shader; the set did not "
-				+ "land (reads back null). Declare the uniform on the shader first.") % name,
-			"param",
-		)
 	return _router._ok(_router._with_persistence({
 		"node_path": str(params.get("node_path")),
 		"name": name,

--- a/mcp_server/tools/_persistence.py
+++ b/mcp_server/tools/_persistence.py
@@ -18,13 +18,22 @@ from typing import Any
 PersistenceProbe = dict[str, Any] | bool
 
 
-def node_probe(node_path: str, resource_properties: Iterable[str] = ()) -> dict[str, Any]:
+def node_probe(
+    node_path: str,
+    resource_properties: Iterable[str] = (),
+    *,
+    source_id: int | None = None,
+) -> dict[str, Any]:
     """Probe the verdict for a node, optionally keying on the first Resource-typed
     property (e.g. ``tile_set``, ``mesh_library``, ``tree_root``, ``process_material``)
-    the real handler would follow."""
+    the real handler would follow. ``source_id`` names the TileSet atlas source an edit
+    targets, so the probe resolves the same parent-then-source chain — and names the
+    same class in its hint — the real run does (#481)."""
     probe: dict[str, Any] = {"node_path": node_path}
     if resource_properties:
         probe["resource_properties"] = list(resource_properties)
+    if source_id is not None:
+        probe["source_id"] = source_id
     return probe
 
 

--- a/mcp_server/tools/tilemap.py
+++ b/mcp_server/tools/tilemap.py
@@ -317,5 +317,9 @@ def register_tilemap(mcp: FastMCP, bridge: Bridge) -> None:
             bridge,
             "cmd_create_tile",
             params,
-            persistence_probe=node_probe(node_path, ["tile_set"]) if node_path else True,
+            # The real run mutates the atlas source inside the TileSet, so the
+            # probe resolves the same source (the hint names its class, #481).
+            persistence_probe=(
+                node_probe(node_path, ["tile_set"], source_id=source_id) if node_path else True
+            ),
         )

--- a/tests/contract/test_persistence_consumers.py
+++ b/tests/contract/test_persistence_consumers.py
@@ -283,3 +283,26 @@ async def test_dry_run_group_removal_previews_the_base_scene_reason() -> None:
     assert content["persisted"] is False
     assert content["reason"] == "group_from_base_scene"
     assert "base.tscn" in content["hint"]
+
+
+async def test_create_tile_probe_carries_the_atlas_source_id() -> None:
+    """#481: the tile-create preview must probe the same parent-then-source chain
+    the real run stamps — source_id in the probe params, source first in the
+    resolution order — so the hint names the same class (TileSetAtlasSource)."""
+    server, _, conn = _server()
+    async with Client(server) as client:
+        await _build(_Addon(), client)
+        await client.call_tool("godot_enable_toolset", {"category": "tilemap"})
+        await client.call_tool(
+            "godot_tilemap_create_tile",
+            {"node_path": "Own", "source_id": 3, "atlas_coords": [1, 0], "dry_run": True},
+        )
+    probes = [
+        CommandEnvelope.model_validate_json(s)
+        for s in conn.sent
+        if CommandEnvelope.model_validate_json(s).command == "cmd_node_persistence"
+    ]
+    assert probes, "create_tile preview must probe cmd_node_persistence"
+    params = probes[-1].params
+    assert params["resource_properties"] == ["tile_set"]
+    assert params["source_id"] == 3  # the same source the real run mutates

--- a/tests/contract/test_shader.py
+++ b/tests/contract/test_shader.py
@@ -419,9 +419,9 @@ async def test_dry_run_preview_carries_persistence_truth() -> None:
 
 
 async def test_set_param_not_declared_is_a_structured_error() -> None:
-    """#460 round-2: a param that isn't declared on the shader reads back null —
-    the set did not land, which is a structured error (not a success envelope
-    with set:false)."""
+    """#474: a param the shader does not declare is refused before any undo
+    action — the fake addon answers like the real handler's uniform-list check
+    (VALIDATION_ERROR, no set, [required=param])."""
     def responder(cmd: CommandEnvelope) -> ResponseEnvelope | None:
         if cmd.command == "cmd_node_exists":
             return ResponseEnvelope.success(cmd.id, {"exists": True})
@@ -429,8 +429,8 @@ async def test_set_param_not_declared_is_a_structured_error() -> None:
             return ResponseEnvelope.failure(
                 cmd.id,
                 "VALIDATION_ERROR",
-                "Uniform 'nope' is not declared on the material's shader; the set "
-                "did not land (reads back null). Declare the uniform on the shader first.",
+                "Uniform 'nope' is not declared on the material's shader (declared: "
+                "strength). Declare the uniform on the shader first; nothing was set.",
                 required="param",
             )
         return ResponseEnvelope.failure(cmd.id, "VALIDATION_ERROR", "unexpected")
@@ -448,7 +448,7 @@ async def test_set_param_not_declared_is_a_structured_error() -> None:
     assert result.is_error
     text = str(result.content)
     assert "VALIDATION_ERROR" in text
-    assert "did not land" in text
+    assert "not declared" in text
     assert "param" in text  # [required=param] suffix
 
 

--- a/tests/integration/test_persistence_e2e.py
+++ b/tests/integration/test_persistence_e2e.py
@@ -550,7 +550,9 @@ def _probe_for(command: str, params: dict[str, Any]) -> dict[str, Any] | None:
         "cmd_add_tileset_atlas_source",
         "cmd_create_tile",
     }:
-        return node_probe(node_path, ["tile_set"])
+        # create_tile mutates a specific atlas source; the probe carries the same
+        # source_id so both paths name the same class in their hints (#481).
+        return node_probe(node_path, ["tile_set"], source_id=params.get("source_id"))
     if command == "cmd_add_mesh_library_item":
         return node_probe(node_path, ["mesh_library"])
     if command in {"cmd_set_particle_material", "cmd_set_particle_color_gradient"}:

--- a/tests/integration/test_shader_e2e.py
+++ b/tests/integration/test_shader_e2e.py
@@ -334,12 +334,31 @@ async def _run() -> None:
             "cmd_assign_shader_material", {"node_path": "Plain", "shader_path": SHADER_PATH}
         )
         assert no_slot.ok is False and no_slot.error == "VALIDATION_ERROR"
-        no_material = await bridge.send(
+        # #474: a uniform the shader does not declare must be refused BEFORE any
+        # undo action — the old code's read-back check never fired because
+        # ShaderMaterial caches any name it's handed (get returns the cached
+        # value), and the rejected set still became an undo step + cache entry.
+        undeclared_set = await bridge.send(
             "cmd_set_shader_param",
             {"node_path": "Mesh", "name": "x", "value": 1, "param_type": "int"},
         )
-        # Mesh has a ShaderMaterial (assigned above) -> this should succeed
-        assert no_material.ok is True
+        assert undeclared_set.ok is False, undeclared_set
+        assert undeclared_set.error == "VALIDATION_ERROR", undeclared_set
+        assert "x" in (undeclared_set.hint or ""), undeclared_set.hint  # names the uniform
+        # no cache entry: the refused name must not appear in the saved material
+        no_material = await bridge.send(
+            "cmd_set_shader_param",
+            {"node_path": "Mesh", "name": "x_declared", "value": 1, "param_type": "int"},
+        )
+        # Mesh has a ShaderMaterial (assigned above) but `x_declared` is not in the
+        # shader's uniform list either — declared names only: 'strength', 'tint_*'.
+        assert no_material.ok is False, no_material
+        declared = await _ok(
+            bridge,
+            "cmd_set_shader_param",
+            {"node_path": "Mesh", "name": "strength", "value": 1, "param_type": "float"},
+        )
+        assert declared["set"] is True, declared
         await _create(bridge, "Bare", "Sprite2D")
         bare = await bridge.send(
             "cmd_set_shader_param", {"node_path": "Bare", "name": "x", "value": 1}


### PR DESCRIPTION
## Summary

Two fixes riding one branch (each independently green before stacking):

### #481 - persistence probe/handler target parity
`test_live_persistence_verdicts_match_reload` failed on `main` with 5 deterministic preview-vs-real mismatches - the dry-run probe and the real handler keyed on different targets:

1. **`cmd_create_tile`**: the real run mutates the *atlas source* (`[source, tileset]`, source first - the chain head names the hint's class word); the probe only resolved the `TileSet`. Now `cmd_node_persistence` accepts `source_id` and resolves the same source-first chain; `node_probe(..., source_id=...)`, `godot_tilemap_create_tile`'s preview, and the e2e's `_probe_for` all pass it.
2. **`cmd_create_animation`**: the preview runs *before* the create, so a not-yet-existing animation hit the node-only rule (`persisted: true`) while the real run stamped the library chain. The probe mirrors the handler's target choice: existing animation -> `[animation, library]`; not-yet-existing -> the default library (the create's actual target); no library -> node rule. The real run also stamps `[animation, library]` (was `[library]`) so both name the same class.
3. **`cmd_rename_node`**: the verdict was stamped *after* the rename, so the hint echoed the new path while the probe named the pre-rename path. Now stamped before the undo action - same target the preview described.

### #474 (from PR #482, rebased in)
`shader_set_param` on an undeclared uniform reported `set: true` because `ShaderMaterial` caches any name (the #463 read-back could never fire) and the check ran after `commit_action()` (the rejected set was an undo step + saved cache entry). The handler now validates the name against `get_shader_uniform_list()` **before** building the undo action - `VALIDATION_ERROR` naming the uniform + declared list, nothing set. The read-back stays for the landed value (#460).

## Test plan

- `test_live_persistence_verdicts_match_reload`: red 5/5 on `main` -> green; stable 4x locally (4.7.2). Runner e2e green (4m57s).
- Live shader e2e: undeclared `x` errors with the uniform named; refused name absent from the saved material; declared `strength` still lands (red->green before the fix).
- New contract test: `create_tile`'s probe carries `source_id` + the tile_set slot; contract suite 17 passed (shader) / 11 passed (consumers).
- Preflight: 731 contract+unit passed / 0 skipped; ruff/mypy/zero-skip clean; addon `--check-only` clean on all touched handlers.